### PR TITLE
Upgrade canvas to 1.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "node test.js && jshint src"
   },
   "dependencies": {
-    "canvas": "1.0.x",
+    "canvas": "1.1.x",
     "jsdom": "0.10.x",
     "xmldom": "0.1.x"
   },


### PR DESCRIPTION
The problem referenced in #887 seems to be fixed so we should be able to upgrade canvas to 1.1.x.
