### PR TITLE
Added support for per object min and max height and width

### DIFF
--- a/build.js
+++ b/build.js
@@ -173,6 +173,7 @@ var filesToInclude = [
   ifSpecifiedInclude('gestures', 'src/mixins/canvas_gestures.mixin.js'),
 
   'src/shapes/object.class.js',
+  'src/mixins/object_behavior.mixin.js',
   'src/mixins/object_origin.mixin.js',
   'src/mixins/object_geometry.mixin.js',
   'src/mixins/object_stacking.mixin.js',

--- a/src/mixins/object_behavior.mixin.js
+++ b/src/mixins/object_behavior.mixin.js
@@ -1,0 +1,37 @@
+(function() {
+
+  /**
+   * Override _setObjectScale and apply max and min dimensions
+   */
+  var setObjectScaleOverridden = fabric.Canvas.prototype._setObjectScale;
+
+  fabric.Canvas.prototype._setObjectScale = function (localMouse, transform,
+    lockScalingX, lockScalingY, by, lockScalingFlip, _dim) {
+
+    var t = transform.target;
+    if (by === 'x') {
+      var tw = t._getTransformedDimensions().x;
+      var w = t.width * (localMouse.x / tw);
+      if (w >= t.getMinWidth() && w <= t.getMaxWidth()) {
+        t.set('width', w);
+        return true;
+      }
+    }
+    else if (by === 'y') {
+      var th = t._getTransformedDimensions().y;
+      var h = t.height * (localMouse.y / th);
+      if (h >= t.getMinHeight() && h <= t.getMaxHeight()) {
+        t.set('height', h);
+        return true;
+      }
+    }
+    else if (by === 'equally') {
+      var tw = t._getTransformedDimensions().x;
+      var w = t.width * (localMouse.x / tw);
+      if (w >= t.getMinWidth() && w <= t.getMaxWidth() && h >= t.getMinHeight() && h <= t.getMaxHeight()) {
+        return setObjectScaleOverridden.call(fabric.Canvas.prototype, localMouse, transform,
+          lockScalingX, lockScalingY, by, lockScalingFlip, _dim);
+      }
+    }
+  };
+})();

--- a/src/mixins/object_behavior.mixin.js
+++ b/src/mixins/object_behavior.mixin.js
@@ -12,7 +12,7 @@
     if (by === 'x') {
       var tw = t._getTransformedDimensions().x;
       var w = t.width * (localMouse.x / tw);
-      if (w >= t.getMinWidth() && w <= t.getMaxWidth()) {
+      if (w >= t.minWidth && w <= t.maxWidth) {
         t.set('width', w);
         return true;
       }
@@ -20,7 +20,7 @@
     else if (by === 'y') {
       var th = t._getTransformedDimensions().y;
       var h = t.height * (localMouse.y / th);
-      if (h >= t.getMinHeight() && h <= t.getMaxHeight()) {
+      if (h >= t.minHeight && h <= t.maxHeight) {
         t.set('height', h);
         return true;
       }
@@ -28,7 +28,9 @@
     else if (by === 'equally') {
       var tw = t._getTransformedDimensions().x;
       var w = t.width * (localMouse.x / tw);
-      if (w >= t.getMinWidth() && w <= t.getMaxWidth() && h >= t.getMinHeight() && h <= t.getMaxHeight()) {
+      var th = t._getTransformedDimensions().y;
+      var h = t.height * (localMouse.y / th);
+      if (w >= t.minWidth && w <= t.maxWidth && h >= t.minHeight && h <= t.maxHeight) {
         return setObjectScaleOverridden.call(fabric.Canvas.prototype, localMouse, transform,
           lockScalingX, lockScalingY, by, lockScalingFlip, _dim);
       }

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -448,6 +448,35 @@
      */
     clipTo:                   null,
 
+
+    /**
+     * When not null, will not allow the width of the object to be smaller than the value
+     * @type Number
+     * @default
+     */
+    minWidth:                null,
+
+    /**
+     * When not null, will not allow the width of the object to be larger than the value
+     * @type Number
+     * @default
+     */
+    maxWidth:                null,
+
+    /**
+     * When not null, will not allow the height of the object to be smaller than the value
+     * @type Number
+     * @default
+     */
+    minHeight:                null,
+
+    /**
+     * When not null, will not allow the height of the object to be larger than the value
+     * @type Number
+     * @default
+     */
+    maxHeight:                null,
+
     /**
      * When `true`, object horizontal movement is locked
      * @type Boolean
@@ -843,6 +872,38 @@
     toDatalessObject: function(propertiesToInclude) {
       // will be overwritten by subclasses
       return this.toObject(propertiesToInclude);
+    },
+
+    /**
+     * Returns the minimum width of the object
+     * @return {Number}
+     */
+    getMinWidth: function() {
+      return this.minWidth ? this.minWidth : Number.NEGATIVE_INFINITY;
+    },
+
+    /**
+     * Returns the maximum width of the object
+     * @return {Number}
+     */
+    getMaxWidth: function() {
+      return this.maxWidth ? this.maxWidth : Number.POSITIVE_INFINITY;
+    },
+
+    /**
+     * Returns the minimum height of the object
+     * @return {Number}
+     */
+    getMinHeight: function() {
+      return this.minHeight ? this.minHeight : Number.NEGATIVE_INFINITY;
+    },
+
+    /**
+     * Returns the maximum height of the object
+     * @return {Number}
+     */
+    getMaxHeight: function() {
+      return this.maxHeight ? this.maxHeight : Number.POSITIVE_INFINITY;
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -454,28 +454,28 @@
      * @type Number
      * @default
      */
-    minWidth:                null,
+    minWidth:                Number.NEGATIVE_INFINITY,
 
     /**
      * When not null, will not allow the width of the object to be larger than the value
      * @type Number
      * @default
      */
-    maxWidth:                null,
+    maxWidth:                Number.POSITIVE_INFINITY,
 
     /**
      * When not null, will not allow the height of the object to be smaller than the value
      * @type Number
      * @default
      */
-    minHeight:                null,
+    minHeight:                Number.NEGATIVE_INFINITY,
 
     /**
      * When not null, will not allow the height of the object to be larger than the value
      * @type Number
      * @default
      */
-    maxHeight:                null,
+    maxHeight:                Number.POSITIVE_INFINITY,
 
     /**
      * When `true`, object horizontal movement is locked
@@ -872,38 +872,6 @@
     toDatalessObject: function(propertiesToInclude) {
       // will be overwritten by subclasses
       return this.toObject(propertiesToInclude);
-    },
-
-    /**
-     * Returns the minimum width of the object
-     * @return {Number}
-     */
-    getMinWidth: function() {
-      return this.minWidth ? this.minWidth : Number.NEGATIVE_INFINITY;
-    },
-
-    /**
-     * Returns the maximum width of the object
-     * @return {Number}
-     */
-    getMaxWidth: function() {
-      return this.maxWidth ? this.maxWidth : Number.POSITIVE_INFINITY;
-    },
-
-    /**
-     * Returns the minimum height of the object
-     * @return {Number}
-     */
-    getMinHeight: function() {
-      return this.minHeight ? this.minHeight : Number.NEGATIVE_INFINITY;
-    },
-
-    /**
-     * Returns the maximum height of the object
-     * @return {Number}
-     */
-    getMaxHeight: function() {
-      return this.maxHeight ? this.maxHeight : Number.POSITIVE_INFINITY;
     },
 
     /**

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -385,6 +385,34 @@
     assert.equal(cObj.get('angle'), 45);
   });
 
+  QUnit.test('minWidth', function(assert) {
+    var cObj = new fabric.Object();
+    assert.equal(cObj.getMinWidth(), Number.NEGATIVE_INFINITY);
+    cObj.set('minWidth', 20);
+    assert.equal(cObj.getMinWidth(), 20);
+  });
+
+  QUnit.test('maxWidth', function(assert) {
+    var cObj = new fabric.Object();
+    assert.equal(cObj.getMaxWidth(), Number.POSITIVE_INFINITY);
+    cObj.set('maxWidth', 20);
+    assert.equal(cObj.getMaxWidth(), 20);
+  });
+
+  QUnit.test('minHeight', function(assert) {
+    var cObj = new fabric.Object();
+    assert.equal(cObj.getMinHeight(), Number.NEGATIVE_INFINITY);
+    cObj.set('minHeight', 20);
+    assert.equal(cObj.getMinHeight(), 20);
+  });
+
+  QUnit.test('maxHeight', function(assert) {
+    var cObj = new fabric.Object();
+    assert.equal(cObj.getMaxHeight(), Number.POSITIVE_INFINITY);
+    cObj.set('maxHeight', 20);
+    assert.equal(cObj.getMaxHeight(), 20);
+  });
+
   QUnit.test('drawBorders', function(assert) {
     var cObj = new fabric.Object(), canvas = fabric.document.createElement('canvas');
 

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -387,30 +387,30 @@
 
   QUnit.test('minWidth', function(assert) {
     var cObj = new fabric.Object();
-    assert.equal(cObj.getMinWidth(), Number.NEGATIVE_INFINITY);
+    assert.equal(cObj.get('minWidth'), Number.NEGATIVE_INFINITY);
     cObj.set('minWidth', 20);
-    assert.equal(cObj.getMinWidth(), 20);
+    assert.equal(cObj.get('minWidth'), 20);
   });
 
   QUnit.test('maxWidth', function(assert) {
     var cObj = new fabric.Object();
-    assert.equal(cObj.getMaxWidth(), Number.POSITIVE_INFINITY);
+    assert.equal(cObj.get('maxWidth'), Number.POSITIVE_INFINITY);
     cObj.set('maxWidth', 20);
-    assert.equal(cObj.getMaxWidth(), 20);
+    assert.equal(cObj.get('maxWidth'), 20);
   });
 
   QUnit.test('minHeight', function(assert) {
     var cObj = new fabric.Object();
-    assert.equal(cObj.getMinHeight(), Number.NEGATIVE_INFINITY);
+    assert.equal(cObj.get('minHeight'), Number.NEGATIVE_INFINITY);
     cObj.set('minHeight', 20);
-    assert.equal(cObj.getMinHeight(), 20);
+    assert.equal(cObj.get('minHeight'), 20);
   });
 
   QUnit.test('maxHeight', function(assert) {
     var cObj = new fabric.Object();
-    assert.equal(cObj.getMaxHeight(), Number.POSITIVE_INFINITY);
+    assert.equal(cObj.get('maxHeight'), Number.POSITIVE_INFINITY);
     cObj.set('maxHeight', 20);
-    assert.equal(cObj.getMaxHeight(), 20);
+    assert.equal(cObj.get('maxHeight'), 20);
   });
 
   QUnit.test('drawBorders', function(assert) {


### PR DESCRIPTION
Sometimes our customers accidentally make objects too small, this can have a couple of averse effects. 

If the object is a group, containing an image, and the image is scaling with the group, this can cause an error because the object is trying to draw on a canvas that has a 0 dimension. 

If not, and they resize the object to 0 height, width, or both, it's very difficult to grab and resize the object.

This PR allows this for any fabric object:
let groupProps = {
                left: 10,
                top: 10,
                width: 100,
                height: 100,
                minWidth: 20,
                minHeight: 20,
                maxWidth: 300,
                maxHeight: 300
            };

group = new fabric.Group(groupItems, groupProps);

I based the code off of similar functionality in textbox_behavior.mixin.js