### PR TITLE
Inheritance breaking minor bug regarding textbox behavior objecting scaling override

### DIFF
--- a/src/mixins/textbox_behavior.mixin.js
+++ b/src/mixins/textbox_behavior.mixin.js
@@ -18,7 +18,7 @@
       }
     }
     else {
-      return setObjectScaleOverridden.call(fabric.Canvas.prototype, localMouse, transform,
+      return setObjectScaleOverridden.call(this, localMouse, transform,
         lockScalingX, lockScalingY, by, lockScalingFlip, _dim);
     }
   };


### PR DESCRIPTION
Hey all, locally I have a very heavily extended version of Fabric (utilizing `klass` subclassing). I was noticing some strangeness regarding `this` bindings when attempting to subclass and override certain scaling operations and traced it back to this. It seems to be an oversite that doesn't manifest unless overriding the scaling logic in a subclass.