### PR TITLE
Prefer placing hidden text area inside wrapper.

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -14,7 +14,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       // to avoid the scroll position jumping when editing text on a tall document.
       // This preference is also enacted when selecting text via clicks.
       this.canvas.wrapperEl.appendChild(this.hiddenTextarea);
-    } else {
+    }
+    else {
       fabric.document.body.appendChild(this.hiddenTextarea);
     }
 


### PR DESCRIPTION
Prefer putting the hidden text area within the canvas wrapper element,
to avoid the scroll position jumping when editing text on a tall document.
This preference is also enacted when selecting text via clicks.
