### PR TITLE
Improve overall IText performance with varying styles > 1000%

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -898,7 +898,7 @@
       if (this._charWidthsCache[cacheProp] && this.caching) {
         return this._charWidthsCache[cacheProp];
       }
-      else {
+      else if(ctx){
         ctx.save();
         var width = this._applyCharStylesGetWidth(ctx, _char, lineIndex, charIndex);
         ctx.restore();


### PR DESCRIPTION
`_getWidthOfChar()` is called continuously throughout the IText rendering pipeline.  

It is called 100's of times when positioning/rendering the cursor, the selection area, the actual text and when rendering any text decorations.

This causes dramatic slowdowns since internally `_getWidthOfChar()` calls `_applyCharStylesGetWidth()`

When there are no inline character styles this is not a problem since `_applyCharStylesGetWidth()` is clever enough to realize that styles are empty and short circuits, returning the cached width value of the character when the IText objects `caching` property is set to `true`

However, when `_applyCharStylesGetWidth()` is dealing with characters with applied styles, it sets and makes multiple `context` changes each time it is run, even when dealing with cached widths.  These context changes only need to be applied when actually rendering the text.  The rest of the time we simply want the width of the character, which when `caching` is true, we already have.

This patch returns the cached width value if present, rather than recalculating everything with `_applyCharStylesGetWidth()` hundreds or thousands of times for each `renderAll()` loop.

The resulting speed up is in excess of 1000% whenever any inline character styles are used.

On an IText instance with 20 separate inline style declarations, selection, cursor manipulation and any object transformations move from an average of 3fps to 60fps when combined with PR #1113 (In Firefox on Windows 8 on an Intel core i7 laptop).
