### PR TITLE
Fix setCoords for negative width and/or height

### DIFF
--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -323,10 +323,10 @@
         h = strokeWidth;
       }
       if (strokeW) {
-        w += strokeWidth;
+        w += w > 0 ? strokeWidth : -strokeWidth;
       }
       if (strokeH) {
-        h += strokeWidth;
+        h += h > 0 ? strokeWidth : -strokeWidth;
       }
       this.currentWidth = w * this.scaleX;
       this.currentHeight = h * this.scaleY;


### PR DESCRIPTION
Hi,

I'm using fabric to let the user draw some Rect on screen with the mouse. 
The Rect has perPixelTargetFind enabled and no fill.

Everything is ok when he draws from top-left to bottom-right.

Although, when he draws from bottom-right to top-left, the selection area is drawed inside his borders, and this make selection very hard, since there's only a pixel (sometimes none) on each side that is inside selection area and is not transparent, making it selectable because of perPixelTargetFind.

I found that in setCoords, strokeWidth is checked for positive numbers only, and added to width and height, but if I have a negative width or height there, the selection area will decrease in abs.

This problem is related to https://github.com/kangax/fabric.js/issues/142
