### PR TITLE
Fire 'selection:changed' on IText object.

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -156,6 +156,7 @@
     selectAll: function() {
       this.selectionStart = 0;
       this.selectionEnd = this.text.length;
+      this.fire('selection:changed');
       this.canvas && this.canvas.fire('text:selection:changed', { target: this });
     },
 

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -9,6 +9,7 @@
     * @mixes fabric.Observable
     *
     * @fires changed ("text:changed" when observing canvas)
+    * @fires selection:changed ("text:selection:changed" when observing canvas)
     * @fires editing:entered ("text:editing:entered" when observing canvas)
     * @fires editing:exited ("text:editing:exited" when observing canvas)
     *
@@ -219,6 +220,7 @@
      */
     setSelectionStart: function(index) {
       if (this.selectionStart !== index) {
+        this.fire('selection:changed');
         this.canvas && this.canvas.fire('text:selection:changed', { target: this });
       }
       this.selectionStart = index;
@@ -231,6 +233,7 @@
      */
     setSelectionEnd: function(index) {
       if (this.selectionEnd !== index) {
+        this.fire('selection:changed');
         this.canvas && this.canvas.fire('text:selection:changed', { target: this });
       }
       this.selectionEnd = index;


### PR DESCRIPTION
Previously the 'text:selection:changed' was only fired on the canvas, but not on the object.
