### PR TITLE
Update arc.js

### DIFF
--- a/src/util/arc.js
+++ b/src/util/arc.js
@@ -22,7 +22,7 @@
     var px = -cosTh * toX - sinTh * toY,
         py = -cosTh * toY + sinTh * toX,
         rx2 = rx * rx, ry2 = ry * ry, py2 = py * py, px2 = px * px,
-        pl = rx2 * ry2 * 0.25 - rx2 * py2 - ry2 * px2,
+        pl = 4 * rx2 * ry2 - rx2 * py2 - ry2 * px2,
         root = 0.0;
 
     if (pl < 0.0) {
@@ -30,7 +30,7 @@
       rx *= s;
       ry *= s;
     } else {
-      root = (large === sweep ? -0.125 : 0.125) *
+      root = (large === sweep ? -0.5 : 0.5) *
               Math.sqrt( pl /(rx2 * py2 + ry2 * px2));
     }
 


### PR DESCRIPTION
Corrected arcs drawing and extended caching logic to have a chache hit more often.
Function is more or less 20 lines of code shorter, but i really cannot figure out if this implementation has more calculation
than the previous. I couldn't manage to find the error in the old one, i had to overwrite it.

in the picture , the multi colored arcs, are all on cache it after calculating the red one.
It will happen rarely, but why miss it?

![image](https://cloud.githubusercontent.com/assets/1194048/3872383/112e58b6-2119-11e4-839a-9e8e21507495.png)

fixes issue #1586
