### PR TITLE
Stop Event.js from messing with global Event objects.

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -27,10 +27,10 @@ if (typeof(eventjs) === "undefined") var eventjs = Event;
 (function(root) { "use strict";
 
 // Add custom *EventListener commands to HTMLElements (set false to prevent funkiness).
-root.modifyEventListener = true;
+root.modifyEventListener = false;
 
 // Add bulk *EventListener commands on NodeLists from querySelectorAll and others  (set false to prevent funkiness).
-root.modifySelectors = true;
+root.modifySelectors = false;
 
 // Event maintenance.
 root.add = function(target, type, listener, configure) {


### PR DESCRIPTION
Fix #1170.
