### PR TITLE
Resizing: allow centerTransform per-object

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -160,7 +160,7 @@
       t.target.set('left', t.original.left);
       t.target.set('top', t.original.top);
 
-      if (e.altKey || this.centerTransform) {
+      if (e.altKey || this.centerTransform || t.target.centerTransform) {
         if (t.originX !== 'center') {
           if (t.originX === 'right') {
             t.mouseXSign = -1;

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -146,6 +146,13 @@
     cornerColor:              'rgba(102,153,255,0.5)',
 
     /**
+     * When true, this object will center point as the origin of transformation
+     * when being resized via the controls.
+     * @type Boolean
+     */
+    centerTransform:        false,
+
+    /**
      * Color of object's fill
      * @type String
      * @default


### PR DESCRIPTION
Instead of ONLY a global setting. Some objects (like circles) make far
more sense with centerTransform so it's nice to be able to do it
per-object.
