### PR TITLE
allow browserify to run over fabric.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "HTML5",
     "object model"
   ],
+  "browser" : {
+    "canvas" : false,
+    "jsdom":   false,
+    "xmldom":  false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/kangax/fabric.js"


### PR DESCRIPTION
These changes provide a shim to avoid trying to pull in `jsdom`, `node-canvas`, and `xmldom` when attempting to run fabric through browserify.  Since there is a check for `isLikelyNode` before performing operations that are specific to the platform these changes should work just like if you loaded fabric.js in the browser directly.

closes #1368 

EDIT: I was using an old browserify which didn't support the false property.  I've force pushed here to cleanup the pull, sorry for any confusion!
