### PR TITLE
Changed toSVG in image.class.js to properly close <image> tag

### DIFF
--- a/src/image.class.js
+++ b/src/image.class.js
@@ -140,7 +140,7 @@
                   // so that object's center aligns with container's left/top
                   'transform="translate('+ (-this.width/2) + ' ' + (-this.height/2) + ')" ' +
                   'width="' + this.width + '" ' +
-                  'height="' + this.height + '"' + '/>'+
+                  'height="' + this.height + '"' + '></image>' +
               '</g>';
     },
 


### PR DESCRIPTION
The `toSVG()` method in image.class.js generated `<image .... />` tag instead of `<image ..></image>` when dumping content to SVG file. This caused errors when the generated SVG document was loaded in something like `<object>`  tag. Code like this:

``` html
<object data="/path/to/document.svg"></object>
```

Where `document.svg` was generated with `fabric.js`, would render an occasional error in the browser.
