### PR TITLE
Group selection by holding shift key

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -308,7 +308,7 @@
 
         this._setupCurrentTransform(e, target);
 
-        var shouldHandleGroupLogic = e.shiftKey && (activeGroup || this.getActiveObject());
+        var shouldHandleGroupLogic = e.shiftKey && (activeGroup || this.getActiveObject()) && this.selection;
         if (shouldHandleGroupLogic) {
           this._handleGroupLogic(e, target);
         }


### PR DESCRIPTION
If group selection was disabled it was also possible to group objects by holding shift key. This bugfix corrects this error.
