### PR TITLE
Resize to fit closes #393

### DIFF
--- a/src/object_geometry.mixin.js
+++ b/src/object_geometry.mixin.js
@@ -193,6 +193,22 @@
     },
 
     /**
+     * Resizes an object to fit within the specified dimensions while retaining the original aspect ratio.
+     * @method resizeToFit
+     * @param width {Number} new width value
+     * @param height {Number} new height value
+     * @return {fabric.Object} thisArg
+     * @chainable
+     */
+    resizeToFit: function(width, height) {
+      var xRatio = width / this.getWidth(),
+        yRatio = height / this.getHeight(),
+        ratio = Math.min(xRatio, yRatio);
+
+      return this.scale(ratio);
+    },
+
+    /**
      * Sets corner position coordinates based on current angle, width and height
      * @method setCoords
      * @return {fabric.Object} thisArg

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -305,6 +305,14 @@
     equal(cObj.get('scaleY'), 100/560);
   });
 
+  test('resizeToFit', function() {
+    var cObj = new fabric.Object({ width: 500, height: 600 });
+    ok(typeof cObj.resizeToFit == 'function');
+    equal(cObj.resizeToFit(100, 200), cObj, 'chainable');
+    equal(cObj.get('scaleY'), cObj.get('scaleX'));
+    equal(cObj.get('scaleY'), 100/500);
+  });
+
   test('scaleToWidth on rotated object', function() {
     var obj = new fabric.Object({ height: 100, width: 100 });
     obj.rotate(45);


### PR DESCRIPTION
A convenience method to resize to fit within the specified dimensions while retaining the original aspect ratio.

I haven't run "node build.js" and "npm test". I had some troubles installing all the dependencies and i received a lot of errors while doing it.
