### PR TITLE
set all properties passed to setOptions, not just stateProperties

### DIFF
--- a/src/object.class.js
+++ b/src/object.class.js
@@ -144,12 +144,8 @@
      * @param {Object} [options]
      */
     setOptions: function(options) {
-      var i = this.stateProperties.length, prop;
-      while (i--) {
-        prop = this.stateProperties[i];
-        if (prop in options) {
-          this.set(prop, options[prop]);
-        }
+	  for(prop in options) {
+	    this.set(prop, options[prop]);
       }
     },
 


### PR DESCRIPTION
This was only setting the stateProperties, and ignoring properties like hasControls if they were included in the options.
