### PR TITLE
Fix callback called 2 times on Node

### DIFF
--- a/src/image.class.js
+++ b/src/image.class.js
@@ -259,11 +259,7 @@
       });
 
        /** @ignore */
-      replacement.onload = function() {
-        _this._element = replacement;
-        callback && callback();
-        replacement.onload = canvasEl = imgEl = null;
-      };
+      
       replacement.width = imgEl.width;
       replacement.height = imgEl.height;
 
@@ -271,12 +267,17 @@
         // cut off data:image/png;base64, part in the beginning
         var base64str = canvasEl.toDataURL('image/png').substring(22);
         replacement.src = new Buffer(base64str, 'base64');
+        
+        // onload doesn't fire in some node versions, so we invoke callback manually
         _this._element = replacement;
-
-        // onload doesn't fire in node, so we invoke callback manually
         callback && callback();
       }
       else {
+        replacement.onload = function() {
+          _this._element = replacement;
+          callback && callback();
+          replacement.onload = canvasEl = imgEl = null;
+        };
         replacement.src = canvasEl.toDataURL('image/png');
       }
 


### PR DESCRIPTION
The recent versions of Node (node-canvas) call onload on the elements.
