### PR TITLE
Correcting invalid control name

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -353,7 +353,7 @@
         top - scaleOffsetY - strokeWidth2 - paddingY);
 
       // bottom-left
-      this._drawControl('tr', ctx, methodName,
+      this._drawControl('bl', ctx, methodName,
         left - scaleOffsetX - strokeWidth2 - paddingX,
         top + height + scaleOffsetSizeY + strokeWidth2 + paddingY);
 


### PR DESCRIPTION
When disabling the "tr" control the "bl" control was vanishing as well...
