### PR TITLE
Update parser.js

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -649,7 +649,7 @@
           parentAttributes = { };
 
       // if there's a parent container (`g` node), parse its attributes recursively upwards
-      if (element.parentNode && /^g$/i.test(element.parentNode.nodeName)) {
+      if (element.parentNode && /^[g|a]$/i.test(element.parentNode.nodeName)) {
         parentAttributes = fabric.parseAttributes(element.parentNode, attributes);
       }
 


### PR DESCRIPTION
I should not multiply the translating values.
Fixes mathformla that was still outside the screen
Nothing else was wrong because scaling effect is very uncommon in svg assets.
