### PR TITLE
Fix insertion of some characters in iText

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -149,7 +149,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * @param {Event} e Event object
    */
   onKeyPress: function(e) {
-    if (!this.isEditing || e.metaKey || e.ctrlKey || e.keyCode in this._keysMap) {
+    if (!this.isEditing || e.metaKey || e.ctrlKey) {
       return;
     }
 


### PR DESCRIPTION
When typing periods, commas, opening parentheses, ampersands, percents and quite possibly other characters in iText, they are not inserted. Bug happening on OS X and Windows.

It's the same bug as #1573 but another solution since event.charCode used in that pull-request is deprecated (https://developer.mozilla.org/en-US/docs/Web/API/event.charCode).

The fix here is the removal of the `e.keyCode in this._keysMap` check from the keypress callback. There seems to be no side-effect.
