### PR TITLE
Adding nullcheck to touches attr on event.

### DIFF
--- a/src/mixins/canvas_gestures.mixin.js
+++ b/src/mixins/canvas_gestures.mixin.js
@@ -14,7 +14,7 @@
      */
     __onTransformGesture: function(e, self) {
 
-      if (this.isDrawingMode || e.touches.length !== 2 || 'gesture' !== self.gesture) {
+      if (this.isDrawingMode || !e.touches || e.touches.length !== 2 || 'gesture' !== self.gesture) {
         return;
       }
 


### PR DESCRIPTION
This was throwing errors in IE11 on desktop.  Not that it needs gesture support...
