### PR TITLE
Loading non-existing files with loadSVGFromURL() throws an error

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -758,13 +758,13 @@
       function onComplete(r) {
 
         var xml = r.responseXML;
-        if (!xml.documentElement && fabric.window.ActiveXObject && r.responseText) {
+        if (xml && !xml.documentElement && fabric.window.ActiveXObject && r.responseText) {
           xml = new ActiveXObject('Microsoft.XMLDOM');
           xml.async = 'false';
           //IE chokes on DOCTYPE
           xml.loadXML(r.responseText.replace(/<!DOCTYPE[\s\S]*?(\[[\s\S]*\])*?>/i,''));
         }
-        if (!xml.documentElement) return;
+        if (!xml || !xml.documentElement) return;
 
         fabric.parseSVGDocument(xml.documentElement, function (results, options) {
           svgCache.set(url, {


### PR DESCRIPTION
If a non-existing file is attempted to be loaded with loadSVGFromURL() an error is thrown because xml will be undefined. Added checks to make sure it's defined or exit early if (still) undefined.
