### PR TITLE
Do not name the requirejs module (see http://requirejs.org/docs/api.html...

### DIFF
--- a/src/amd/requirejs.js
+++ b/src/amd/requirejs.js
@@ -7,5 +7,5 @@ var exports = exports || {};
 exports.fabric = fabric;
 
 if (typeof define === "function" && define.amd) {
-  define("fabric", [], function() { return fabric });
+  define([], function() { return fabric });
 }


### PR DESCRIPTION
After hours of fighting with requirejs I realized that the reason my fabricjs wasn't being imported was because the module was named, which causes it to fail unless the code is in a file called exactly "fabric.js", which mine wasn't since I was using bower (the code was in a file called all.require.js).  This pull request removes this constraint.

See http://requirejs.org/docs/api.html#modulename for details.
