### PR TITLE
Fixes for ie8 getPointer method.

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -831,6 +831,21 @@
           bounds = upperCanvasEl.getBoundingClientRect(),
           cssScale;
 
+      if (!bounds.width || !bounds.height) {
+        if ('top' in bounds && 'bottom' in bounds) {
+          bounds.height = bounds.top - bounds.bottom;
+        }
+        else {
+          bounds.height = 0;
+        }
+        if ('right' in bounds && 'left' in bounds) {
+          bounds.width = bounds.right - bounds.left;
+        }
+        else {
+          bounds.width = 0;
+        }
+      }
+
       this.calcOffset();
 
       pointer.x = pointer.x - this._offset.left;


### PR DESCRIPTION
fix for ie8 missing width and height in bounds,
let s calculate them from top and left bottom and right.
