### PR TITLE
FIX firing selection:cleared when group is changing to active selection.

### DIFF
--- a/src/shapes/active_selection.class.js
+++ b/src/shapes/active_selection.class.js
@@ -76,6 +76,7 @@
       canvas.add(newGroup);
       canvas._activeObject = newGroup;
       newGroup.setCoords();
+      canvas.trigger('selection:updated', { target: newGroup });
       return newGroup;
     },
 

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -432,6 +432,7 @@
       var activeSelection = new fabric.ActiveSelection([]);
       activeSelection.set(options);
       activeSelection.type = 'activeSelection';
+      canvas._activeObject = activeSelection;
       canvas.remove(this);
       objects.forEach(function(object) {
         object.group = activeSelection;
@@ -440,8 +441,8 @@
       });
       activeSelection.canvas = canvas;
       activeSelection._objects = objects;
-      canvas._activeObject = activeSelection;
       activeSelection.setCoords();
+      canvas.trigger('selection:updated', { target: activeSelection });
       return activeSelection;
     },
 


### PR DESCRIPTION
There is problem when we changing group to activeSelection because canvas fire selection:cleared. 

This commit silently unselect group before removing it from canvas and it should prevnet trigering before:selection:cleared and selection:cleared events in canvas _onObjectRemoved.

Other way to resolve it could be fire event selection:created after set canvas._activeObject = activeSelection;