### PR TITLE
[Fix] loadSVGFromString receives raw buffer instead of string when loading SVG file from disk

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -96,7 +96,7 @@
     url = url.replace(/^\n\s*/, '').replace(/\?.*$/, '').trim();
     if (url.indexOf('http') !== 0) {
       request_fs(url, function(body) {
-        fabric.loadSVGFromString(body, callback, reviver);
+        fabric.loadSVGFromString(body.toString(), callback, reviver);
       });
     }
     else {


### PR DESCRIPTION
According to [the NodeJS documentation](http://nodejs.org/api/fs.html#fs_fs_readfile_filename_options_callback), `fs.readFile()` returns the raw buffer if no encoding is specified. Since `fabric.loadSVGFromString()` expects a String as the first parameter,  the call would break the canvas loading if a SVG file is involved. This PR fixes that, transforming the buffer into a String (assuming `utf-8` encoding, which is [the default](http://nodejs.org/api/buffer.html#buffer_buf_tostring_encoding_start_end)).

**Note**: If multiple encodings support is something desirable, it may be wise to add an optional parameter somehow, which would specify an encoding other than `utf-8`.
