### PR TITLE
strokeText bugfix for Firefox < 4

### DIFF
--- a/src/text.class.js
+++ b/src/text.class.js
@@ -395,6 +395,7 @@
      */
     _renderTextStroke: function(ctx, textLines) {
       if (this.strokeStyle) {
+        ctx.beginPath();
         for (var i = 0, len = textLines.length; i < len; i++) {
           ctx.strokeText(
             textLines[i],
@@ -402,6 +403,7 @@
             (-this.height / 2) + (i * this.fontSize * this.lineHeight) + this.fontSize
           );
         }
+        ctx.closePath();
       }
     },
 


### PR DESCRIPTION
In Firefox < 4 was a bug in strokeText(): https://bugzilla.mozilla.org/show_bug.cgi?id=499628

ctx.beginPath() => ctx.strokeText() => ctx.closePtah() resolve the problem. This workaround should not affect the behavior in other browsers.

Issue: #345
