### PR TITLE
Another freedrawing bug in Firefox 3.6.1 - 3.6.24

### DIFF
--- a/src/freedrawing.class.js
+++ b/src/freedrawing.class.js
@@ -223,7 +223,7 @@
       var originLeft = this.box.minx  + (this.box.maxx - this.box.minx) /2;
       var originTop = this.box.miny  + (this.box.maxy - this.box.miny) /2;
 
-      this.canvas.contextTop.arc(originLeft, originTop, 3, 0, Math.PI * 2);
+      this.canvas.contextTop.arc(originLeft, originTop, 3, 0, Math.PI * 2, false);
 
       p.set({ left: originLeft, top: originTop });
 


### PR DESCRIPTION
In Firefox 3.6.28 it works correct.
canvas 2d context arc() requires optional parameter anticlockwise - bugzilla issue https://bugzilla.mozilla.org/show_bug.cgi?id=617319.
