### PR TITLE
Added object property to disable object from group selections.

### DIFF
--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -77,19 +77,25 @@
      * @private
      */
     _createActiveGroup: function(target, e) {
+      if (!this._activeObject) {
+        // Group cannot be created if no existing active object is present.
+        return;
+      }
 
-      if (this._activeObject && target !== this._activeObject) {
+      var groupSelectable = (this._activeObject.groupSelectable && target.groupSelectable),
+          isNewSelectionObject = (target !== this._activeObject),
+          group;
 
-        var group = this._createGroup(target);
+      if (isNewSelectionObject && groupSelectable) {
+        group = this._createGroup(target);
         group.addWithUpdate();
 
         this.setActiveGroup(group);
         this._activeObject = null;
 
         this.fire('selection:created', { target: group, e: e });
+        target.set('active', true);
       }
-
-      target.set('active', true);
     },
 
     /**
@@ -150,7 +156,7 @@
       for (var i = this._objects.length; i--; ) {
         currentObject = this._objects[i];
 
-        if (!currentObject || !currentObject.selectable || !currentObject.visible) {
+        if (!currentObject || !currentObject.selectable || !currentObject.groupSelectable || !currentObject.visible) {
           continue;
         }
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -573,6 +573,14 @@
     selectable:               true,
 
     /**
+     * When set to `false`, an object can not be selected for modification using group-based selection.
+     * But events still fire on it.
+     * @type Boolean
+     * @default
+     */
+    groupSelectable:          true,
+
+    /**
      * When set to `false`, an object can not be a target of events. All events propagate through it. Introduced in v1.3.4
      * @type Boolean
      * @default

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -574,7 +574,6 @@
 
     /**
      * When set to `false`, an object can not be selected for modification using group-based selection.
-     * But events still fire on it.
      * @type Boolean
      * @default
      */


### PR DESCRIPTION
Enhanced how group selections are made. Before an object could only be either 'selectable' or not, meaning point-and-click based and group-based selection worked the same way. I now added a bit of granularity to the selection model so an item can now be 'selectable' using only point-and-click based interaction and cannot be part of a group selection (e.g. if 'groupSelectable' is set to true).
