### PR TITLE
fix(dependencies): move optional deps to peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "export_tests_to_site": "cp test/unit/*.js ../fabricjs.com/test/unit",
     "all": "npm run build && npm run test && npm run lint && npm run lint_tests && npm run export_dist_to_site && npm run export_tests_to_site"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "canvas-prebuilt": "1.6.x",
     "jsdom": "9.x.x",
     "xmldom": "0.1.x"


### PR DESCRIPTION
purpose: currently, downstream users of fabric.js needed to either:
1. install cairo
2. run `npm install --no-optional`

or those downstream users faced a failing npm install that blocked most
CI usage.

With this change, downstream users of frabric.js can `npm install` and
continue without any errors. If the downstream users require use of
node-canvas then they can explicitly install those deps (as npm will
spit out an unmet peer dependency warning after `npm install`)