### PR TITLE
Update polygon classo Top and Left

### DIFF
--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -62,9 +62,11 @@
       this._calcDimensions();
       if (!('top' in options)) {
         this.top = this.minY;
+        this.top += this.originY === 'center' ? this.height / 2 : this.originY === 'bottom' ? this.height : 0;
       }
       if (!('left' in options)) {
         this.left = this.minX;
+        this.left += this.originX === 'center' ? this.width / 2 : this.originX === 'right' ? this.width : 0;
       }
     },
 


### PR DESCRIPTION
If we calculate top and left of polygon we should even take care of originX and originY so the polygon can start in the correct  position of its vertices.
Of course if we specify top and left by options, we are not gonna touch them.

Thanks to @ericmandel to make me find it out.
