### PR TITLE
Text background - box and/or character fill or none

### DIFF
--- a/src/text.class.js
+++ b/src/text.class.js
@@ -427,15 +427,17 @@
 
         for (var i = 0, len = textLines.length; i < len; i++) {
 
-          var lineWidth = ctx.measureText(textLines[i]).width;
-          var lineLeftOffset = this._getLineLeftOffset(lineWidth);
+          if (textLines[i] !== '') {
+            var lineWidth = ctx.measureText(textLines[i]).width;
+            var lineLeftOffset = this._getLineLeftOffset(lineWidth);
 
-          ctx.fillRect(
-            (-this.width / 2) + lineLeftOffset,
-            (-this.height / 2) + (i * this.fontSize * this.lineHeight),
-            lineWidth,
-            this.fontSize * this.lineHeight
-          );
+            ctx.fillRect(
+              (-this.width / 2) + lineLeftOffset,
+              (-this.height / 2) + (i * this.fontSize * this.lineHeight),
+              lineWidth,
+              this.fontSize * this.lineHeight
+            );
+          }
         }
         ctx.restore();
       }


### PR DESCRIPTION
fabric.Text has now two properties for background-color (#320):
1. backgroundColor => background-color for whole bounding-box
2. textBackgroundColor =>  background-color for textlines (same behavior like "old" fabric.Text#backgroundColor)

You can see it here:
<img src="http://kienzle.geschaeft.s3.amazonaws.com/projects/sketch/fabricjs_textBAckgroundColor.png"/>
