### PR TITLE
Update parser.js

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -142,11 +142,11 @@
     }
 
     function skewXMatrix(matrix, args) {
-      matrix[2] = args[0];
+      matrix[2] = Math.tan(fabric.util.degreesToRadians(args[0]));
     }
 
     function skewYMatrix(matrix, args) {
-      matrix[1] = args[0];
+      matrix[1] = Math.tan(fabric.util.degreesToRadians(args[0]));
     }
 
     function translateMatrix(matrix, args) {


### PR DESCRIPTION
With or without skew support, this is the correct way of parsing skew matrix.
transform = skew(x) , where is x is an angle, but in the transform matrix we have to put the tan(x) with x in radians.
