### PR TITLE
isTargetTransparent() now samples the cache directly.

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -492,7 +492,7 @@
      * @return {Boolean}
      */
     isTargetTransparent: function (target, x, y) {
-      if (target.shouldCache() && target._cacheCanvas && !target.isCacheDirty()) {
+      if (target.shouldCache() && target._cacheCanvas) {
         var normalizedPointer = this._normalizePointer(target, {x: x, y: y}),
             targetRelativeX = target.cacheTranslationX + (normalizedPointer.x * target.zoomX),
             targetRelativeY = target.cacheTranslationY + (normalizedPointer.y * target.zoomY);

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -492,6 +492,17 @@
      * @return {Boolean}
      */
     isTargetTransparent: function (target, x, y) {
+      if (target.shouldCache() && target._cacheCanvas && !target.isCacheDirty()) {
+        var normalizedPointer = this._normalizePointer(target, {x: x, y: y}),
+            targetRelativeX = target.cacheTranslationX + (normalizedPointer.x * target.zoomX),
+            targetRelativeY = target.cacheTranslationY + (normalizedPointer.y * target.zoomY);
+
+        var isTransparent = fabric.util.isTransparent(
+          target._cacheContext, targetRelativeX, targetRelativeY, this.targetFindTolerance);
+
+        return isTransparent;
+      }
+
       var ctx = this.contextCache,
           originalColor = target.selectionBackgroundColor, v = this.viewportTransform;
 


### PR DESCRIPTION
This is a work in progress. It seems to work for the limited things I've tried it with -- mostly hit-testing paths. I know that it doesn't work on apple platforms where retina scaling is enabled, so I'd like some advice on how to get that working properly, and any other feedback/notes.

For example, I check for cache validity with the following:
```
if (target.shouldCache && target._cacheCanvas && !target.isCacheDirty())
```
Is there a better way to be doing this, or other things to consider checking about the state of the cache?

And finally, does the math here correct?

Thank you!

---

Previously, isTargetTransparent would do a paint from the cache to the contextCache which has more overhead and is slower. With this commit, fabricjs will test the cache canvas directly using x/y coordinates calculated with respect to the target object center. This is more performant since it avoids an extra render
on every call to isTargetTransparent.
