### PR TITLE
Rotation point not flipped with control

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -315,15 +315,11 @@
 
       if (this.hasRotatingPoint && this.isControlVisible('mtr') && !this.get('lockRotation') && this.hasControls) {
 
-        var rotateHeight = (
-          this.flipY
-            ? height + (padding * 2)
-            : -height - (padding * 2)
-        ) / 2;
+        var rotateHeight = ( -height - (padding * 2)) / 2;
 
         ctx.beginPath();
         ctx.moveTo(0, rotateHeight);
-        ctx.lineTo(0, rotateHeight + (this.flipY ? this.rotatingPointOffset : -this.rotatingPointOffset));
+        ctx.lineTo(0, rotateHeight - this.rotatingPointOffset);
         ctx.closePath();
         ctx.stroke();
       }
@@ -434,9 +430,7 @@
       if (this.hasRotatingPoint) {
         this._drawControl('mtr', ctx, methodName,
           left + width/2 - scaleOffset,
-          this.flipY
-            ? (top + height + this.rotatingPointOffset - this.cornerSize/2 + padding)
-            : (top - this.rotatingPointOffset - this.cornerSize/2 - padding));
+          top - this.rotatingPointOffset - this.cornerSize/2 - padding);
       }
 
       ctx.restore();


### PR DESCRIPTION
As referenced by @kienz in #170 the rotation control get flipped but not the rotation point.
Proposed solution is to not rotate the control.
It works, just evaluate if it is what you prefer. ( between fixing the point and fixing the control )

Normal
![image](https://cloud.githubusercontent.com/assets/1194048/3707651/b7590acc-1437-11e4-8bcb-e4c8e60aa649.png)
Flipped content but not the controls.
![image](https://cloud.githubusercontent.com/assets/1194048/3707659/e50e0d64-1437-11e4-954a-62e2061805da.png)
