### PR TITLE
Accept all printable characters

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -67,7 +67,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       return;
     }
 
-    e.stopPropagation();
+    e.stopImmediatePropagation();
+    e.preventDefault();
 
     this.canvas && this.canvas.renderAll();
   },
@@ -149,7 +150,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * @param {Event} e Event object
    */
   onKeyPress: function(e) {
-    if (!this.isEditing || e.metaKey || e.ctrlKey || e.keyCode in this._keysMap) {
+    if (!this.isEditing || e.metaKey || e.ctrlKey) {
       return;
     }
 


### PR DESCRIPTION
When typing periods, commas, opening parentheses, ampersands, percents and quite possibly other characters in iText, they are not inserted. Bug happening on OS X and Windows. See #1583, #1573.

This fix (inspired by Adobe Brackets code) should allow all printable characters while preventing arrow keys from rendering on Firefox. It doesn't fix the issue with function keys, home, end, etc. though.
