### PR TITLE
Added clipBackground option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **Edge**
-
+- Add "clipBackground" a canvas option to render the background before the canvas clip context.
 - [BACK_INCOMPAT] `fabric.Collection#remove` doesn't return removed object -> returns `this` (chainable)
 
 - Add "mouse:over" and "mouse:out" canvas events (and corresponding "mouseover", "mouseout" object events)

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -141,6 +141,13 @@
     preserveObjectStacking: false,
 
     /**
+     * Indicates whether the backGroundImage get clipped or not by clip context.
+     * @type Boolean
+     * @default
+     */
+    clipBackground: true,
+
+    /**
      * The transformation (in the format of Canvas transform) which focuses the viewport
      * @type Array
      * @default
@@ -834,11 +841,15 @@
 
       this.fire('before:render');
 
+      if (!this.clipBackground) {
+        this._renderBackground(canvasToDrawOn);
+      }
       if (this.clipTo) {
         fabric.util.clipContext(this, canvasToDrawOn);
       }
-
-      this._renderBackground(canvasToDrawOn);
+      if (this.clipBackground) {
+        this._renderBackground(canvasToDrawOn);
+      }
       this._renderObjects(canvasToDrawOn, activeGroup);
       this._renderActiveGroup(canvasToDrawOn, activeGroup);
 


### PR DESCRIPTION
Add an option to render the background before the canvas clipcontext.

I needed this option for a little tool based on fabric, i would like to see if it can be considered interesting.
I know i can achieve the same effect probably with some CSS background, but in this way the effect is exportable with canvas.toObject.

The effect is shown in the screens and is simple as it gets:
![image](https://cloud.githubusercontent.com/assets/1194048/5274611/74f4ef90-7a97-11e4-970a-3f7c30463428.png)

Using clipping masks and keeping the background function
