### PR TITLE
Bugfix in loadFromJSON() for numTotalAsyncObjects > 0

### DIFF
--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -181,6 +181,7 @@
         klass.fromObject(o, function (o) {
           enlivenedObjects[index] = o;
           if (++numLoadedAsyncObjects === numTotalAsyncObjects) {
+            numTotalAsyncObjects = 0;
             if (callback) {
               callback(enlivenedObjects);
             }


### PR DESCRIPTION
I don't know if this change is correct but it worked. Maybe you can have a look at it.
Here is a jsfiddle:

http://jsfiddle.net/r2ZE7/60/

Pull Request for issue #215
