### PR TITLE
Update parser.js

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -509,7 +509,7 @@
 
       parseUseDirectives(doc);
       /* http://www.w3.org/TR/SVG/struct.html#SVGElementWidthAttribute
-      *  as per specs, width and height attributes are to be considered
+      *  as per spec, width and height attributes are to be considered
       *  100% if no value is specified.
       */
       var viewBoxAttr = doc.getAttribute('viewBox'),


### PR DESCRIPTION
Better than getting 0px width and height.
Specs say that when they are missing we should consider 100%, in our case 100% will be 100px because we don't have anything to compare the SVG to before adding the SVG into a canvas.
Otherwise we could take canvas widht and height.
