### PR TITLE
Build canvas from json even if no object is sent

### DIFF
--- a/src/canvas_serialization.mixin.js
+++ b/src/canvas_serialization.mixin.js
@@ -181,7 +181,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @scope fabric.Stati
         overlayImageLoaded;
     
     var cbIfLoaded = function () {
-      callback && backgroundPatternLoaded && overlayImageLoaded && backgroundPatternLoaded && callback();
+      callback && backgroundImageLoaded && overlayImageLoaded && backgroundPatternLoaded && callback();
     };
 
     if (serialized.backgroundImage) {


### PR DESCRIPTION
Allow to build the canvas from json without objects and without background pattern, background image, and/or background color.
