### PR TITLE
add transform matrix to render method, reset image width and height

### DIFF
--- a/src/image.class.js
+++ b/src/image.class.js
@@ -131,6 +131,11 @@
      */
     render: function(ctx, noTransform) {
       ctx.save();
+      var m = this.transformMatrix;
+      this._resetWidthHeight();
+      if (m) {
+        ctx.transform(m[0], m[1], m[2], m[3], m[4], m[5]);
+      }
       if (!noTransform) {
         this.transform(ctx);
       }


### PR DESCRIPTION
Hi,

This fixes the issue with #28 & #31 on http://fabricjs.com/svg_rendering/

I'm still looking into why the transform matrix doesn't act as expected in these examples 
#137, #127, #89, #88, #87, #86, #60, #30,
