### PR TITLE
Flippyng y by scaling x and viceversa

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -525,7 +525,7 @@
         forbidScalingY || lockScalingY || target.set('scaleY', transform.newScaleY);
       }
 
-      forbidScalingX || forbidScalingY || this._flipObject(transform);
+      forbidScalingX || forbidScalingY || this._flipObject(transform, by);
 
     },
 
@@ -550,8 +550,8 @@
     /**
      * @private
      */
-    _flipObject: function(transform) {
-      if (transform.newScaleX < 0) {
+    _flipObject: function(transform, by) {
+      if (transform.newScaleX < 0 && by !== 'y') {
         if (transform.originX === 'left') {
           transform.originX = 'right';
         }
@@ -560,7 +560,7 @@
         }
       }
 
-      if (transform.newScaleY < 0) {
+      if (transform.newScaleY < 0 && by !== 'x') {
         if (transform.originY === 'top') {
           transform.originY = 'bottom';
         }


### PR DESCRIPTION
When we resize an object by X or by Y we do not scale by the other dimension.
But if we go in direction of flipping it, we may flip it even on the dimension we are not resizing.

It looks a weird behaviour because you see the object suddendly translate, not event flip, with no intermediate state.

You can check on kitchensink.
