### PR TITLE
Added imageSmoothingEnabled option on fabric.StaticCanvas

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -127,6 +127,13 @@
     allowTouchScrolling: false,
 
     /**
+     * Indicates whether this canvas will use image smoothing, this is on by default in browsers
+     * @type Boolean
+     * @default
+     */
+    imageSmoothingEnabled: true,
+
+    /**
      * Callback; invoked right before object is about to be scaled/rotated
      * @param {fabric.Object} target Object that's about to be scaled/rotated
      */
@@ -144,6 +151,7 @@
 
       this._createLowerCanvas(el);
       this._initOptions(options);
+      this._setImageSmoothing();
 
       if (options.overlayImage) {
         this.setOverlayImage(options.overlayImage, this.renderAll.bind(this));
@@ -301,6 +309,22 @@
      */
     setBackgroundColor: function(backgroundColor, callback) {
       return this.__setBgOverlayColor('backgroundColor', backgroundColor, callback);
+    },
+
+    /**
+     * @private
+     * @see {@link http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#dom-context-2d-imagesmoothingenabled|WhatWG Canvas Standard}
+     */
+    _setImageSmoothing: function(){
+      var ctx = this.getContext();
+
+      ctx.imageSmoothingEnabled       = this.imageSmoothingEnabled;
+      ctx.webkitImageSmoothingEnabled = this.imageSmoothingEnabled;
+      ctx.mozImageSmoothingEnabled    = this.imageSmoothingEnabled;
+      ctx.msImageSmoothingEnabled     = this.imageSmoothingEnabled;
+      ctx.oImageSmoothingEnabled      = this.imageSmoothingEnabled;
+
+      return this;
     },
 
     /**


### PR DESCRIPTION
I would like to be able to set the `imageSmoothingEnabled` property on a canvas when I'm instantiating that canvas with Fabric and have Fabric take care of the various vendor prefixes for me. Image smoothing is often undesirable when rendering images with a 'pixel art' aesthetic.

I've created a fiddle that highlights my motivation for having this option: http://jsfiddle.net/LeJmQ/4/

As you can see the image on the right is much sharper in Chrome, FF and IE >= 11.
