### PR TITLE
Initialize variable with the correct name that is actually used

### DIFF
--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -10,7 +10,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     // for triple click
     this.__lastLastClickTime = +new Date();
 
-    this.lastPointer = { };
+    this.__lastPointer = { };
 
     this.on('mousedown', this.onMouseDown.bind(this));
   },


### PR DESCRIPTION
The initDoubleClickSimulation was initializing a variable called "lastPointer" but no such variable is ever used. The variable used is named "__lastPointer" and if it's not initialized, it's possible for fabric to blow up.
