### PR TITLE
Allow fabric to attach to canvas inside child iframe

### DIFF
--- a/src/util/dom_misc.js
+++ b/src/util/dom_misc.js
@@ -191,7 +191,8 @@
   var getElementStyle;
   if (fabric.document.defaultView && fabric.document.defaultView.getComputedStyle) {
     getElementStyle = function(element, attr) {
-      return fabric.document.defaultView.getComputedStyle(element, null)[attr];
+      var style = fabric.document.defaultView.getComputedStyle(element, null) || {};
+      return style[attr];
     };
   }
   else {


### PR DESCRIPTION
When attempting to attach fabric to a canvas to an element inside a child iframe it fails due to 'position' not being a property of null because the iframe document does not have any computed styles.
