### PR TITLE
Native textShadow offsets and blur bug

### DIFF
--- a/src/text.class.js
+++ b/src/text.class.js
@@ -352,9 +352,9 @@
 
         ctx.save();
         ctx.shadowColor = shadowColor;
-        ctx.shadowOffsetX = parseInt(offsetsAndBlur[0], 10);
-        ctx.shadowOffsetY = parseInt(offsetsAndBlur[1], 10);
-        ctx.shadowBlur = parseInt(offsetsAndBlur[2], 10);
+        ctx.shadowOffsetX = parseInt(offsetsAndBlur[1], 10);
+        ctx.shadowOffsetY = parseInt(offsetsAndBlur[2], 10);
+        ctx.shadowBlur = parseInt(offsetsAndBlur[3], 10);
 
         this._shadows = [{
           blur: ctx.shadowBlur,


### PR DESCRIPTION
Setting the textShadow offsetX, offsetY and blur were wrong.
