### PR TITLE
Line object coordinates are correct

### DIFF
--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -60,8 +60,8 @@
       this.set('width', Math.abs(this.x2 - this.x1) || 1);
       this.set('height', Math.abs(this.y2 - this.y1) || 1);
 
-      this.set('left', options.left || this._getLeftToOriginX());
-      this.set('top', options.top || this._getTopToOriginY());
+      this.set('left', ('left' in options) ? options.left : this._getLeftToOriginX());
+      this.set('top', ('top' in options) ? options.top : this._getTopToOriginY());
     },
 
     /**

--- a/test/unit/line.js
+++ b/test/unit/line.js
@@ -373,6 +373,19 @@
         top: 76,
       }
     },
+    { description: '0 left and 0 top options override points',
+      givenLineArgs: {
+        points: [12, 34, 56, 78],
+        options: {
+          left: 0,
+          top: 0,
+        }
+      },
+      expectedCoords: {
+        left: 0,
+        top: 0,
+      }
+    },
     { description: 'equal x2 and y2 for left-top origin when x1 and y1 are largest and line not offset',
       givenLineArgs: {
         points: [100, 200, 30, 40],


### PR DESCRIPTION
Patch for issue #1018.

fabric.Line._setWidthHeight was assigning left and top as if both
origins were 'center'.

It now uses private helper methods to calculate the distances from
left and top edges of canvas to the line origins.

The data for existing Line.toObject test is updated with origin-relative
coordinates.

I might have gone a bit overboard with the test cases.

Fixing the coordinates caused a path-group rendering bug I couldn't understand:
http://jsfiddle.net/YtCC2/56/

After some experimentation I came up with a solution that works, but I don't know why it works:
http://jsfiddle.net/YtCC2/57/

I didn't know how to test rendering, and didn't find any existing `_render` tests.

**edit**: The line must be shifted to the path group left-top, so the offset will be origin-dependent. I was confused, because I tried changing the origins of existing lines, which had no effect. I'll fix it in a few hours
