### PR TITLE
Update itext_key_behavior.mixin.js

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -292,7 +292,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     var swapSel = this.selectionEnd;
     this.selectionEnd = this.selectionStart;
     this.selectionStart = swapSel;
-  }
+  },
 
   /**
    * Moves cursor down while keeping selection


### PR DESCRIPTION
Added behaviour for keys pagUP ,pagDOWN , HOME, END, TAB and ESC. ( mimic meta key, that on windows i don't know where it is )
Removed rendering of squares in firefox.
