### PR TITLE
'image not completely loaded' Node.js large image rendering.

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -47,14 +47,8 @@
   /** @private */
   function request_fs(url, callback){
     var fs = require('fs'),
-    stream = fs.createReadStream(url),
-    body = '';
-    stream.on('data', function(chunk){
-        body += chunk;
-    });
-    stream.on('end', function(){
-      callback(body);
-    });
+    body = fs.readFileSync(url);
+    callback(body);
   }
 
   fabric.util.loadImage = function(url, callback, context) {


### PR DESCRIPTION
I was having trouble loading large images up for rendering under node.js, getting:
"Error: Image given has not completed loading" errors. So changing the
chunked reader into a blocking file read solved the problem for me.
