### PR TITLE
Bugfix for visible property / doc additions

### DIFF
--- a/src/group.class.js
+++ b/src/group.class.js
@@ -213,6 +213,7 @@
      * Renders instance on a given context
      * @method render
      * @param {CanvasRenderingContext2D} ctx context to render instance on
+     * @param {Boolean} [noTransform] When true, context is not transformed
      */
     render: function(ctx, noTransform) {
       // do not render if object is not visible

--- a/src/image.class.js
+++ b/src/image.class.js
@@ -88,8 +88,12 @@
      * Renders image on a specified context
      * @method render
      * @param {CanvasRenderingContext2D} ctx Context to render on
+     * @param {Boolean} [noTransform] When true, context is not transformed
      */
     render: function(ctx, noTransform) {
+      // do not render if object is not visible
+      if (!this.visible) return;
+
       ctx.save();
       var m = this.transformMatrix;
       // this._resetWidthHeight();
@@ -120,7 +124,7 @@
      * Returns object representation of an instance
      * @method toObject
      * @param {Array} propertiesToInclude
-     * @return {Object} object representation of an instance
+     * @return {Object} propertiesToInclude Object representation of an instance
      */
     toObject: function(propertiesToInclude) {
       return extend(this.callSuper('toObject', propertiesToInclude), {

--- a/src/object.class.js
+++ b/src/object.class.js
@@ -631,10 +631,9 @@
      * Renders an object on a specified context
      * @method render
      * @param {CanvasRenderingContext2D} ctx context to render on
-     * @param {Boolean} noTransform
+     * @param {Boolean} [noTransform] When true, context is not transformed
      */
     render: function(ctx, noTransform) {
-
       // do not render if width/height are zeros or object is not visible
       if (this.width === 0 || this.height === 0 || !this.visible) return;
 

--- a/src/path.class.js
+++ b/src/path.class.js
@@ -529,9 +529,12 @@
      * Renders path on a specified context
      * @method render
      * @param {CanvasRenderingContext2D} ctx context to render path on
-     * @param {Boolean} noTransform When true, context is not transformed
+     * @param {Boolean} [noTransform] When true, context is not transformed
      */
     render: function(ctx, noTransform) {
+      // do not render if object is not visible
+      if (!this.visible) return;
+
       ctx.save();
       var m = this.transformMatrix;
       if (m) {

--- a/src/path_group.class.js
+++ b/src/path_group.class.js
@@ -65,7 +65,6 @@
      * @param {CanvasRenderingContext2D} ctx Context to render this instance on
      */
     render: function(ctx) {
-
       // do not render if object is not visible
       if (!this.visible) return;
 

--- a/src/text.class.js
+++ b/src/text.class.js
@@ -639,6 +639,7 @@
      * Renders text instance on a specified context
      * @method render
      * @param ctx {CanvasRenderingContext2D} context to render on
+     * @param {Boolean} [noTransform] When true, context is not transformed
      */
     render: function(ctx, noTransform) {
       // do not render if object is not visible


### PR DESCRIPTION
Add check if object is visible to fabric.Image and fabric.Path. 
Now all fabric instances with own render method should check for visible property.

Some doc updates - add noTransform to doc and set it optional
