### PR TITLE
Prevent multiple hidden Textareas

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -11,7 +11,6 @@
       this.initKeyHandlers();
       this.initCursorSelectionHandlers();
       this.initDoubleClickSimulation();
-      this.initHiddenTextarea();
     },
 
     /**
@@ -308,7 +307,8 @@
       this.exitEditingOnOthers();
 
       this.isEditing = true;
-
+      
+      this.initHiddenTextarea();
       this._updateTextarea();
       this._saveEditingProps();
       this._setEditingProps();
@@ -400,7 +400,8 @@
       this.selectable = true;
 
       this.selectionEnd = this.selectionStart;
-      this.hiddenTextarea && this.hiddenTextarea.blur();
+      this.hiddenTextarea && this.canvas && this.hiddenTextarea.parentNode.removeChild(this.hiddenTextarea);
+      this.hiddenTextarea = null;
 
       this.abortCursorAnimation();
       this._restoreEditingProps();


### PR DESCRIPTION
Currently a hidden `TEXTAREA` is created for every IText instance and remain in the DOM forever.  

This patch creates the required textarea on demand in `enterEditing` and destroys it in `exitEditing`

This prevents multiple Textareas from hanging around in the DOM which can cause slowdowns in complex scenes with lots of IText instances.
