### PR TITLE
Bugfix for controlsAboveOverlay (issue #380)

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1216,7 +1216,8 @@
 
       if (this.controlsAboveOverlay &&
           this.lastRenderedObjectWithControlsAboveOverlay &&
-          this.containsPoint(e, this.lastRenderedObjectWithControlsAboveOverlay)) {
+          this.containsPoint(e, this.lastRenderedObjectWithControlsAboveOverlay) &&
+          this.lastRenderedObjectWithControlsAboveOverlay._findTargetCorner(e, this._offset)) {
         target = this.lastRenderedObjectWithControlsAboveOverlay;
         return target;
       }


### PR DESCRIPTION
Only if pointer is over targetCorner lastRenderedObjectWithControlsAboveOverlay is used as targetObject.

See issue #380.
