### PR TITLE
Fire event 'removed' on object level

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -458,6 +458,7 @@
      */
     _onObjectRemoved: function(obj) {
       this.fire('object:removed', { target: obj });
+      obj.fire('removed');
     },
 
     /**


### PR DESCRIPTION
There is `obj.fire('added')` but not `obj.fire('removed')`.
