### PR TITLE
Simplify `license` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,7 @@
   "bugs": {
     "url": "https://github.com/kangax/fabric.js/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/kangax/fabric.js/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "build": "node build.js modules=ALL exclude=json,cufon,gestures",
     "test": "node test.js && jshint src"


### PR DESCRIPTION
npm allows specifying MIT license just by its name. Look at http://spdx.org/licenses/.

We don't need `licenses` array because there is just one license.
