### PR TITLE
Fix bug for not firing selection:created when using Shift to add objects

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -421,6 +421,7 @@
             var group = new fabric.Group([ this._activeObject, target ]);
             this.setActiveGroup(group);
             activeGroup = this.getActiveGroup();
+            this.fire('selection:created', { target: activeGroup, e: e });
           }
         }
         // activate target object in any case


### PR DESCRIPTION
Currently if you use Shift+Click to add objects to a group, selection:created will only fire after you add 3 or more objects to the group. This fix allows selection:created to fire when the group is first created (when the second object is added).
