### PR TITLE
Fix issue with saving/restoring datalessJSON while retaining the edit…

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -556,10 +556,10 @@
    * @param {Object} object Object to create a group from
    * @param {Function} [callback] Callback to invoke when an group instance is created
    */
-fabric.Group.fromObject = function(object, callback) {
+  fabric.Group.fromObject = function(object, callback) {
     var options = fabric.util.object.clone(object, true);
 
-    if (typeof object.sourcePath === "string") {
+    if (typeof object.sourcePath === 'string') {
       var sourcePath = object.sourcePath;
       fabric.loadSVGFromURL(sourcePath, function(elements) {
         elements.forEach(function (obj, i) {
@@ -569,7 +569,7 @@ fabric.Group.fromObject = function(object, callback) {
         group.setOptions(options);
         callback && callback(group);
       });
-    } 
+    }
     else {
       fabric.util.enlivenObjects(object.objects, function(enlivenedObjects) {
         delete options.objects;
@@ -577,5 +577,5 @@ fabric.Group.fromObject = function(object, callback) {
       });
     }
   };
-  
+
 })(typeof exports !== 'undefined' ? exports : this);


### PR DESCRIPTION
In reference to #4598 and #4946

This was really a two part issue. 

Part 1. was the objects.forEach bug. (objects.forEach would bug out when it received a url string)
Fix: in toDatalessObject: I removed the if/else assigning the sourcePath to the objects prop. Instead I figured it made more sense to keep all the objects default values minus the paths. This way we can retain the relatively small properties while still achieving the goal of dumping the large paths for the small sourcePath url.

Part 2. was rebuilding the svg/group. (Svg group options should rebuild to how they were exported) 
Fix: I leveraged the implementation used in Paths and the previous PathGroup(pre 2.0) and modified the fabric.Group.fromObject to check for a sourcePath. If the sourcePath was found load the SVG from the url and set each object element to the object “elements” original value. I used ._setObject for clarity but .set works just as well. I then grouped the elements using groupSVGElements and set the options to the original object. 

Hope that makes sense! 