### PR TITLE
Improvment for bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,13 @@
   ],
   "description": "Object model for HTML5 canvas, and SVG-to-canvas parser. Backed by jsdom and node-canvas.",
   "main": "./dist/fabric.min.js",
+  "ignore": [
+    "lib",
+    "src",
+    "test",
+    "*.*",
+    ".*"
+  ],
   "keywords": [
     "canvas",
     "graphic",


### PR DESCRIPTION
Add `ignore` section in the `bower.json` file to prevent full repository downloading with `bower install fabric`
