### PR TITLE
fabric.Text.clone now also calls an optional callback method

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1158,6 +1158,7 @@
       if (this.constructor.fromObject) {
         return this.constructor.fromObject(this.toObject(propertiesToInclude), callback);
       }
+      callback && callback(new fabric.Object(this.toObject(propertiesToInclude)));
       return new fabric.Object(this.toObject(propertiesToInclude));
     },
 

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1136,10 +1136,13 @@
    * @static
    * @memberOf fabric.Text
    * @param {Object} object Object to create an instance from
+   * @param {Function} [callback] Callback to invoke when an fabric.Text instance is created
    * @return {fabric.Text} Instance of fabric.Text
    */
-  fabric.Text.fromObject = function(object) {
-    return new fabric.Text(object.text, clone(object));
+  fabric.Text.fromObject = function(object, callback) {
+    var newText = new fabric.Text(object.text, clone(object));
+    callback && callback(newText);
+    return newText;
   };
 
   fabric.util.createAccessors(fabric.Text);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -547,21 +547,27 @@ test('getBoundingRectWithStroke', function() {
     equal(cObj.drawControls(dummyContext), cObj, 'chainable');
   });
 
-  test('clone', function() {
+  asyncTest('clone', function() {
     var cObj = new fabric.Object({ left: 123, top: 456, opacity: 0.66 });
     ok(typeof cObj.clone == 'function');
-    var clone = cObj.clone();
 
-    equal(clone.get('left'), 123);
-    equal(clone.get('top'), 456);
-    equal(clone.get('opacity'), 0.66);
+    var returnedClone = cObj.clone(function(clone) {
+      setTimeout(function() {
+        equal(returnedClone.get('left'), clone.get('left'));
 
-    // augmenting clone properties should not affect original instance
-    clone.set('left', 12).set('scaleX', 2.5).setAngle(33);
+        equal(clone.get('left'), 123);
+        equal(clone.get('top'), 456);
+        equal(clone.get('opacity'), 0.66);
 
-    equal(cObj.get('left'), 123);
-    equal(cObj.get('scaleX'), 1);
-    equal(cObj.getAngle(), 0);
+        // augmenting clone properties should not affect original instance
+        clone.set('left', 12).set('scaleX', 2.5).setAngle(33);
+
+        equal(cObj.get('left'), 123);
+        equal(cObj.get('scaleX'), 1);
+        equal(cObj.getAngle(), 0);
+        start();
+      }, 0);
+    });
   });
 
   asyncTest('cloneAsImage', function() {
@@ -1113,11 +1119,11 @@ test('toDataURL & reference to canvas', function() {
     equal(object.shadow.blur, 10);
     equal(object.shadow.offsetX, 5);
     equal(object.shadow.offsetY, 15);
-    
+
     equal(object.setShadow(null), object, 'should be chainable');
     ok(!(object.shadow instanceof fabric.Shadow));
     equal(object.shadow, null);
-    
+
   });
 
   test('set shadow', function() {

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -219,12 +219,22 @@
     deepEqual(textWithAttrs.toObject(), expectedObject);
   });
 
+  asyncTest('fabric.Text.clone', function() {
+    var text = createTextObject();
+    var returnedClone = text.clone(function(clone) {
+      setTimeout(function() {
+        deepEqual(returnedClone, clone);
+        start();
+      }, 0);
+    });
+  });
+
   test('empty fromElement', function() {
     ok(fabric.Text.fromElement() === null);
   });
 
   test('dimensions after text change', function() {
-    var text = new fabric.Text('x');
+    var text = createTextObject();
     equal(text.width, CHAR_WIDTH);
 
     text.setText('xx');
@@ -232,7 +242,7 @@
   });
 
   test('setting fontFamily', function() {
-    var text = new fabric.Text('x');
+    var text = createTextObject();
     text.path = 'foobar.js';
 
     text.set('fontFamily', 'foobar');
@@ -243,7 +253,7 @@
   });
 
   test('toSVG', function() {
-    var text = new fabric.Text('x');
+    var text = createTextObject();
 
     // temp workaround for text objects not obtaining width under node
     text.width = CHAR_WIDTH;


### PR DESCRIPTION
Fixed issue described in #1629 and expanded on unit tests for the clone method. All fabric classes should now use a callback when cloning, but only some return a clone, since some classes' constructors are asynchronous.
