### PR TITLE
Bugfix fabric.PathGroup if object is not visible

### DIFF
--- a/src/object.class.js
+++ b/src/object.class.js
@@ -628,7 +628,7 @@
      */
     render: function(ctx, noTransform) {
 
-      // do not render if width or height are zeros
+      // do not render if width/height are zeros or object is not visible
       if (this.width === 0 || this.height === 0 || !this.visible) return;
 
       ctx.save();

--- a/src/path_group.class.js
+++ b/src/path_group.class.js
@@ -65,6 +65,10 @@
      * @param {CanvasRenderingContext2D} ctx Context to render this instance on
      */
     render: function(ctx) {
+
+      // do not render if object is not visible
+      if (!this.visible) return;
+
       ctx.save();
 
       var m = this.transformMatrix;


### PR DESCRIPTION
- if object is not visible and of type 'path-group' the object was still drawn
