### PR TITLE
Fixes touchmove event being missed when using on Android/Chrome

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -204,6 +204,7 @@
      * @param {Event} e Event object fired on mousedown
      */
     _onMouseDown: function (e) {
+      e.preventDefault();
       this.__onMouseDown(e);
 
       addListener(fabric.document, 'touchend', this._onMouseUp, { passive: false });


### PR DESCRIPTION
This fixes the behavior reported in #3822.  When using Chrome on Android writing/drawing was not "smooth" and parts of drawing would be dropped.

With this in place free drawing is much smoother and no glyphs are missed.

I'm interested in hearing if 
- there is a different solution
- this might cause any ill-effects (I saw none testing with various devices and browsers)
- should any other event handlers preventDefault()

