### PR TITLE
Make closepath commands update current x/y coordinates.

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -158,6 +158,8 @@
     _render: function(ctx) {
       var current, // current instruction
           previous = null,
+          subpathStartX = 0,
+          subpathStartY = 0,
           x = 0, // current x
           y = 0, // current y
           controlX = 0, // current control point x
@@ -210,12 +212,16 @@
           case 'm': // moveTo, relative
             x += current[1];
             y += current[2];
+            subpathStartX = x;
+            subpathStartY = y;
             ctx.moveTo(x + l, y + t);
             break;
 
           case 'M': // moveTo, absolute
             x = current[1];
             y = current[2];
+            subpathStartX = x;
+            subpathStartY = y;
             ctx.moveTo(x + l, y + t);
             break;
 
@@ -427,6 +433,8 @@
 
           case 'z':
           case 'Z':
+            x = subpathStartX;
+            y = subpathStartY;
             ctx.closePath();
             break;
         }


### PR DESCRIPTION
Fixes the following:

``` xml
<?xml version="1.0"?>
<svg width="400" height="400" viewBox="0 0 400 400"
     xmlns="http://www.w3.org/2000/svg">
  <path d="m 200,200 100,0 0,100 z l 0,100 -100,0 z m 0,0 -100,0 0,-100 z l 0,-100 100,0 z"
        fill="#cccccc" />
</svg>
```

Which renders incorrectly as
![relative-subpaths](https://cloud.githubusercontent.com/assets/887005/3204634/d800d0d2-edab-11e3-8cf8-47293c61a551.png)

But is supposed to render like
![screen shot 2014-06-06 at 2 00 48 pm](https://cloud.githubusercontent.com/assets/887005/3204713/f536366e-edac-11e3-9fb6-9ce8eac84b47.png)
