### PR TITLE
Fix opacity for groups ( part 2 )

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -64,7 +64,6 @@
       if (options) {
         extend(this, options);
       }
-      this._setOpacityIfSame();
 
       this.setCoords();
       this.saveCoords();
@@ -415,21 +414,6 @@
         object.setCoords();
       });
       return this;
-    },
-
-    /**
-     * @private
-     */
-    _setOpacityIfSame: function() {
-      var objects = this.getObjects(),
-          firstValue = objects[0] ? objects[0].get('opacity') : 1,
-          isSameOpacity = objects.every(function(o) {
-            return o.get('opacity') === firstValue;
-          });
-
-      if (isSameOpacity) {
-        this.opacity = firstValue;
-      }
     },
 
     /**


### PR DESCRIPTION
Now that object inside group calculate opacity recursively up ( looking for groups and groups of groups ), we should not change group opacity looking at items contained.
