### PR TITLE
Syntax: move a comma

### DIFF
--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -56,14 +56,14 @@ fabric.Shadow = fabric.util.createClass(/** @lends fabric.Shadow.prototype */ {
       offsetX: this.offsetX,
       offsetY: this.offsetY
     };
-  },
+  }
 
   /* _TO_SVG_START_ */
   /**
    * Returns SVG representation of a shadow
    * @return {String}
    */
-  toSVG: function() {
+  ,toSVG: function() {
 
   }
   /* _TO_SVG_END_ */


### PR DESCRIPTION
When SVG import was excluded, this ended us as a trailing comma which
older versions of IE completely barf on.

This change moves the comma inside the conditional block.
