### PR TITLE
Fix for issue #433 - wrong width/height of image objects

### DIFF
--- a/src/image.class.js
+++ b/src/image.class.js
@@ -403,11 +403,9 @@
    * @return {fabric.Image}
    */
   fabric.Image.fromElement = function(element, callback, options) {
-    options || (options = { });
-
     var parsedAttributes = fabric.parseAttributes(element, fabric.Image.ATTRIBUTE_NAMES);
 
-    fabric.Image.fromURL(parsedAttributes['xlink:href'], callback, extend(parsedAttributes, options));
+    fabric.Image.fromURL(parsedAttributes['xlink:href'], callback, extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
   };
 
   /**


### PR DESCRIPTION
If svg with image objects was parsed the width/height props 
of the image were overridden by width/height of the svg file.
