### PR TITLE
Rewrite renderSelection to only draw once per line

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -512,17 +512,19 @@
 
       var start = this.get2DCursorLocation(this.selectionStart),
           end = this.get2DCursorLocation(this.selectionEnd),
+          startLine = start.lineIndex,
+          endLine = end.lineIndex,
           textLines = this.text.split(this._reNewline),
           charIndex = start.charIndex - textLines[0].length;
 
-      for(var i = start.lineIndex, lineCount = end.lineIndex; i <= lineCount; i++){
+      for (var i = startLine; i <= endLine; i++) {
         var lineOffset = this._getCachedLineOffset(i, textLines) || 0,
             lineHeight = this._getCachedLineHeight(i),
             boxWidth = 0;
 
-        if (i == start.lineIndex) {
+        if (i === startLine) {
           for (var j = 0, len = textLines[i].length; j < len; j++) {
-            if (j >= start.charIndex && (i !== end.lineIndex || j < end.charIndex)) {
+            if (j >= start.charIndex && (i !== endLine || j < end.charIndex)) {
               boxWidth += this._getWidthOfChar(ctx, textLines[i][j], i, charIndex);
             }
             if (j < start.charIndex) {
@@ -531,11 +533,11 @@
             charIndex++;
           }
         }
-        else if (i > start.lineIndex && i < end.lineIndex) {
+        else if (i > startLine && i < endLine) {
           boxWidth += this._getCachedLineWidth(i, textLines) || 5;
           charIndex += textLines[i].length;
         }
-        else if (i == end.lineIndex) {
+        else if (i === endLine) {
           for (var j = 0, len = end.charIndex; j < len; j++) {
             boxWidth += this._getWidthOfChar(ctx, textLines[i][j], i, charIndex);
             charIndex++;


### PR DESCRIPTION
Previously RenderSelection performed a fillRect() command for every character.  This resulted in poor performance on large bodies of text.  This rewrite calculates the selection box for each line of text and draws a single rectangle for each line, dramatically improving performance.
