### PR TITLE
Moves the resetting of _currentTransform.target inside `if (activeGroup)`-block

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -895,11 +895,12 @@
         activeGroup.forEachObject(function(o) {
           o.set('active', true);
         });
+
+        if (this._currentTransform) {
+          this._currentTransform.target = this.getActiveGroup();
+        }
       }
 
-      if (this._currentTransform) {
-        this._currentTransform.target = this.getActiveGroup();
-      }
 
       return data;
     },


### PR DESCRIPTION
This solves a problem that occurred if you were transforming (moving, scaling, rotating) a single object
when toJSON()/toObject() was run.

To reproduce the bug, see this fiddle: http://jsfiddle.net/vdb76/1/

Related commit: eb75f4b491c97577d419ab0ee9ca382b37434d29

Related issues:
#1159 (resolved by the commit above)
#896 (possibly fixed)
