### PR TITLE
fontSize not being used from options in fabric.Text

### DIFF
--- a/src/text.class.js
+++ b/src/text.class.js
@@ -130,6 +130,7 @@
       this.stateProperties.push(
         'fontFamily', 
         'fontWeight', 
+        'fontSize', 
         'path', 
         'text', 
         'textDecoration', 


### PR DESCRIPTION
just added fontSize in stateProperties since it this option was not having effect.
