### PR TITLE
Fix freedrawing for Firefox

### DIFF
--- a/src/freedrawing.class.js
+++ b/src/freedrawing.class.js
@@ -217,11 +217,11 @@
       p.strokeWidth = this.canvas.freeDrawingLineWidth;
       this.canvas.add(p);
 
-      // set path origin coordinates based on our bouding box
+      // set path origin coordinates based on our bounding box
       var originLeft = this.box.minx  + (this.box.maxx - this.box.minx) /2;
       var originTop = this.box.miny  + (this.box.maxy - this.box.miny) /2;
 
-      this.canvas.contextTop.arc(originLeft, originTop, 3);
+      this.canvas.contextTop.arc(originLeft, originTop, 3, 0, Math.PI * 2);
 
       p.set({ left: originLeft, top: originTop });
 


### PR DESCRIPTION
TypeError: Not enough arguments to CanvasRenderingContext2D.arc.
[Bei diesem Fehler anhalten]

this.canvas.contextTop.arc(originLeft, originTop, 3);
