### PR TITLE
Update polygon.class.js

### DIFF
--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -62,8 +62,8 @@
       this.width = (maxX - minX) || 1;
       this.height = (maxY - minY) || 1;
 
-      this.left = this.width / 2 + minX,
-      this.top = this.height / 2 + minY;
+      this.left = minX,
+      this.top = minY;
     },
 
     /**
@@ -71,11 +71,13 @@
      */
     _applyPointOffset: function() {
       // change points to offset polygon into a bounding box
+      // executed one time
+      this.left += this.width / 2;
+      this.top += this.height / 2;
       this.points.forEach(function(p) {
         p.x -= this.left;
         p.y -= this.top;
       }, this);
-      console.debug('done');
     },
 
     /**


### PR DESCRIPTION
Example PULL REQUEST for polygon FIX idea.

If you check now, whatever the polygon points are, the polygon get translated near origin.
This is because points get offsetted.
And that is good.
This PR has 2 meaning:
1) correcting offsetting by applying top and left that was missing.
2) killing useless this.minX and this.minY
3) calling the Offsetting JUST if we are not in pathgroup and NOT skipping offsetting if we come from "fromElement".

This is an idea, check the code, don't care about spaces, errors in tests ( there will be plenty ).
Just to give support of discussion of the issue #1607

Basically works good, other work must be done to polylines and tests of course.
Let me know what you think.

It fixes position of polygon on creation, and it is a step forward into importing SVG ungrouped ( to whom it may interest ).
