### PR TITLE
fabric.StaticCanvas.clear() delete _activeObject

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -501,6 +501,9 @@
       if (this.discardActiveGroup) {
         this.discardActiveGroup();
       }
+      if (this.discardActiveObject) {
+        this.discardActiveObject();
+      }
       this.clearContext(this.contextContainer);
       if (this.contextTop) {
         this.clearContext(this.contextTop);


### PR DESCRIPTION
If canvas is cleared `canvas._activeObject` should be removed.
