### PR TITLE
Fix normal, italic and bold, normal on node-canvas

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -832,8 +832,8 @@
     _getFontDeclaration: function() {
       return [
         // node-canvas needs "weight style", while browsers need "style weight"
-        (fabric.isLikelyNode ? (this.fontWeight == 'normal' ? '' : this.fontWeight) : this.fontStyle),
-        (fabric.isLikelyNode ? (this.fontStyle == 'normal' ? '' : this.fontStyle) : this.fontWeight),
+        (fabric.isLikelyNode ? (this.fontWeight === 'normal' ? '' : this.fontWeight) : this.fontStyle),
+        (fabric.isLikelyNode ? (this.fontStyle === 'normal' ? '' : this.fontStyle) : this.fontWeight),
         this.fontSize + 'px',
         (fabric.isLikelyNode ? ('"' + this.fontFamily + '"') : this.fontFamily)
       ].join(' ');

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -832,8 +832,8 @@
     _getFontDeclaration: function() {
       return [
         // node-canvas needs "weight style", while browsers need "style weight"
-        (fabric.isLikelyNode ? this.fontWeight : this.fontStyle),
-        (fabric.isLikelyNode ? this.fontStyle : this.fontWeight),
+        (fabric.isLikelyNode ? (this.fontWeight == 'normal' ? '' : this.fontWeight) : this.fontStyle),
+        (fabric.isLikelyNode ? (this.fontStyle == 'normal' ? '' : this.fontStyle) : this.fontWeight),
         this.fontSize + 'px',
         (fabric.isLikelyNode ? ('"' + this.fontFamily + '"') : this.fontFamily)
       ].join(' ');

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -77,7 +77,7 @@
     var fontDecl = text._getFontDeclaration();
     ok(typeof fontDecl == 'string', 'it returns a string');
     if (fabric.isLikelyNode) {
-      equal(fontDecl, 'normal  40px "Times New Roman"');
+      equal(fontDecl, '  40px "Times New Roman"');
     }
     else {
       equal(fontDecl, ' normal 40px Times New Roman');


### PR DESCRIPTION
When using text configured like so:

```
fontStyle: 'normal',
fontWeight: 'bold'
```

Or:

```
fontStyle: 'italic',
fontWeight: 'normal'
```

It renders correctly on the browser, but node-canvas seems to fail when one of the two properties is 'normal'. Replacing 'normal' with empty string fixes it.

The example from node-canvas repo omits normal as well:
https://github.com/Automattic/node-canvas/blob/v1.x/examples/font.js

Expected output:
![Expected](https://bilgorajski.pro/img/fabric-node-canvas-font-bug/expected.png)
Actual output:
![Actual](https://bilgorajski.pro/img/fabric-node-canvas-font-bug/actual.png)

(from top to bottom: normal normal, bold normal, normal italic, bold italic)

I'm using node-canvas compiled with node-gyp (not the prebuilt one), with Pango support enabled. This may be the cause of the bug, but I can't check the prebuilt one as I'm getting Pango errors, so please check if this can be reproduced.