### PR TITLE
empty objects callback missed bug in enlivenObjects function fixed

### DIFF
--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -191,6 +191,11 @@
       return;
     }
 
+		if (0 === objects.length) {
+			('function' === typeof(callback)) && callback({});
+			return;
+		}
+
     objects.forEach(function (o, index) {
       // if sparse array
       if (!o || !o.type) {


### PR DESCRIPTION
if objects array is empty within enlivenObjects function, callback will never be called ... this should fix it ...
