### PR TITLE
Avoid unnecessary renderAll calls in mousedown and mouseup events.

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -201,7 +201,7 @@
       var activeGroup = this.getActiveGroup();
       if (activeGroup) {
         activeGroup.setObjectsCoords();
-        activeGroup.isMoving = false
+        activeGroup.isMoving = false;
         this._setCursor(this.defaultCursor);
       }
 


### PR DESCRIPTION
Tested it with `canvas.selection = true/false`.
If you click on atciveObject, activeGroup or empty space (no activeObject exists) no `canvas.renderAll()` is called.
