### PR TITLE
minor jsdoc comment fix for fabric.Image.clone()

### DIFF
--- a/src/image.class.js
+++ b/src/image.class.js
@@ -172,8 +172,8 @@
     /**
      * Returns a clone of an instance
      * @method clone
-     * @param {Array} propertiesToInclude
      * @param {Function} callback Callback is invoked with a clone as a first argument
+     * @param {Array} propertiesToInclude
      */
     clone: function(callback, propertiesToInclude) {
       this.constructor.fromObject(this.toObject(propertiesToInclude), callback);


### PR DESCRIPTION
The jsdoc params for fabric.Image.clone() were out of order, so the API reference for this method at

```
http://fabricjs.com/docs/symbols/fabric.Image.html#clone
```

has an incorrect method summary (with the order of propertiesToInclude
and callback swapped).
