### PR TITLE
fabric.Group#visible = false did not work

### DIFF
--- a/src/group.class.js
+++ b/src/group.class.js
@@ -247,6 +247,9 @@
      * @param {CanvasRenderingContext2D} ctx context to render instance on
      */
     render: function(ctx, noTransform) {
+      // do not render if object is not visible
+      if (!this.visible) return;
+
       ctx.save();
       this.transform(ctx);
 
@@ -260,6 +263,9 @@
         var object = this._objects[i-1],
             originalScaleFactor = object.borderScaleFactor,
             originalHasRotatingPoint = object.hasRotatingPoint;
+
+        // do not render if object is not visible
+        if (!object.visible) continue;
 
         object.borderScaleFactor = groupScaleFactor;
         object.hasRotatingPoint = false;


### PR DESCRIPTION
The fabric.Object#visible attribute has no affect to fabric.Goup and its objects.
