### PR TITLE
Bugfix object.opacity == 0 in svg output

### DIFF
--- a/src/object.class.js
+++ b/src/object.class.js
@@ -495,7 +495,7 @@
         "stroke-width: ", (this.strokeWidth ? this.strokeWidth : '0'), "; ",
         "stroke-dasharray: ", (this.strokeDashArray ? this.strokeDashArray.join(' ') : "; "),
         "fill: ", (this.fill ? (this.fill && this.fill.toLive ? 'url(#SVGID_' + this.fill.id + ')' : this.fill) : 'none'), "; ",
-        "opacity: ", (this.opacity ? this.opacity : '1'), ";",
+        "opacity: ", (typeof this.opacity !== 'undefined' ? this.opacity : '1'), ";",
         (this.visible ? '' : " visibility: hidden;")
       ].join("");
     },


### PR DESCRIPTION
If object.opacity = 0 the svg output sets opacity to 1.
Closes #571
