### PR TITLE
do not force rect visibility true if dimensions are > 0

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -821,7 +821,10 @@
       if (ownAttributes.font) {
         fabric.parseFontDeclaration(ownAttributes.font, ownAttributes);
       }
-      ownAttributes.visible = ownAttributes.visible && ownAttributes.display;
+      if (typeof ownAttributes.visible !== 'undefined' || typeof ownAttributes.display !== 'undefined') {
+        ownAttributes.visible = (ownAttributes.visible === true) && (ownAttributes.display === true);
+        delete ownAttributes.display;
+      }
       return _setStrokeFillOpacity(extend(parentAttributes, ownAttributes));
     },
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -26,7 +26,7 @@
         r:                    'radius',
         cy:                   'top',
         y:                    'top',
-        display:              'visible',
+        display:              'display',
         visibility:           'visible',
         transform:            'transformMatrix',
         'fill-opacity':       'fillOpacity',

--- a/src/parser.js
+++ b/src/parser.js
@@ -82,12 +82,15 @@
         value = fabric.parseTransformAttribute(value);
       }
     }
-    else if (attr === 'visible') {
-      value = (value === 'none' || value === 'hidden') ? false : true;
+    else if (attr === 'display') {
+      value = (value === 'none') ? false : true;
       // display=none on parent element always takes precedence over child element
-      if (parentAttributes && parentAttributes.visible === false) {
+      if (parentAttributes && parentAttributes.display === false) {
         value = false;
       }
+    }
+    else if (attr === 'visible') {
+      value = (value === 'hidden') ? false : true;
     }
     else if (attr === 'originX' /* text-anchor */) {
       value = value === 'start' ? 'left' : value === 'end' ? 'right' : 'center';
@@ -818,7 +821,10 @@
       if (ownAttributes.font) {
         fabric.parseFontDeclaration(ownAttributes.font, ownAttributes);
       }
-      return _setStrokeFillOpacity(extend(parentAttributes, ownAttributes));
+      ownAttributes = _setStrokeFillOpacity(extend(parentAttributes, ownAttributes));
+      ownAttributes.visible = ownAttributes.visible && ownAttributes.display && parentAttributes.display;
+      delete ownAttributes.display;
+      return ownAttributes;
     },
 
     /**

--- a/src/parser.js
+++ b/src/parser.js
@@ -821,10 +821,8 @@
       if (ownAttributes.font) {
         fabric.parseFontDeclaration(ownAttributes.font, ownAttributes);
       }
-      ownAttributes = _setStrokeFillOpacity(extend(parentAttributes, ownAttributes));
-      ownAttributes.visible = ownAttributes.visible && ownAttributes.display && parentAttributes.display;
-      delete ownAttributes.display;
-      return ownAttributes;
+      ownAttributes.visible = ownAttributes.visible && ownAttributes.display;
+      return _setStrokeFillOpacity(extend(parentAttributes, ownAttributes));
     },
 
     /**

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -221,7 +221,9 @@
 
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
-    return new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
+    var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
+    rect.visible = rect.visible && (rect.width > 0 && rect.height > 0);
+    return rect;
   };
   /* _FROM_SVG_END_ */
 

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -222,7 +222,7 @@
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
     var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
-    rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
+    //rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
     return rect;
   };
   /* _FROM_SVG_END_ */

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -222,7 +222,7 @@
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
     var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
-    rect.visible = rect.width > 0 && rect.height > 0;
+    rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
     return rect;
   };
   /* _FROM_SVG_END_ */

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -222,7 +222,7 @@
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
     var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
-    rect.visible = rect.visible && (rect.width > 0 && rect.height > 0);
+    rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
     return rect;
   };
   /* _FROM_SVG_END_ */

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -222,7 +222,7 @@
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
     var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
-    //rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
+    rect.visible = rect.visible && (rect.width > 0) && (rect.height > 0);
     return rect;
   };
   /* _FROM_SVG_END_ */

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -221,9 +221,7 @@
 
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
-    var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
-    rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
-    return rect;
+    return new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
   };
   /* _FROM_SVG_END_ */
 

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -91,7 +91,7 @@
   test('rect from element with 0 dimension is not visible', function() {
     var elRectWithAttrs = fabric.document.createElement('rect');
 
-    elRectWithAttrs.setAttribute('visibility', true);
+    elRectWithAttrs.setAttribute('visibility', 'visible');
 
     var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
     ok(rectWithAttrs instanceof fabric.Rect);
@@ -100,10 +100,10 @@
 
   });
 
-  test('rect from element with dimensions is not visible if visibility is false', function() {
+  test('rect from element with dimensions is not visible if visibility is hidden', function() {
     var elRectWithAttrs = fabric.document.createElement('rect');
 
-    elRectWithAttrs.setAttribute('visibility', false);
+    elRectWithAttrs.setAttribute('visibility', 'hidden');
     elRectWithAttrs.setAttribute('width', 100);
     elRectWithAttrs.setAttribute('height', 100);
 
@@ -118,6 +118,26 @@
     deepEqual(rectWithAttrs.toObject(), expectedObject);
 
   });
+
+  test('rect from element with dimensions is not visible if display is none', function() {
+    var elRectWithAttrs = fabric.document.createElement('rect');
+
+    elRectWithAttrs.setAttribute('display', 'none');
+    elRectWithAttrs.setAttribute('width', 100);
+    elRectWithAttrs.setAttribute('height', 100);
+
+    var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
+    ok(rectWithAttrs instanceof fabric.Rect);
+
+    var expectedObject = fabric.util.object.extend(REFERENCE_RECT, {
+      width:            100,
+      height:           100,
+      visible:          false
+    });
+    deepEqual(rectWithAttrs.toObject(), expectedObject);
+
+  });
+
 
   test('fabric.Rect.fromElement with custom attributes', function() {
     var elRectWithAttrs = fabric.document.createElement('rect');

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -95,8 +95,9 @@
 
     var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
     ok(rectWithAttrs instanceof fabric.Rect);
-
-    deepEqual(rectWithAttrs.toObject(), REFERENCE_RECT);
+    var expectedObject = fabric.util.object.extend({ }, REFERENCE_RECT);
+    expectedObject.visible = false;
+    deepEqual(rectWithAttrs.toObject(), expectedObject);
 
   });
 
@@ -109,12 +110,10 @@
 
     var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
     ok(rectWithAttrs instanceof fabric.Rect);
-
-    var expectedObject = fabric.util.object.extend(REFERENCE_RECT, {
-      width:            100,
-      height:           100,
-      visible:          false
-    });
+    var expectedObject = fabric.util.object.extend({ }, REFERENCE_RECT);
+    expectedObject.width = 100;
+    expectedObject.height = 100;
+    expectedObject.visible = false;
     deepEqual(rectWithAttrs.toObject(), expectedObject);
 
   });
@@ -129,11 +128,10 @@
     var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
     ok(rectWithAttrs instanceof fabric.Rect);
 
-    var expectedObject = fabric.util.object.extend(REFERENCE_RECT, {
-      width:            100,
-      height:           100,
-      visible:          false
-    });
+    var expectedObject = fabric.util.object.extend({ }, REFERENCE_RECT);
+    expectedObject.width = 100;
+    expectedObject.height = 100;
+    expectedObject.visible = false;
     deepEqual(rectWithAttrs.toObject(), expectedObject);
 
   });

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -96,7 +96,7 @@
     var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
     ok(rectWithAttrs instanceof fabric.Rect);
 
-    deepEqual(rectWithAttrs.toObject(), expectedObject);
+    deepEqual(rectWithAttrs.toObject(), REFERENCE_RECT);
 
   });
 

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -82,9 +82,41 @@
     var elRect = fabric.document.createElement('rect');
     var rect = fabric.Rect.fromElement(elRect);
     var expectedObject = fabric.util.object.extend({ }, REFERENCE_RECT);
+    //standard element has no dimensions so is not visible.
     expectedObject.visible = false;
     ok(rect instanceof fabric.Rect);
     deepEqual(rect.toObject(), expectedObject);
+  });
+
+  test('rect from element with 0 dimension is not visible', function() {
+    var elRectWithAttrs = fabric.document.createElement('rect');
+
+    elRectWithAttrs.setAttribute('visibility', true);
+
+    var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
+    ok(rectWithAttrs instanceof fabric.Rect);
+
+    deepEqual(rectWithAttrs.toObject(), expectedObject);
+
+  });
+
+  test('rect from element with dimensions is not visible if visibility is false', function() {
+    var elRectWithAttrs = fabric.document.createElement('rect');
+
+    elRectWithAttrs.setAttribute('visibility', false);
+    elRectWithAttrs.setAttribute('width', 100);
+    elRectWithAttrs.setAttribute('height', 100);
+
+    var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
+    ok(rectWithAttrs instanceof fabric.Rect);
+
+    var expectedObject = fabric.util.object.extend(REFERENCE_RECT, {
+      width:            100,
+      height:           100,
+      visible:          false
+    });
+    deepEqual(rectWithAttrs.toObject(), expectedObject);
+
   });
 
   test('fabric.Rect.fromElement with custom attributes', function() {

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -119,6 +119,24 @@
 
   });
 
+  test('rect from element display block does not win over visibility hidden', function() {
+    var elRectWithAttrs = fabric.document.createElement('rect');
+
+    elRectWithAttrs.setAttribute('display', 'block');
+    elRectWithAttrs.setAttribute('visibility', 'hidden');
+    elRectWithAttrs.setAttribute('width', 100);
+    elRectWithAttrs.setAttribute('height', 100);
+
+    var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
+    ok(rectWithAttrs instanceof fabric.Rect);
+    var expectedObject = fabric.util.object.extend({ }, REFERENCE_RECT);
+    expectedObject.width = 100;
+    expectedObject.height = 100;
+    expectedObject.visible = false;
+    deepEqual(rectWithAttrs.toObject(), expectedObject);
+
+  });
+
   test('rect from element with dimensions is not visible if display is none', function() {
     var elRectWithAttrs = fabric.document.createElement('rect');
 

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -92,6 +92,7 @@
     var elRectWithAttrs = fabric.document.createElement('rect');
 
     elRectWithAttrs.setAttribute('visibility', 'visible');
+    elRectWithAttrs.setAttribute('display', 'block');
 
     var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
     ok(rectWithAttrs instanceof fabric.Rect);
@@ -136,6 +137,24 @@
 
   });
 
+  test('rect from element display none win over visibility', function() {
+    var elRectWithAttrs = fabric.document.createElement('rect');
+
+    elRectWithAttrs.setAttribute('display', 'none');
+    elRectWithAttrs.setAttribute('visibility', 'visible');
+    elRectWithAttrs.setAttribute('width', 100);
+    elRectWithAttrs.setAttribute('height', 100);
+
+    var rectWithAttrs = fabric.Rect.fromElement(elRectWithAttrs);
+    ok(rectWithAttrs instanceof fabric.Rect);
+
+    var expectedObject = fabric.util.object.extend({ }, REFERENCE_RECT);
+    expectedObject.width = 100;
+    expectedObject.height = 100;
+    expectedObject.visible = false;
+    deepEqual(rectWithAttrs.toObject(), expectedObject);
+
+  });
 
   test('fabric.Rect.fromElement with custom attributes', function() {
     var elRectWithAttrs = fabric.document.createElement('rect');


### PR DESCRIPTION
this fixes correct parsing of display / visibility attribute for rects.

failing svg

```
<svg xmlns:x="http://ns.adobe.com/Extensibility/1.0/" xmlns:i="http://ns.adobe.com/AdobeIllustrator/10.0/" xmlns:graph="http://ns.adobe.com/Graphs/1.0/" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve"><switch><foreignObject requiredExtensions="http://ns.adobe.com/AdobeIllustrator/10.0/" x="0" y="0" width="1" height="1"></foreignObject><g i:extraneous="self"><g display="none"><path display="inline" fill="#000000" stroke="#D1D3D4" stroke-width="4" stroke-miterlimit="10" d="M14.6,2C7.6,2,2,7.7,2,14.6     v70.8C2,92.4,7.6,98,14.6,98h70.8C92.4,98,98,92.4,98,85.4V14.6C98,7.7,92.4,2,85.4,2H14.6z"></path><rect x="14" y="14" display="inline" fill="#000000" stroke="#D1D3D4" stroke-miterlimit="10" width="72" height="72"></rect></g><g><path fill="#000000" d="M61.5,27.5C61.5,33.9,56.3,39,50,39c-6.4,0-11.5-5.1-11.5-11.5S43.6,16,50,16     C56.3,16,61.5,21.1,61.5,27.5"></path><path fill="none" d="M19.8,69.9c0.2,0.6,0.5,1.2,0.9,1.7l10.5,12.6L20.8,71.5C20.4,71,20,70.5,19.8,69.9z"></path><path fill="#000000" d="M28.3,46.4c-1.7,1.3-3,2.9-4,4.7c-0.2,0.3-0.3,0.6-0.4,1c0.1-0.3,0.2-0.7,0.4-1     C25.3,49.2,26.7,47.6,28.3,46.4z"></path><path fill="#000000" d="M28.3,46.4c1.1-0.8,2.3-1.6,3.7-2.1C30.7,44.8,29.5,45.5,28.3,46.4z"></path><path fill="#000000" d="M32,44.3c0.7-0.3,1.3-0.5,2-0.7C33.4,43.8,32.7,44,32,44.3z"></path><path fill="#000000" d="M80.9,67.8c0-0.5-0.1-0.9-0.3-1.4l-5.2-14.7c-0.1-0.2-0.2-0.4-0.3-0.7c-0.3-0.6-0.7-1.2-1.1-1.8     c-0.8-1.1-1.8-2.1-2.9-3s-2.3-1.6-3.7-2.1c-0.7-0.3-1.3-0.5-2-0.7C64,43.2,62.5,43,61,43H37.9c-1.5,0-3,0.2-4.4,0.6     c-0.7,0.2-1.4,0.4-2,0.7c-1.3,0.5-2.6,1.3-3.7,2.1c-0.4,0.3-0.8,0.7-1.2,1c-1.1,1.1-2.1,2.3-2.8,3.7c-0.2,0.3-0.3,0.6-0.4,1     l-4.2,14.7c-0.3,1-0.3,2.1,0.1,3.1c0.1,0.3,0.2,0.6,0.4,0.9c0.2,0.3,0.3,0.5,0.5,0.8l10.5,12.6c0.6,0.8,1.5,1.3,2.4,1.6     c0.5,0.2,1.1,0.3,1.7,0.3v0h0h11.5c0.3,0,0.6-0.1,0.8-0.2c0.3-0.1,0.5-0.3,0.7-0.4c0.2-0.2,0.3-0.4,0.4-0.7     c0.1-0.3,0.2-0.5,0.2-0.8c0-0.6-0.2-1.2-0.7-1.5c-0.1-0.1-0.3-0.2-0.5-0.3C47.1,82,46.8,82,46.5,82h-3.7L30.1,66.9l2.6-9.3h2v0.1     v4v7.5L43.7,80h0.8h2h6.4h0.6h2.1l8.6-9.8v-8.4v-4.2h2.2l3.3,9.3l-5.5,6.3v0L56.5,82h-3.6c-0.1,0-0.3,0-0.4,0     c-0.4,0.1-0.9,0.2-1.2,0.5c-0.1,0.1-0.2,0.2-0.3,0.3c-0.2,0.2-0.3,0.4-0.4,0.7c0,0.1-0.1,0.3-0.1,0.4c0,0.7,0.4,1.4,0.9,1.7     c0.2,0.2,0.5,0.3,0.8,0.3c0.1,0,0.3,0,0.4,0h11.5v0c1.4,0,2.8-0.6,3.9-1.7l11.5-12.6c0.7-0.7,1.1-1.6,1.3-2.5     C80.9,68.8,81,68.3,80.9,67.8z M51,75h-2c-0.6,0-1-0.4-1-1s0.4-1,1-1h2c0.6,0,1,0.4,1,1S51.6,75,51,75z M52,72h-4     c-0.6,0-1-0.4-1-1s0.4-1,1-1h4c0.6,0,1,0.4,1,1S52.6,72,52,72z M55,63.6L55,63.6c-2.1,2.6-2,4.4-2,4.4c0,0.6-0.4,1-1,1h-4     c-0.6,0-1-0.4-1-1c0,0,0.1-1.8-2-4.4h0c-0.9-1.1-1.5-2.5-1.5-4.1c0-3.6,2.9-6.5,6.5-6.5s6.5,2.9,6.5,6.5     C56.5,61.1,56,62.5,55,63.6z"></path></g></g></switch></svg>
```

that would be fixed.
