### PR TITLE
bower.json: missed files fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,12 @@
     "lib",
     "src",
     "test",
-    ".*"
+    "build_all",
+    "build.js",
+    "build.sh",
+    "create_build_script.js",
+    "test.js",
+    "HEADER.js"
   ],
   "keywords": [
     "canvas",


### PR DESCRIPTION
Last time i missed one case: _._ means "ALL(i thought it's *_/_.*, as usual) files with extension" in bower.
