### PR TITLE
build.js with argument 'dest' to specify a path other than 'dist/'

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
 
 var buildArgs = process.argv.slice(2),
     buildArgsAsObject = { },
-    rootPath = process.cwd(),
+    rootPath = process.cwd();
 
 buildArgs.forEach(function(arg) {
   var key = arg.split('=')[0],


### PR DESCRIPTION
I would like to be able to specify a path where node build.js would build into. If I understand build.js correctly, there is no way other than to just change the hard coded 'dist/' into something else. 

I noticed that the build script will execute succesfully when called from another folder, and will output the files relative to that folder. But I did not want to be bound to the 'dist/' that will still have to be the last folder. 

So I created the option to provide a custom destination path in the same style as the custom minifier. 
