### PR TITLE
prevent loading the the `fs` module in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "browser" : {
     "canvas" : false,
+    "fs":      false,
     "jsdom":   false,
     "xmldom":  false
   },


### PR DESCRIPTION
while browserify uses an empty module for `fs` by default, webpack does
not and will refuse to bundle fabric (previous versions of webpack did
bundle it, but that was considered a bug in webpack which was recently
fixed (webpack/webpack#411).
