### PR TITLE
Fix ordering of the pieces

### DIFF
--- a/src/elements_parser.js
+++ b/src/elements_parser.js
@@ -44,7 +44,7 @@ fabric.ElementsParser.prototype._createObject = function(klass, el, index) {
   else {
     var obj = klass.fromElement(el, this.options);
     this.reviver && this.reviver(el, obj);
-    this.instances.splice(index, 1, obj);
+    this.instances[index] = obj;
     this.checkIfDone();
   }
 };
@@ -53,7 +53,7 @@ fabric.ElementsParser.prototype.createCallback = function(index, el) {
   var _this = this;
   return function(obj) {
     _this.reviver && _this.reviver(el, obj);
-    _this.instances.splice(index, 1, obj);
+    _this.instances[index] = obj;
     _this.checkIfDone();
   };
 };


### PR DESCRIPTION
I see that in pathgroup there is sort of ordering of the render, loading elements sync or async but putting in array with the index variable in the right place. This should allow proper rendering, but it looks like it doesn't work good.
it was just array.slice prolem , was slicing 0 elements instead of 1 element.

( after some other tests i removed slice completely and i added simple assignment of variable )

Visual effect of this PR:
( ok don't pay attention to the nose of the bear please, is some side effect of nested transform on line position that i still didn't manage to fix )
![image](https://cloud.githubusercontent.com/assets/1194048/3622541/b606c430-0e37-11e4-86f3-13f38a86493c.png)

current fabricjs
![image](https://cloud.githubusercontent.com/assets/1194048/3622586/dc4dee06-0e38-11e4-9fd8-1a0218f5d954.png)

![image](https://cloud.githubusercontent.com/assets/1194048/3622593/0262d340-0e39-11e4-9f4d-94ca80d4959a.png)
