### PR TITLE
Class Utils fails to work with arrays

### DIFF
--- a/src/util/lang_class.js
+++ b/src/util/lang_class.js
@@ -29,7 +29,9 @@
           };
         })(property);
       }
-      else {
+      else if( Object.prototype.toString.call( klass.prototype[property] ) === '[object Array]') {
+        klass.prototype[property] = source[property].slice(); //Arrays are passed by reference!
+      }else{
         klass.prototype[property] = source[property];
       }
 


### PR DESCRIPTION
As javascript passes arrays by reference you will end up working 
on one array in multiple instances if you declare a class member as 
empty array. To get around this the class util has to check for arrays
and clone them (using slice).
