### PR TITLE
Transform matrix and isInPathGroup fix for images

### DIFF
--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -128,13 +128,16 @@
 
       // this._resetWidthHeight();
       if (isInPathGroup) {
-        ctx.translate(-this.group.width/2 + this.width/2, -this.group.height/2 + this.height/2);
+        ctx.translate(-this.group.width/2, -this.group.height/2);
       }
       if (m) {
         ctx.transform(m[0], m[1], m[2], m[3], m[4], m[5]);
       }
       if (!noTransform) {
         this.transform(ctx);
+      }
+      if (isInPathGroup) {
+        ctx.translate(this.width/2, this.height/2);
       }
 
       ctx.save();


### PR DESCRIPTION
This code fixes image position for tags with transform="matrix(-2.3668 0 0 2.3925 244.17 27.1837)"> attribute.
