### PR TITLE
fabric.Group objects toSVG() order changed

### DIFF
--- a/src/group.class.js
+++ b/src/group.class.js
@@ -495,7 +495,7 @@
      */
     toSVG: function() {
       var objectsMarkup = [ ];
-      for (var i = 0, len = this.objects.length; i < len; i++) {
+      for (var i = this.objects.length; i--; ) {
         objectsMarkup.push(this.objects[i].toSVG());
       }
 


### PR DESCRIPTION
Changed the sort order in toSVG() from "first..last" to "last..first".
If they rendern on canvas the same order is used https://github.com/kangax/fabric.js/blob/master/src/group.class.js#L243
