### PR TITLE
canvas: implemented inheritCanvasStyle option to copy styles of original canvas

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1237,8 +1237,18 @@
       fabric.util.setStyle(this.wrapperEl, {
         width: this.getWidth() + 'px',
         height: this.getHeight() + 'px',
-        position: 'relative'
+        position: this.inheritCanvasStyle ? this.wrapperEl.style.position : 'relative'
       });
+      if (this.inheritCanvasStyle) {
+        for (var i = 0; i < this.lowerCanvasEl.style.length; i++) {
+          var elem = this.lowerCanvasEl.style[i];
+          this.wrapperEl.style[elem] = this.lowerCanvasEl.style[elem];
+        }
+        this.lowerCanvasEl.style = {};
+        this.lowerCanvasEl.style.position = 'absolute';
+        this.lowerCanvasEl.style.top = 0;
+        this.lowerCanvasEl.style.left = 0;
+      }
       fabric.util.makeElementUnselectable(this.wrapperEl);
     },
 
@@ -1249,13 +1259,12 @@
     _applyCanvasStyle: function (element) {
       var width = this.getWidth() || element.width,
           height = this.getHeight() || element.height;
-
       fabric.util.setStyle(element, {
         position: 'absolute',
         width: width + 'px',
         height: height + 'px',
-        left: 0,
-        top: 0
+        left: this.inheritCanvasStyle === true ? undefined : 0,
+        top: this.inheritCanvasStyle === true ? undefined : 0
       });
       element.width = width;
       element.height = height;

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -174,10 +174,11 @@
      * @param {Object} [options] Options object
      */
     _initStatic: function(el, options) {
+      this._saveOptions(options);
       var cb = fabric.StaticCanvas.prototype.renderAll.bind(this);
       this._objects = [];
       this._createLowerCanvas(el);
-      this._initOptions(options);
+      this._initOptions();
       this._setImageSmoothing();
       // only initialize retina scaling once
       if (!this.interactive) {
@@ -475,11 +476,16 @@
      * @private
      * @param {Object} [options] Options object
      */
-    _initOptions: function (options) {
+    _saveOptions: function (options) {
       for (var prop in options) {
         this[prop] = options[prop];
       }
+    },
 
+    /**
+     * @private
+     */
+    _initOptions: function () {
       this.width = this.width || parseInt(this.lowerCanvasEl.width, 10) || 0;
       this.height = this.height || parseInt(this.lowerCanvasEl.height, 10) || 0;
 


### PR DESCRIPTION
If there is a canvas like the following

`<canvas id="c" width="500" height="500" style="position: absolute; width:500px; height:500px; right:5px;></canvas>`

it's rendered with "position: relative" and placed at the left of the screen.

This pull request solves the problem copying all style property from source canvas to the wrapper canvas.

Hope this helps.
