### PR TITLE
Bugfix align_guidelines for canvas.toDataURL()

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -181,8 +181,11 @@ function initAligningGuidelines(canvas) {
     }
   });
 
-  canvas.on('after:render', function() {
+  canvas.on('before:render', function() {
     canvas.clearContext(canvas.contextTop);
+  });
+
+  canvas.on('after:render', function() {
     for (var i = verticalLines.length; i--; ) {
       drawVerticalLine(verticalLines[i]);
     }

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -533,6 +533,8 @@
         this.clearContext(canvasToDrawOn);
       }
 
+      this.fire('before:render');
+
       if (this.clipTo) {
         this._clipCanvas(canvasToDrawOn);
       }
@@ -545,8 +547,6 @@
       if (typeof this.backgroundImage === 'object') {
         this._drawBackroundImage(canvasToDrawOn);
       }
-
-      this.fire('before:render');
 
       var activeGroup = this.getActiveGroup();
       for (var i = 0, length = this._objects.length; i < length; ++i) {


### PR DESCRIPTION
Bugfix for canvas.toDataURL() - canvas.clearContext(canvas.contextTop) in after:render clears context if canvas.toDataURL() is called.

Observe before:render and clear contextTop.
