### PR TITLE
Fixed text decoration line not ignoring charSpacing at the end of line (#5006)

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1138,7 +1138,8 @@
           leftOffset = this._getLeftOffset(),
           topOffset = this._getTopOffset(), top,
           boxStart, boxWidth, charBox, currentDecoration,
-          maxHeight, currentFill, lastFill;
+          maxHeight, currentFill, lastFill,
+          charSpacing = this._getWidthOfCharSpacing();
 
       for (var i = 0, len = this._textLines.length; i < len; i++) {
         heightOfLine = this.getHeightOfLine(i);
@@ -1186,7 +1187,7 @@
         currentDecoration && currentFill && ctx.fillRect(
           leftOffset + lineLeftOffset + boxStart,
           top + this.offsets[type] * size + dy,
-          boxWidth,
+          boxWidth - charSpacing,
           this.fontSize / 15
         );
         topOffset += heightOfLine;


### PR DESCRIPTION
Fixed text underline/overline/linethrough line not ignoring charSpacing at the end of line (#5006)