### PR TITLE
Fix IOS drawing bug

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -141,14 +141,20 @@
     _onMouseDown: function (e) {
       this.__onMouseDown(e);
 
-      addListener(fabric.document, 'mouseup', this._onMouseUp);
       addListener(fabric.document, 'touchend', this._onMouseUp);
-
-      addListener(fabric.document, 'mousemove', this._onMouseMove);
       addListener(fabric.document, 'touchmove', this._onMouseMove);
 
       removeListener(this.upperCanvasEl, 'mousemove', this._onMouseMove);
       removeListener(this.upperCanvasEl, 'touchmove', this._onMouseMove);
+
+      if (e.type === 'touchstart') {
+        // Unbind mousedown to prevent double triggers from touch devices
+        removeListener(this.upperCanvasEl, 'mousedown', this._onMouseDown); 
+      }
+      else {
+        addListener(fabric.document, 'mouseup', this._onMouseUp);
+        addListener(fabric.document, 'mousemove', this._onMouseMove);
+      }
     },
 
     /**
@@ -166,6 +172,14 @@
 
       addListener(this.upperCanvasEl, 'mousemove', this._onMouseMove);
       addListener(this.upperCanvasEl, 'touchmove', this._onMouseMove);
+
+      if (e.type === 'touchend') {
+        // Wait 400ms before rebinding mousedown to prevent double triggers
+        // from touch devices
+        setTimeout(function() {
+          addListener(this.upperCanvasEl, 'mousedown', this._onMouseDown);
+        }, 400);
+      }
     },
 
     /**


### PR DESCRIPTION
When starting to draw using the pencil in IOS, after 300ms a line is drawn in the direction of the button which activated the drawing mode. This happens only once. So when you draw a second line, there are no issues.

This can be reproduced in the kitchensink demo using an Apple device: http://fabricjs.com/kitchensink/

The cause of this bug is the mousemove event. This is fired using wrong coordinates. Android doesn't fire the mousemove event. This solutions filters the mousemove event for all touch devices.

I tried removing the mousemove event completely for touch devices. But this breaks moving stuff around.
