### PR TITLE
Allow to opt out from the viewport transformation of the SVG output.

### DIFF
--- a/src/mixins/object.svg_export.js
+++ b/src/mixins/object.svg_export.js
@@ -48,7 +48,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) return '';
     var toFixed = fabric.util.toFixed,
         angle = this.getAngle(),
-        vpt = this.getViewportTransform(),
+        vpt = !this.canvas || this.canvas.svgViewportTransformation ? this.getViewportTransform() : [1, 0, 0, 1, 0, 0],
         center = fabric.util.transformPoint(this.getCenterPoint(), vpt),
 
         NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1116,6 +1116,14 @@
 
     /* _TO_SVG_START_ */
     /**
+     * When true, getSvgTransform() will apply the StaticCanvas.viewportTransform to the SVG transformation. When true,
+     * a zoomed canvas will then produce zoomed SVG output.
+     * @type Boolean
+     * @default
+     */
+    svgViewportTransformation: true,
+
+    /**
      * Returns SVG representation of canvas
      * @function
      * @param {Object} [options] Options object for SVG output
@@ -1188,13 +1196,28 @@
      * @private
      */
     _setSVGHeader: function(markup, options) {
+      var width, height, vpt;
+
+      if (options.viewBox) {
+        width = options.viewBox.width;
+        height = options.viewBox.height;
+      } else {
+        width = this.width;
+        height = this.height;
+        if (!this.svgViewportTransformation) {
+          vpt = this.viewportTransform;
+          width /= vpt[0];
+          height /= vpt[3];
+        }
+      }
+
       markup.push(
         '<svg ',
           'xmlns="http://www.w3.org/2000/svg" ',
           'xmlns:xlink="http://www.w3.org/1999/xlink" ',
           'version="1.1" ',
-          'width="', (options.viewBox ? options.viewBox.width : this.width), '" ',
-          'height="', (options.viewBox ? options.viewBox.height : this.height), '" ',
+          'width="', width, '" ',
+          'height="', height, '" ',
           (this.backgroundColor && !this.backgroundColor.toLive
             ? 'style="background-color: ' + this.backgroundColor + '" '
             : null),


### PR DESCRIPTION
With this change the user can decide wheter he wants the viewport transformation to affect the SVG output or not. 

By default the viewport transformation affects the SVG output. This is how Fabric behaved until now.
