### PR TITLE
timeout of 0 to free the UI on createObjects

### DIFF
--- a/src/elements_parser.js
+++ b/src/elements_parser.js
@@ -15,9 +15,9 @@ fabric.ElementsParser = {
 
   createObjects: function() {
     for (var i = 0, len = this.elements.length; i < len; i++) {
-      (function(that, fabric, i) {
-          fabric.window.setTimeout(function() { that.createObject(that.elements[i], i); }, 0);
-      })(this, fabric, i);
+      (function(that, i) {
+          setTimeout(function() { that.createObject(that.elements[i], i); }, 0);
+      })(this, i);
     }
   },
 


### PR DESCRIPTION
This minimal fix makes a huge difference on big D3 charts I'm rendering that were blocking the UI for 10 seconds. Now the UI stays responsive.
