### PR TITLE
getBoundingBox get position from getElementStyle

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -769,8 +769,9 @@ root.getBoundingBox = function(o) {
 	while (tmp !== null) {
 		if (tmp === document.body) break;
 		if (tmp.scrollTop === undefined) break;
-		var style = window.getComputedStyle(tmp);
-		var position = style.getPropertyValue("position");
+		//var style = window.getComputedStyle(tmp);
+    		//var position = style.getPropertyValue("position");
+    		var position = fabric.util.getElementStyle(tmp, "position");
 		if (position === "absolute") {
 			break;
 		} else if (position === "fixed") {


### PR DESCRIPTION
if using old window.getComputedStyle(tmp) IE8 gives an error
