### PR TITLE
Bugfix for wrong offset for cloned objects (polygon & polyline)

### DIFF
--- a/src/polygon.class.js
+++ b/src/polygon.class.js
@@ -178,7 +178,7 @@
    * @return {fabric.Polygon}
    */
   fabric.Polygon.fromObject = function(object) {
-    return new fabric.Polygon(object.points, object);
+    return new fabric.Polygon(object.points, object, true);
   };
 
 })(typeof exports !== 'undefined' ? exports : this);

--- a/src/polyline.class.js
+++ b/src/polyline.class.js
@@ -151,7 +151,7 @@
    */
   fabric.Polyline.fromObject = function(object) {
     var points = object.points;
-    return new fabric.Polyline(points, object);
+    return new fabric.Polyline(points, object, true);
   };
 
 })(typeof exports !== 'undefined' ? exports : this);


### PR DESCRIPTION
Bugfix for wrong offset if object is cloned. Same bug as issue #416
