### PR TITLE
Fixes for aligning_guidelines and centering_guidelines

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -6,7 +6,6 @@
 function initAligningGuidelines(canvas) {
 
   var ctx = canvas.getSelectionContext(),
-      canvasHeight = canvas.getHeight(),
       aligningLineOffset = 5,
       aligningLineMargin = 4,
       aligningLineWidth = 1,
@@ -60,8 +59,8 @@ function initAligningGuidelines(canvas) {
         activeObjectCenter = activeObject.getCenterPoint(),
         activeObjectLeft = activeObjectCenter.x,
         activeObjectTop = activeObjectCenter.y,
-        activeObjectHeight = activeObject.getHeight(),
-        activeObjectWidth = activeObject.getWidth(),
+        activeObjectHeight = activeObject.getBoundingRectHeight(),
+        activeObjectWidth = activeObject.getBoundingRectWidth(),
         horizontalInTheRange = false,
         verticalInTheRange = false,
         transform = canvas._currentTransform;
@@ -78,8 +77,8 @@ function initAligningGuidelines(canvas) {
       var objectCenter = canvasObjects[i].getCenterPoint(),
           objectLeft = objectCenter.x,
           objectTop = objectCenter.y,
-          objectHeight = canvasObjects[i].getHeight(),
-          objectWidth = canvasObjects[i].getWidth();
+          objectHeight = canvasObjects[i].getBoundingRectHeight(),
+          objectWidth = canvasObjects[i].getBoundingRectWidth();
 
       // snap by the horizontal center line
       if (isInRange(objectLeft, activeObjectLeft)) {

--- a/lib/centering_guidelines.js
+++ b/lib/centering_guidelines.js
@@ -48,17 +48,22 @@ function initCenteringGuidelines(canvas) {
       isInHorizontalCenter;
 
   canvas.on('object:moving', function(e) {
-    object = e.target;
+    var object = e.target,
+        objectCenter = object.getCenterPoint(),
+        transform = canvas._currentTransform;
 
-    isInVerticalCenter = object.get('left') in canvasWidthCenterMap,
-    isInHorizontalCenter = object.get('top') in canvasHeightCenterMap;
+    if (!transform) return;
 
-    if (isInHorizontalCenter) {
-      object.set('top', canvasHeightCenter);
+    isInVerticalCenter = objectCenter.x in canvasWidthCenterMap,
+    isInHorizontalCenter = objectCenter.y in canvasHeightCenterMap;
+
+    if (isInHorizontalCenter || isInVerticalCenter) {
+      object.setPositionByOrigin(new fabric.Point((isInVerticalCenter ? canvasWidthCenter : objectCenter.x), (isInHorizontalCenter ? canvasHeightCenter : objectCenter.y)), transform.originX, transform.originY);
     }
-    if (isInVerticalCenter) {
-      object.set('left', canvasWidthCenter);
-    }
+  });
+
+  canvas.on('before:render', function() {
+    canvas.clearContext(canvas.contextTop);
   });
 
   canvas.on('after:render', function() {


### PR DESCRIPTION
Hey kangax, sorry it's me again. :-)

I think both scripts works now as expected.

aligning_guidelines:
- Bugfix for rotated objects - rotated objects should be aligned correctly

centering_guidelines:
- Fix for objects with different origin (originX or originY != 'center')
- Fix for clear lines
