### PR TITLE
Support Shadow scaling for CanvasZoom and ScaleFactor

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -649,7 +649,7 @@
         angle = 360 + angle;
       }
 
-      t.target.angle = angle;
+      t.target.angle = angle % 360;
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1061,10 +1061,12 @@
         return;
       }
 
+      var mult = this.canvas._currentMultiplier || 1;
+
       ctx.shadowColor = this.shadow.color;
-      ctx.shadowBlur = this.shadow.blur;
-      ctx.shadowOffsetX = this.shadow.offsetX;
-      ctx.shadowOffsetY = this.shadow.offsetY;
+      ctx.shadowBlur = this.shadow.blur * mult * (this.scaleX + this.scaleY) / 2;
+      ctx.shadowOffsetX = this.shadow.offsetX * mult * this.scaleX;
+      ctx.shadowOffsetY = this.shadow.offsetY * mult * this.scaleY;
     },
 
     /**


### PR DESCRIPTION
This should account both for scale factor and canvas zooming

current fabricjs behaving
![image](https://cloud.githubusercontent.com/assets/1194048/4742343/378745fc-5a1e-11e4-8b12-19452de1ee32.png)

with this pr everything zoomed
![image](https://cloud.githubusercontent.com/assets/1194048/4742296/dd1f689c-5a1d-11e4-9fac-1a5f1616b355.png)
