### PR TITLE
Fix mouse handling inside a scrollable div.

### DIFF
--- a/dist/all.js
+++ b/dist/all.js
@@ -3258,8 +3258,8 @@ fabric.util.string = {
         scrollTop = 0;
       }
       else if (element === fabric.document) {
-        scrollLeft = body.scrollLeft || docElement.scrollLeft || 0;
-        scrollTop = body.scrollTop ||  docElement.scrollTop || 0;
+        scrollLeft += body.scrollLeft || docElement.scrollLeft || 0;
+        scrollTop += body.scrollTop ||  docElement.scrollTop || 0;
       }
       else {
         scrollLeft += element.scrollLeft || 0;


### PR DESCRIPTION
See this (using the latest master):

http://jsfiddle.net/Lmgwu/

Once you scroll inside the container, mouse coordinates are handled incorrectly. This is because all scrollLeft/scrollTop values are reset once the loop reaches the root element.
