### PR TITLE
Add support for Buffers to utils.loadImage

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -77,7 +77,7 @@
       callback && callback.call(context, img);
     };
     var img = new Image();
-    if (url && url.indexOf('data') === 0) {
+    if (url && (url instanceof Buffer || url.indexOf('data') === 0)) {
       img.src = img._src = url;
       callback && callback.call(context, img);
     }


### PR DESCRIPTION
If the user has preloaded image data in a Buffer, allow that user to use
that data to load into a Fabric.js image.

This is possible because node-canvas [supports setting 'src' to a Buffer](https://github.com/LearnBoost/node-canvas/blob/master/lib/image.js#L29).
