### PR TITLE
[BACK_INCOMPAT] Possibility to remove multiple `fabric.Objects` from collection (canvas, group) 

### DIFF
--- a/src/mixins/collection.mixin.js
+++ b/src/mixins/collection.mixin.js
@@ -6,12 +6,12 @@ fabric.Collection = {
   /**
    * Adds objects to collection, then renders canvas (if `renderOnAddRemove` is not `false`)
    * Objects should be instances of (or inherit from) fabric.Object
-   * @param [...] Zero or more fabric instances
+   * @param {...fabric.Object} object Zero or more fabric instances
    * @return {Self} thisArg
    */
   add: function () {
     this._objects.push.apply(this._objects, arguments);
-    for (var i = arguments.length; i--; ) {
+    for (var i = 0, length = arguments.length; i < length; i++) {
       this._onObjectAdded(arguments[i]);
     }
     this.renderOnAddRemove && this.renderAll();
@@ -25,6 +25,7 @@ fabric.Collection = {
    * @param {Number} index Index to insert object at
    * @param {Boolean} nonSplicing When `true`, no splicing (shifting) of objects occurs
    * @return {Self} thisArg
+   * @chainable
    */
   insertAt: function (object, index, nonSplicing) {
     var objects = this.getObjects();
@@ -40,22 +41,27 @@ fabric.Collection = {
   },
 
   /**
-   * Removes an object from a collection, then renders canvas (if `renderOnAddRemove` is not `false`)
-   * @param {Object} object Object to remove
+   * Removes objects from a collection, then renders canvas (if `renderOnAddRemove` is not `false`)
+   * @param {...fabric.Object} object Zero or more fabric instances
    * @return {Self} thisArg
+   * @chainable
    */
-  remove: function(object) {
+  remove: function() {
     var objects = this.getObjects(),
-        index = objects.indexOf(object);
+        index;
 
-    // only call onObjectRemoved if an object was actually removed
-    if (index !== -1) {
-      objects.splice(index, 1);
-      this._onObjectRemoved(object);
+    for (var i = 0, length = arguments.length; i < length; i++) {
+      index = objects.indexOf(arguments[i]);
+
+      // only call onObjectRemoved if an object was actually removed
+      if (index !== -1) {
+        objects.splice(index, 1);
+        this._onObjectRemoved(arguments[i]);
+      }
     }
 
     this.renderOnAddRemove && this.renderAll();
-    return object;
+    return this;
   },
 
   /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1332,7 +1332,8 @@
      * @chainable
      */
     remove: function() {
-      return this.canvas.remove(this);
+      this.canvas.remove(this);
+      return this;
     },
 
     /**

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -52,17 +52,35 @@
     ok(typeof group.getObjects == 'function');
     ok(Object.prototype.toString.call(group.getObjects()) == '[object Array]', 'should be an array');
     equal(group.getObjects().length, 2, 'should have 2 items');
-    deepEqual([ rect1, rect2 ], group.getObjects(), 'should return deepEqual objects as those passed to constructor');
+    deepEqual(group.getObjects(), [ rect1, rect2 ], 'should return deepEqual objects as those passed to constructor');
+  });
+
+  test('getObjects with type', function() {
+    var rect = new fabric.Rect({ width: 10, height: 20 }),
+        circle = new fabric.Circle({ radius: 30 });
+
+    var group = new fabric.Group([ rect, circle ]);
+
+    equal(group.size(), 2, 'should have length=2 initially');
+
+    deepEqual(group.getObjects('rect'), [rect], 'should return rect only');
+    deepEqual(group.getObjects('circle'), [circle], 'should return circle only');
   });
 
   test('add', function() {
     var group = makeGroupWith2Objects();
-    var rect = new fabric.Rect();
+    var rect1 = new fabric.Rect(),
+        rect2 = new fabric.Rect(),
+        rect3 = new fabric.Rect();
 
     ok(typeof group.add == 'function');
-    equal(group.add(rect), group, 'should be chainable');
-    equal(group.getObjects()[group.getObjects().length-1], rect, 'last object should be newly added one');
+    equal(group.add(rect1), group, 'should be chainable');
+    strictEqual(group.item(group.size()-1), rect1, 'last object should be newly added one');
     equal(group.getObjects().length, 3, 'there should be 3 objects');
+
+    group.add(rect2, rect3);
+    strictEqual(group.item(group.size()-1), rect3, 'last object should be last added one');
+    equal(group.size(), 5, 'there should be 5 objects');
   });
 
   test('remove', function() {
@@ -72,8 +90,11 @@
         group = new fabric.Group([ rect1, rect2, rect3 ]);
 
     ok(typeof group.remove == 'function');
-    equal(group.remove(rect2), rect2, 'should return removed object');
-    deepEqual([rect1, rect3], group.getObjects(), 'should remove object properly');
+    equal(group.remove(rect2), group, 'should be chainable');
+    deepEqual(group.getObjects(), [rect1, rect3], 'should remove object properly');
+
+    group.remove(rect1, rect3);
+    equal(group.isEmpty(), true, 'group should be empty');
   });
 
   test('size', function() {
@@ -452,7 +473,7 @@ test('toObject without default values', function() {
     equal(group.item(1), rect1);
     group.insertAt(rect2, 2);
     equal(group.item(2), rect2);
-    equal(group, group.insertAt(rect1, 2), 'should be chainable');
+    equal(group.insertAt(rect1, 2), group, 'should be chainable');
   });
 
   // asyncTest('cloning group with image', function() {

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -900,6 +900,18 @@ test('toDataURL & reference to canvas', function() {
     equal(canvas.getObjects().length, 0);
   });
 
+  test('object:removed', function() {
+    var object = new fabric.Object();
+    var removedEventFired = false;
+
+    canvas.add(object);
+
+    object.on('removed', function(){ removedEventFired = true; });
+    object.remove();
+
+    ok(removedEventFired);
+  });
+
   test('center', function() {
     var object = new fabric.Object();
 


### PR DESCRIPTION
[BACK_INCOMPAT] Possibility to remove multiple `fabric.Objects` from collection (canvas, group) 
`this` (canvas, group or object) is returned instead of deleted object
Update unit tests - use strictEqual for some cases
Add multiple objects raised `object:added` for last added object first - now 1st added object raises 1st `object:added` event, 2nd object raises 2nd `object:added`…

Closes issue #963
