### PR TITLE
Remove activeObject in `fabric.Canvas#remove` - Closes issue #962

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -560,6 +560,13 @@
      * @param {fabric.Object} obj Object that was removed
      */
     _onObjectRemoved: function(obj) {
+      // removing active object should fire "selection:cleared" events
+      if (this.getActiveObject() === obj) {
+        this.fire('before:selection:cleared', { target: obj });
+        this._discardActiveObject();
+        this.fire('selection:cleared');
+      }
+
       this.fire('object:removed', { target: obj });
       obj.fire('removed');
     },
@@ -1054,22 +1061,6 @@
       }
     },
     /* _TO_SVG_END_ */
-
-    /**
-     * Removes an object from canvas and returns it
-     * @param {fabric.Object} object Object to remove
-     * @return {fabric.Object} removed object
-     */
-    remove: function (object) {
-      // removing active object should fire "selection:cleared" events
-      if (this.getActiveObject() === object) {
-        this.fire('before:selection:cleared', { target: object });
-        this.discardActiveObject();
-        this.fire('selection:cleared');
-      }
-
-      return fabric.Collection.remove.call(this, object);
-    },
 
     /**
      * Moves an object to the bottom of the stack of drawn objects

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -986,8 +986,7 @@
     canvas.setActiveObject(canvas.item(0));
     canvas.remove(canvas.item(0));
 
-    // TODO: find out why this is failing
-    // equal(isFired, true, 'removing active object should fire "selection:cleared"');
+    equal(isFired, true, 'removing active object should fire "selection:cleared"');
   });
 
   test('clipTo', function() {


### PR DESCRIPTION
Fire 'before:selection:cleared' and 'selection:cleared' if activeObject is removed from canvas
Add unit test

Fixes issue #962
