### PR TITLE
Node.js - allow loadImage to support data url

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -46,7 +46,7 @@
     var img = new Image();
   	if ( url && url.indexOf('data') == 0 )
   	{
-  		img.src = url;
+  		img.src = img._src = url;
   		callback(img);
   	}
   	else if ( url )


### PR DESCRIPTION
The overload for fabric.util.loadImage when run under node.js did not accomodate data:image url.

This could be optimised as src duplicates _src.

I need it to handle this scenario so that the data url is embedded in toSVG().
Perhaps some option to toggle when xlink:href should be original url or data url.

Driven by inkscape not supporting external href.

As it stands the changes still need tweaking due to above considerations.

<pre>
fabric.util.loadImage('https://www.google.co.nz/images/srpr/logo3w.png', function(img) {
    var oImg = new fabric.Image(img);
    oImg.toDataURL(function(e)
    {
        img.src = img._src = e;
        var oImg2 = new fabric.Image(img);
        canvas.add(oImg2);
        console.log(canvas.toSVG());
    });
})
</pre>
