### PR TITLE
Add createJPEGStream method for fabric canvas

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -121,6 +121,10 @@
     return this.nodeCanvas.createPNGStream();
   };
 
+  fabric.StaticCanvas.prototype.createJPEGStream = function(opts) {
+    return this.nodeCanvas.createJPEGStream(opts);
+  };
+
   var origSetWidth = fabric.StaticCanvas.prototype.setWidth;
   fabric.StaticCanvas.prototype.setWidth = function(width) {
     origSetWidth.call(this);


### PR DESCRIPTION
Node Canvas already has support for createJPEGStream. Create a route to
take advantage of that through fabric.js canvas.
