### PR TITLE
Update itext_key_behavior.mixin.js

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -57,7 +57,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       return;
     }
 
-    if (e.keyCode in this._keysMap) {
+    if (e.keyCode in this._keysMap && e.charCode === 0) {
       this[this._keysMap[e.keyCode]](e);
     }
     else if ((e.keyCode in this._ctrlKeysMap) && (e.ctrlKey || e.metaKey)) {
@@ -149,7 +149,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * @param {Event} e Event object
    */
   onKeyPress: function(e) {
-    if (!this.isEditing || e.metaKey || e.ctrlKey || e.keyCode in this._keysMap) {
+    if (!this.isEditing || e.metaKey || e.ctrlKey || ( e.keyCode in this._keysMap && e.charCode === 0 )) {
       return;
     }
 


### PR DESCRIPTION
Some characters don't work on Mac OS X such as dot ".", opened parenthesis "(" and others. The key events return key codes witch are in _keysmap variable and so those characters are not rendered. Ex : '.' event key code return 46.
