### PR TITLE
add flood fill color

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -62,6 +62,14 @@
     backgroundImage: null,
 
     /**
+     * Flood fill color within background image of canvas instance.
+     * Should be set via {@link fabric.StaticCanvas#setFloodFillColor}.
+     * @type {(String|fabric.Pattern)}
+     * @default
+     */
+    floodFillColor: '',
+
+    /**
      * Overlay color of canvas instance.
      * Should be set via {@link fabric.StaticCanvas#setOverlayColor}
      * @since 1.3.9
@@ -184,6 +192,9 @@
       }
       if (options.backgroundColor) {
         this.setBackgroundColor(options.backgroundColor, this.renderAll.bind(this));
+      }
+      if (options.floodFillColor) {
+        this.setFloodFillColor(options.floodFillColor, this.renderAll.bind(this));
       }
       if (options.overlayColor) {
         this.setOverlayColor(options.overlayColor, this.renderAll.bind(this));
@@ -366,6 +377,30 @@
      */
     setBackgroundColor: function(backgroundColor, callback) {
       return this.__setBgOverlayColor('backgroundColor', backgroundColor, callback);
+    },
+
+    /**
+     * Sets {@link fabric.StaticCanvas#floodFillColor|flood fill color} for this canvas and overlap with background image
+     * @param {(String|fabric.Pattern)} floodFillColor Color or pattern to set flood fill color to
+     * @param {Function} callback Callback to invoke when flood fill color is set
+     * @return {fabric.Canvas} thisArg
+     * @chainable
+     * @example <caption>Normal floodFillColor - color value</caption>
+     * canvas.setFloodFillColor('rgba(255, 73, 64, 0.6)', canvas.renderAll.bind(canvas));
+     * @example <caption>fabric.Pattern used as floodFillColor</caption>
+     * canvas.setFloodFillColor({
+     *   source: 'http://fabricjs.com/assets/escheresque_ste.png'
+     * }, canvas.renderAll.bind(canvas));
+     * @example <caption>fabric.Pattern used as floodFillColor with repeat and offset</caption>
+     * canvas.setFloodFillColor({
+     *   source: 'http://fabricjs.com/assets/escheresque_ste.png',
+     *   repeat: 'repeat',
+     *   offsetX: 200,
+     *   offsetY: 100
+     * }, canvas.renderAll.bind(canvas));
+     */
+    setFloodFillColor: function(floodFillColor, callback) {
+      return this.__setBgOverlayColor('floodFillColor', floodFillColor, callback);
     },
 
     /**
@@ -941,7 +976,28 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _renderBackground: function(ctx) {
+      if (this.backgroundImage) {
+        this._draw(ctx, this.backgroundImage);
+      }
+      if (this.floodFillColor) {
+        ctx.save();
+        //draw flood fill overlap with background image
+        ctx.globalCompositeOperation = 'source-atop';
+        ctx.fillStyle = this.floodFillColor.toLive
+          ? this.floodFillColor.toLive(ctx)
+          : this.floodFillColor;
+
+        ctx.fillRect(
+          this.floodFillColor.offsetX || 0,
+          this.floodFillColor.offsetY || 0,
+          this.width,
+          this.height);
+        ctx.restore();
+      }
       if (this.backgroundColor) {
+        ctx.save();
+        //draw background color behind background image
+        ctx.globalCompositeOperation = 'destination-over';
         ctx.fillStyle = this.backgroundColor.toLive
           ? this.backgroundColor.toLive(ctx)
           : this.backgroundColor;
@@ -951,9 +1007,7 @@
           this.backgroundColor.offsetY || 0,
           this.width,
           this.height);
-      }
-      if (this.backgroundImage) {
-        this._draw(ctx, this.backgroundImage);
+        ctx.restore();
       }
     },
 


### PR DESCRIPTION
The flood fill color draws 'background' color or pattern only overlaps with background image instead of the whole canvas like backgroundColor does.
Its very useful when you want to change the color or pattern of the real design area, like a T-shirt background image with transparent background in a canvas.
