### PR TITLE
IText stealing focus from other inputs

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -4,9 +4,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * Initializes key handlers
    */
   initKeyHandlers: function() {
-    fabric.util.addListener(fabric.document, 'keydown', this.onKeyDown.bind(this));
-    fabric.util.addListener(fabric.document, 'keypress', this.onKeyPress.bind(this));
-    fabric.util.addListener(fabric.document, 'click', this.onClick.bind(this));
+    // moved all handlers to initHiddenTextarea
   },
 
   /**
@@ -19,6 +17,15 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea.style.cssText = 'position: absolute; top: 0; left: -9999px';
 
     fabric.document.body.appendChild(this.hiddenTextarea);
+      
+        
+    fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
+    fabric.util.addListener(this.hiddenTextarea, 'keypress', this.onKeyPress.bind(this));
+        
+    if (!this.returnToTextareaHandler) {
+      this.returnToTextareaHandler = true;
+      fabric.util.addListener(this.canvas.upperCanvasEl, 'click', this.onClick.bind(this));
+    }      
   },
 
   /**


### PR DESCRIPTION
When IText is in edit mode there is no way to enter value to other input (for example - input to change font-size). That's because click returns focus to hidden textarea. Also IText steals key events because it is listening for them at document level.

This patch binds key events to hidden textarea and limits click event for returning focus to canvas IText belongs to.
