### PR TITLE
Simplify `engines`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "uglify-js": "2.4.x"
   },
   "engines": {
-    "node": ">=0.4.0 && <1.0.0"
+    "node": ">=0.4.0"
   },
   "main": "./dist/fabric.js"
 }


### PR DESCRIPTION
<1.0.0 is not needed as there is not node v1.0.0+.
