### PR TITLE
Freedraw bugfix for Firefox 3.6.x

### DIFF
--- a/src/freedrawing.class.js
+++ b/src/freedrawing.class.js
@@ -96,6 +96,8 @@
       var p1 = this._points[0];
       var p2 = this._points[1];
 
+      ctx.moveTo(p1.x, p1.y);
+
       for (var i = 1, len = this._points.length; i < len; i++) {
         // we pick the point between pi+1 & pi+2 as the
         // end point and p1 as our control point.


### PR DESCRIPTION
The pointer flies away on starting freedrawing - line is drawing.
Here you can see a screenshot:
<img src="https://s3-eu-west-1.amazonaws.com/kienzle.geschaeft/projects/sketch/fabric_freedraw_problem_firefox_3.6.x.png"/>

jsFiddle:
http://jsfiddle.net/r2ZE7/95/
