### PR TITLE
Activate clicked object if group selection is cleared

### DIFF
--- a/src/canvas_events.mixin.js
+++ b/src/canvas_events.mixin.js
@@ -237,8 +237,8 @@
         else {
           if (target !== this.getActiveGroup()) {
             this.deactivateAll();
+            this.setActiveObject(target, e);
           }
-          this.setActiveObject(target, e);
         }
 
         this._setupCurrentTransform(e, target);


### PR DESCRIPTION
If group selection is cleared and pointer clicked other object 
=> activate this object.

Second commit:
Only setActiveObject if target !== activeGroup.

See issue #506
