### PR TITLE
Support css-style zIndex

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -375,20 +375,20 @@
       else {
         objsToRender = this._objects;
       }
-      
+
       objsToRender = objsToRender.sort(function(a, b) {
         var sortValue = 0, az = a.zIndex || 0, bz = b.zIndex || 0;
-        
+
         if (az < bz) {
           sortValue = -1;
         }
         else if (az > bz) {
           sortValue = 1;
         }
-        
+
         return sortValue;
       });
-      
+
       return objsToRender;
     },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -389,6 +389,8 @@
         else if (az > bz) {
           sortValue = 1;
         }
+        
+        return sortValue;
       });
     },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -375,6 +375,16 @@
       else {
         objsToRender = this._objects;
       }
+      
+      objsToRender = objsToRender.sort(function(a, b) {
+        var d = 0, az = a.zIndex || 0, bz = b.zIndex || 0;
+        
+        if (az < bz) d = -1;
+        else if (az > bz) d = 1;
+        
+        return d;
+      });
+      
       return objsToRender;
     },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -378,7 +378,7 @@
 
       return this._sortObjectsByDisplayOrder(objsToRender);
     },
-    
+
     _sortObjectsByDisplayOrder: function (objects) {
       return objects.sort(function(a, b) {
         var sortValue = 0, az = a.zIndex || 0, bz = b.zIndex || 0;
@@ -389,7 +389,7 @@
         else if (az > bz) {
           sortValue = 1;
         }
-        
+
         return sortValue;
       });
     },

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -376,7 +376,11 @@
         objsToRender = this._objects;
       }
 
-      objsToRender = objsToRender.sort(function(a, b) {
+      return this._sortObjectsByDisplayOrder(objsToRender);
+    },
+    
+    _sortObjectsByDisplayOrder: function (objects) {
+      return objects.sort(function(a, b) {
         var sortValue = 0, az = a.zIndex || 0, bz = b.zIndex || 0;
 
         if (az < bz) {
@@ -385,11 +389,7 @@
         else if (az > bz) {
           sortValue = 1;
         }
-
-        return sortValue;
       });
-
-      return objsToRender;
     },
 
     /**
@@ -1248,6 +1248,7 @@
      * @private
      */
     _searchPossibleTargets: function(objects, pointer) {
+      objects = this._sortObjectsByDisplayOrder(objects);
 
       // Cache all targets where their bounding box contains point.
       var target, i = objects.length, normalizedPointer, subTarget;

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -377,12 +377,16 @@
       }
       
       objsToRender = objsToRender.sort(function(a, b) {
-        var d = 0, az = a.zIndex || 0, bz = b.zIndex || 0;
+        var sortValue = 0, az = a.zIndex || 0, bz = b.zIndex || 0;
         
-        if (az < bz) d = -1;
-        else if (az > bz) d = 1;
+        if (az < bz) {
+          sortValue = -1;
+        }
+        else if (az > bz) {
+          sortValue = 1;
+        }
         
-        return d;
+        return sortValue;
       });
       
       return objsToRender;


### PR DESCRIPTION
`canvas.moveTo`/`object.moveTo` as a solution to zPosition/zIndex doesn't really work when you have more than a couple objects on the canvas because moving any object around in the array affects the index of all other objects in the array.

This solution shouldn't affect the order of the array unless `zIndex` values are set on objects, so it shouldn't break `sendToBack`, `sendToFront`, etc...

It allows multiple objects to have the same zIndex value and when that is the case, leave them in their natural order.