### PR TITLE
Set object shadow and context shadow only if shadowColor is set

### DIFF
--- a/src/brushes/base_brush.class.js
+++ b/src/brushes/base_brush.class.js
@@ -76,10 +76,12 @@ fabric.BaseBrush = fabric.util.createClass(/** @lends fabric.BaseBrush.prototype
    * Sets brush shadow styles
    */
   setShadowStyles: function() {
+    if (!this.shadowColor) return;
+
     var ctx = this.canvas.contextTop;
 
     ctx.shadowBlur = this.shadowBlur;
-    ctx.shadowColor = this.shadowColor || this.color;
+    ctx.shadowColor = this.shadowColor;
     ctx.shadowOffsetX = this.shadowOffsetX;
     ctx.shadowOffsetY = this.shadowOffsetY;
   },

--- a/src/brushes/circle_brush.class.js
+++ b/src/brushes/circle_brush.class.js
@@ -7,6 +7,7 @@ fabric.CircleBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabri
   /**
    * Width of a brush
    * @type Number
+   * @default
    */
   width: 10,
 
@@ -22,7 +23,6 @@ fabric.CircleBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabri
 
   /**
    * Invoked on mouse down
-   * @param {Object} pointer
    */
   onMouseDown: function() {
     this.points.length = 0;
@@ -58,14 +58,18 @@ fabric.CircleBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabri
         radius: point.radius,
         left: point.x,
         top: point.y,
-        fill: point.fill,
-        shadow: {
-          color: this.shadowColor || this.color,
+        fill: point.fill
+      });
+
+      if (this.shadowColor) {
+        circle.setShadow({
+          color: this.shadowColor,
           blur: this.shadowBlur,
           offsetX: this.shadowOffsetX,
           offsetY: this.shadowOffsetY
-        }
-      });
+        });
+      }
+
       this.canvas.add(circle);
       this.canvas.fire('path:created', { path: circle });
     }

--- a/src/brushes/pencil_brush.class.js
+++ b/src/brushes/pencil_brush.class.js
@@ -211,13 +211,17 @@
       path.strokeWidth = this.width;
       path.strokeLineCap = this.strokeLineCap;
       path.strokeLineJoin = this.strokeLineJoin;
-      path.setShadow({
-        color: this.shadowColor || this.color,
-        blur: this.shadowBlur,
-        offsetX: this.shadowOffsetX,
-        offsetY: this.shadowOffsetY,
-        affectStroke: true
-      });
+
+      if (this.shadowColor) {
+        path.setShadow({
+          color: this.shadowColor,
+          blur: this.shadowBlur,
+          offsetX: this.shadowOffsetX,
+          offsetY: this.shadowOffsetY,
+          affectStroke: true
+        });
+      }
+
       return path;
     },
 

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -7,30 +7,35 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   /**
    * Width of a spray
    * @type Number
+   * @default
    */
   width:              10,
 
   /**
    * Density of a spray (number of dots per chunk)
    * @type Number
+   * @default
    */
   density:            20,
 
   /**
    * Width of spray dots
    * @type Number
+   * @default
    */
   dotWidth:           1,
 
   /**
    * Width variance of spray dots
    * @type Number
+   * @default
    */
   dotWidthVariance:   1,
 
   /**
    * Whether opacity of a dot should be random
    * @type Boolean
+   * @default
    */
   randomOpacity:      false,
 
@@ -83,14 +88,17 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
           height: sprayChunk[j].width,
           left: sprayChunk[j].x + 1,
           top: sprayChunk[j].y + 1,
-          fill: this.color,
-          shadow: {
-            color: this.shadowColor || this.color,
+          fill: this.color
+        });
+
+        if (this.shadowColor) {
+          rect.setShadow({
+            color: this.shadowColor,
             blur: this.shadowBlur,
             offsetX: this.shadowOffsetX,
             offsetY: this.shadowOffsetY
-          }
-        });
+          });
+        }
 
         this.canvas.add(rect);
         this.canvas.fire('path:created', { path: rect });


### PR DESCRIPTION
Set object shadow and context shadow only if shadowColor is set
Otherwise toSVG() returns for every brush object a shadow filter
