### PR TITLE
Fix object onClick (previously failed change)

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -46,7 +46,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
 
   onClick: function() {
     // No need to trigger click event here, focus is enough to have the keyboard appear on Android
-    this.hiddenTextarea.focus();
+    this.hiddenTextarea && this.hiddenTextarea.focus();
   },
 
   /**


### PR DESCRIPTION
Adds checking for the existence of `this.hiddenTextarea` before firing the focus event to bring up the mobile keyboard.

This change should have been in the related pull request but for whatever reason hasn't seemed to go through.

Fixes bug introduced in https://github.com/kangax/fabric.js/commit/213b99eb9f3903d78d2eb5138a0997b40953002d due to the missing change
