### PR TITLE
Constrain rounded rect radii to half the width & height.

### DIFF
--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -108,8 +108,8 @@
         return;
       }
 
-      var rx = Math.min(this.rx || 0, this.width / 2),
-          ry = Math.min(this.ry || 0, this.height / 2),
+      var rx = this.rx ? Math.min(this.rx, this.width / 2) : 0,
+          ry = this.ry ? Math.min(this.ry, this.height / 2) : 0,
           w = this.width,
           h = this.height,
           x = -w / 2,


### PR DESCRIPTION
This fixes round rects being rendered like this when they have excessively large radii:
![extreme-radius](https://cloud.githubusercontent.com/assets/887005/2904561/bfbdd2a2-d5fc-11e3-9d29-3dac40faebb3.png)

Per http://www.w3.org/TR/SVG11/shapes.html#RectElement:

```
6. If rx is greater than half of ‘width’, then set rx to half of ‘width’.
7. If ry is greater than half of ‘height’, then set ry to half of ‘height’.
```
