### PR TITLE
User defined "selectable area" for objects

### DIFF
--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -92,6 +92,16 @@
      * @return {Boolean} true if point is inside the object
      */
     containsPoint: function(point) {
+      //eventBounds is an option object that defines where selecting an object works
+      //if you have a mask covering part of an object, it forces clicks to be on the object
+      //in order to interact witht the object.
+      var coords = typeof this.eventBounds !== 'undefined' ? {
+        tl:  {x: this.eventBounds.x, y: this.eventBounds.y},
+        tr:  {x: this.eventBounds.x + this.eventBounds.width, y: this.eventBounds.y},
+        bl:  {x: this.eventBounds.x, y:this.eventBounds.y + this.eventBounds.height},
+        br:  {x: this.eventBounds.x + this.eventBounds.width, y:this.eventBounds.y + this.eventBounds.height}
+      }: this.oCoords;
+      
       var lines = this._getImageLines(this.oCoords),
           xPoints = this._findCrossPoints(point, lines);
 

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -96,13 +96,12 @@
       //if you have a mask covering part of an object, it forces clicks to be on the object
       //in order to interact witht the object.
       var coords = typeof this.eventBounds !== 'undefined' ? {
-        tl:  {x: this.eventBounds.x, y: this.eventBounds.y},
-        tr:  {x: this.eventBounds.x + this.eventBounds.width, y: this.eventBounds.y},
-        bl:  {x: this.eventBounds.x, y:this.eventBounds.y + this.eventBounds.height},
-        br:  {x: this.eventBounds.x + this.eventBounds.width, y:this.eventBounds.y + this.eventBounds.height}
-      }: this.oCoords;
-      
-      var lines = this._getImageLines(coords),
+        tl:  { x: this.eventBounds.x, y: this.eventBounds.y },
+        tr:  { x: this.eventBounds.x + this.eventBounds.width, y: this.eventBounds.y },
+        bl:  { x: this.eventBounds.x, y:this.eventBounds.y + this.eventBounds.height },
+        br:  { x: this.eventBounds.x + this.eventBounds.width, y:this.eventBounds.y + this.eventBounds.height }
+      } : this.oCoords,
+          lines = this._getImageLines(coords),
           xPoints = this._findCrossPoints(point, lines);
 
       // if xPoints is odd then point is inside the object

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -102,7 +102,7 @@
         br:  {x: this.eventBounds.x + this.eventBounds.width, y:this.eventBounds.y + this.eventBounds.height}
       }: this.oCoords;
       
-      var lines = this._getImageLines(this.oCoords),
+      var lines = this._getImageLines(coords),
           xPoints = this._findCrossPoints(point, lines);
 
       // if xPoints is odd then point is inside the object


### PR DESCRIPTION
This adds an optional {eventBounds} attribute to the fabric object that defines where selecting an object works.

IE: if you have a mask covering part of an object, it forces clicks to be on the object in order to interact with the object.

eventBounds = {x: val, y: val, width: val, height: val}
