### PR TITLE
Fix object selection with shift key - Closes issue #912

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -479,6 +479,8 @@
           if (activeGroup.size() === 1) {
             // remove group alltogether if after removal it only contains 1 object
             this.discardActiveGroup();
+            // activate last remaining object
+            this.setActiveObject(activeGroup.item(0));
           }
         }
         else {

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -166,11 +166,12 @@
     _shouldRender: function(target, pointer) {
       var activeObject = this.getActiveGroup() || this.getActiveObject();
 
-      return (
+      return !!(
         (target && (
         target.isMoving ||
         target !== activeObject)) ||
-        (!target && activeObject) ||
+        (!target && !!activeObject) ||
+        (!target && !activeObject && !this._groupSelector) ||
         (pointer &&
         this._previousPointer &&
         this.selection && (


### PR DESCRIPTION
If you select two object and click one object with pressed shift key the last remaining object got selected.
Closes issue #912
