### PR TITLE
Fix slow clicks (> 100 ms) focusing previously-deselected IText.

### DIFF
--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -33,6 +33,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.__lastClickTime = this.__newClickTime;
     this.__lastPointer = newPointer;
     this.__lastIsEditing = this.isEditing;
+    this.__lastSelected = this.selected;
   },
 
   isDoubleClick: function(newPointer) {
@@ -144,7 +145,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       this.__isMousedown = false;
       if (this._isObjectMoved(options.e)) return;
 
-      if (this.selected) {
+      if (this.__lastSelected) {
         this.enterEditing();
         this.initDelayedCursor(true);
       }


### PR DESCRIPTION
There's a `setTimeout` in itext_behavior's `selected` handler, which I think is meant to keep a clicked IText from entering editing in `mouseup` unless it was already selected before the click. However, some people click slowly (keep the mouse down for over 100 ms), and the text still enters editing in that case, even if they only meant to select the text box.
