### PR TITLE
Render object controls correctly at large scaling This fixes issue #680.

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -311,7 +311,7 @@
 
       var size = this.cornerSize,
           size2 = size / 2,
-          strokeWidth2 = this.strokeWidth > 1 ? (strokeWidth / 2) : 0,
+          strokeWidth2 = this.strokeWidth > 1 ? (this.strokeWidth / 2) : 0,
           left = -(this.width / 2),
           top = -(this.height / 2),
           _left,


### PR DESCRIPTION
The rendering of controls did not take into account the strokeWidth scaling. fixes isssue #680 
