### PR TITLE
fabric.FreeDrawing: Clear contextTop before call renderAll() in _finalizeAndAddPath

### DIFF
--- a/src/freedrawing.class.js
+++ b/src/freedrawing.class.js
@@ -237,6 +237,7 @@
       // does not change position
       p.setCoords();
 
+      this.canvas.contextTop && this.canvas.clearContext(this.canvas.contextTop);
       this.canvas.renderAll();
 
       // fire event 'path' created


### PR DESCRIPTION
Same problem like issue #399.

After fabric.Path is created the top context is not cleared correctly.
