### PR TITLE
Problems trying to create an empty Group

### DIFF
--- a/src/util/lang_array.js
+++ b/src/util/lang_array.js
@@ -147,6 +147,9 @@
    * @param {String} byProperty
    */
   function max(array, byProperty) {
+		if(array.length === 0) {
+		  return 0;
+		}
     var i = array.length - 1, 
         result = byProperty ? array[i][byProperty] : array[i];
     if (byProperty) {
@@ -174,6 +177,9 @@
    * @param {String} byProperty
    */
   function min(array, byProperty) {
+		if(array.length === 0) {
+      return 0;
+		}
     var i = array.length - 1, 
         result = byProperty ? array[i][byProperty] : array[i];
 


### PR DESCRIPTION
Trying to initialize an empty Group causes a memory leak and the script to crash. I tested this on Chrome and Firefox and got the same results on each. To reproduce this you can simply do this:

```
var group = new fabric.Group();
```

I found that the issue came from both the _min_ and _max_ functions in the lang_array.js file. When tracing the code I found that the initialize function is called, then it calls _calcBounds() which calls the min and max functions. Since there isn't anything in the objects array the variables aX and aY get assigned as undefined. When they get passed to the functions in question it causes the crash.
