### PR TITLE
Update path.class.js

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -543,7 +543,7 @@
         chunks.push(this.path[i].join(' '));
       }
       var path = chunks.join(' ');
-      if (!(this.group && this.group.type == 'path-group')) {
+      if (!(this.group && this.group.type === 'path-group')) {
         addTransform = 'translate(' + (-this.width / 2) + ', ' + (-this.height / 2) + ')';
       }
       markup.push(


### PR DESCRIPTION
Like any other shape in fabric, when exported to svg, the shape has to be translated around origin.
This additional translation brings it there.

Fixes svg export of paths OUTSIDE of path-gropus. Inside was already ok.
