### PR TITLE
Allow cutted words in a Textbox shape

### DIFF
--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -301,6 +301,7 @@
       for (var i = 0; i < words.length; i++) {
         // i would avoid resplitting the graphemes
         word = fabric.util.string.graphemeSplit(words[i]);
+        cutIndex = word.length - 1;
         wordWidth = this._measureWord(word, lineIndex, offset);
 
         lineWidth += infixWidth + wordWidth - additionalSpace;

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -354,7 +354,7 @@
 
       i && graphemeLines.push(line);
 
-      if (largestWordWidth > this.dynamicMinWidth) {
+      if (!this.allowCuttedWords && largestWordWidth > this.dynamicMinWidth) {
         this.dynamicMinWidth = largestWordWidth - additionalSpace;
       }
 


### PR DESCRIPTION
It's a way to mimic html/css world *white-space normal or pre-wrap* property, because sometime you want the text to fit exactly in the `width` you set no matter what.

Example here http://jsfiddle.net/Da7SP/736/ one with `minWidth` one without, both with the option activated and a last one without it.

this would close #2376