### PR TITLE
Fix text selection and cursor position when text is justified

### DIFF
--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -1050,13 +1050,13 @@
      * @param {Number} lineIndex
      */
     _getWidthOfSpace: function (ctx, lineIndex) {
-      var lines = this.text.split(this._reNewline);
-      var line = lines[lineIndex];
-      var words = line.split(/\s+/);
-      var wordsWidth = this._getWidthOfWords(ctx, line, lineIndex);
-      var widthDiff = this.width - wordsWidth;
-      var numSpaces = words.length - 1;
-      var width = widthDiff / numSpaces;
+      var lines = this.text.split(this._reNewline),
+          line = lines[lineIndex],
+          words = line.split(/\s+/),
+          wordsWidth = this._getWidthOfWords(ctx, line, lineIndex),
+          widthDiff = this.width - wordsWidth,
+          numSpaces = words.length - 1,
+          width = widthDiff / numSpaces;
 
       return width;
     },
@@ -1076,7 +1076,7 @@
         if (!_char.match(/\s/)) {
           width += this._getWidthOfChar(ctx, _char, lineIndex, charIndex);
         }
-      };
+      }
 
       return width;
     },


### PR DESCRIPTION
Text selection and cursor position are not correct when text is justified.
See: https://monosnap.com/file/q1zlqOQN0WLpCG416HYfKDtO4GtOdo.

The bug is due to the whitespace width not being taken into account when rendering the cursor and selection.
This pull request fixes it.
