### PR TITLE
Fix for stroke shadow covering fills.

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -572,6 +572,9 @@
           i
         );
       }
+      if (this.shadow && !this.shadow.affectStroke) {
+        this._removeShadow(ctx);
+      }
     },
 
     /**


### PR DESCRIPTION
Added fix for stroke shadow as in object class in normal renderFill method.
Fix for issue #1647
