### PR TITLE
Add svg element to async objects (reviver)

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -356,7 +356,7 @@
                 instances.splice(index, 0, obj);
                 checkIfDone();
               };
-            })(index), options);
+            })(index, el), options);
           }
           else {
             var obj = klass.fromElement(el, options);


### PR DESCRIPTION
If async objects parsed (image), the reviver svg element is undefined.
You can see it here:
http://jsfiddle.net/Kienz/nhYww/
