### PR TITLE
Fix text jump to top of page

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -7,8 +7,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea = fabric.document.createElement('textarea');
 
     this.hiddenTextarea.setAttribute('autocapitalize', 'off');
-    this.hiddenTextarea.style.cssText = 'position: absolute; top: 0; left: -9999px';
-
+    this.hiddenTextarea.style.cssText = 'position: fixed; bottom: 20px; left: 0px; opacity: 0;'
+                                        + ' width: 0px; height: 0px; z-index: -999;';
     fabric.document.body.appendChild(this.hiddenTextarea);
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));


### PR DESCRIPTION
Following replies in #1310 this fix is the best all in all fix for the jumping problem.

zoomcase firefox and chrome not jumping, internet explorer i didn't bother to test.
I intentionally scrolled left and down, to make it as general as possible and used high browser zoom.

![image](https://cloud.githubusercontent.com/assets/1194048/5180738/8b500fc6-748f-11e4-9b0c-2c77231d1189.png)

@slashgrin i opened parallel PR, sorry for not waiting your tests but i preferred to go on.
