### PR TITLE
Cufon renderer for fabric.Text - textBackgroundColor and backgroundColor

### DIFF
--- a/lib/cufon.js
+++ b/lib/cufon.js
@@ -819,9 +819,15 @@ Cufon.registerEngine('canvas', (function() {
     function renderBackground() {
       g.save();
 
-      g.fillStyle = options.backgroundColor;
-
       var left = 0, lineNum = 0, boundaries = [{ left: 0 }];
+
+      if (options.backgroundColor) {
+        g.save();
+        g.fillStyle = options.backgroundColor;
+        g.translate(0, font.ascent);
+        g.fillRect(0, 0, width + 10, (-font.ascent + font.descent) * lines);
+        g.restore();
+      }
 
       if (options.textAlign === 'right') {
         g.translate(lineOffsets[lineNum], 0);
@@ -872,9 +878,10 @@ Cufon.registerEngine('canvas', (function() {
 
         var charWidth = Number(glyph.w || font.w) + letterSpacing;
 
-        // only draw background when there's some kind of value
-        if (options.backgroundColor) {
+        // only draw text-background when there's some kind of value
+        if (options.textBackgroundColor) {
           g.save();
+          g.fillStyle = options.textBackgroundColor;
           g.translate(0, font.ascent);
           g.fillRect(0, 0, charWidth + 10, -font.ascent + font.descent);
           g.restore();

--- a/src/text.class.js
+++ b/src/text.class.js
@@ -225,7 +225,8 @@
         lineHeight: this.lineHeight,
         strokeStyle: this.strokeStyle,
         strokeWidth: this.strokeWidth,
-        backgroundColor: this.backgroundColor
+        backgroundColor: this.backgroundColor,
+        textBackgroundColor: this.textBackgroundColor
       });
 
       // update width, height


### PR DESCRIPTION
[BACK_INCOMPAT] Cufon rendered for fabric.Text now has two properties: backgroundColor (whole bounding-box) and textBackgroundColor (textlines, same behavior as "old" fabric.Text#backgroundColor)
