### PR TITLE
finer animation

### DIFF
--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -1,6 +1,6 @@
 (function() {
 
-  /**
+   /**
     * Changes value from one to another within certain period of time, invoking callbacks as value is being changed.
     * @memberOf fabric.util
     * @param {Object} [options] Animation options


### PR DESCRIPTION
I've added a check for the sub-millisecond callback argument available in most implementations of `rAF`, and use it for finer grained animations (sub-millisecond means more precise calculations).

The drawback is that it requires `rAF` to be called as an entry into the method, in order to get a precise start time, since the argument is actually time since the page loaded, and therefore different than `+new Date()`. I think it's worth the tradeoff.
