### PR TITLE
Valid svg output (http://validator.w3.org/)

### DIFF
--- a/src/path.class.js
+++ b/src/path.class.js
@@ -635,7 +635,6 @@
       return [
         '<g transform="', (this.group ? '' : this.getSvgTransform()), '">',
           '<path ',
-            'width="', this.width, '" height="', this.height, '" ',
             'd="', path, '" ',
             'style="', this.getSvgStyles(), '" ',
             'transform="translate(', (-this.width / 2), ' ', (-this.height/2), ')" />',

--- a/src/path_group.class.js
+++ b/src/path_group.class.js
@@ -142,8 +142,6 @@
       var objects = this.getObjects();
       var markup = [
         '<g ',
-          'width="', this.width, '" ',
-          'height="', this.height, '" ',
           'style="', this.getSvgStyles(), '" ',
           'transform="', this.getSvgTransform(), '" ',
         '>'

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -940,8 +940,8 @@
       if (!options.suppressPreamble) {
         markup.push(
           '<?xml version="1.0" standalone="no" ?>',
-            '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN" ',
-              '"http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">'
+            '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" ',
+              '"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">'
         );
       }
       markup.push(


### PR DESCRIPTION
- delete width/height attributes from g (http://www.w3.org/TR/SVG/struct.html#GElement) and path element (http://www.w3.org/TR/SVG/paths.html#PathElement)
- update DOCTYPE for svg version 1.1
