### PR TITLE
Added Canvas.onBeforeMove

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -601,6 +601,9 @@
       if (target._findTargetCorner(this.getPointer(e, true))) {
         this.onBeforeScaleRotate(target);
       }
+      else {
+        this.onBeforeMove(target);
+      }
 
     },
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -172,6 +172,8 @@
 
     /**
      * Callback; invoked right before object is being moved
+     * Since there is no way to know if the object is going to be selected or moved,
+     * this event is not a guarantee that object will be moved but indicator for likely to move
      */
     onBeforeMove: function () {
       /* NOOP */

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -171,6 +171,13 @@
     },
 
     /**
+     * Callback; invoked right before object is being moved
+     */
+    onBeforeMove: function () {
+      /* NOOP */
+    },
+
+    /**
      * When true, canvas is scaled by devicePixelRatio for better rendering on retina screens
      * @type Boolean
      * @default

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -69,6 +69,26 @@
 
     canvas.zoomToPoint({ x: 0, y: 0 }, 1);
     canvas.onBeforeScaleRotate = _onBeforeScaleRotate;
+
+    var _onBeforeMove = canvas.onBeforeMove;
+    t = null;
+    counter = 0;
+
+    canvas.onBeforeMove = function (target) {
+      t = target;
+      counter++;
+    };
+
+    var e = {
+      clientX: canvasOffset.left + rect.left + rect.width / 2,
+      clientY: canvasOffset.top + rect.top + rect.height / 2,
+      which: 1
+    };
+    canvas._beforeTransform(e, rect);
+    assert.equal(counter, 1, '_beforeTransform should trigger onBeforeMove when object is about to be moved');
+    assert.equal(t, rect, 'onBeforeMove should receive correct target');
+
+    canvas.onBeforeMove = _onBeforeMove;
   });
 
   QUnit.test('mouse:down with different buttons', function(assert) {


### PR DESCRIPTION
Hi,

When implementing undo functionality for an object, we can know the state before scale and rotate using the existing Canvas.onBeforeScaleRotate callback.

But there's no such thing for movement. I needed to know the state of the object before it's going to move.

Hence, this pull request. Added `Canvas.onBeforeMove` method that gets before the component is going to be moved.

I have a small problem though: it also triggers when mouse down happens on the object. I couldn't find any way to distinguish these both and thought about renaming onBeforeMove to `onLikelyToMove` but didn't feel it is clean solution. Do you have any thoughts about this?
