### PR TITLE
on nodejs load remote image with full path

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -27,7 +27,7 @@
     var req = reqHandler.request({
       hostname: oURL.hostname,
       port: oURL.port,
-      path: oURL.pathname,
+      path: oURL.path,
       method: 'GET'
     }, function(response){
       var body = "";


### PR DESCRIPTION
sometime use server generate image, and passing parameter in url
so when send request should use full path, not only pathname
