### PR TITLE
Reset superscript subscript

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -163,7 +163,7 @@
       size:       0.60,
       baseline:   0
     },
-  
+
     /**
      * Unsubscript schema object (minimum overlap)
      * @type {Object}
@@ -1005,7 +1005,7 @@
     setSubscript: function(start, end) {
       return this._setScript(start, end, this.subscript);
     },
-    
+
     /**
      * Turns the character into a 'superior figure' (i.e. 'superscript')
      * @param {Number} start selection start

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -155,6 +155,25 @@
     },
 
     /**
+     * Unsuperscript schema object (minimum overlap)
+     * @type {Object}
+     * @default
+     */
+    unsuperscript: {
+      size:       0.60,
+      baseline:   0
+    },
+  
+    /**
+     * Unsubscript schema object (minimum overlap)
+     * @type {Object}
+     * @default
+     */
+    unsubscript: {
+      size:     0.60,
+      baseline: 0
+    },
+    /**
      * Background color of text lines
      * @type String
      * @default
@@ -986,6 +1005,28 @@
     setSubscript: function(start, end) {
       return this._setScript(start, end, this.subscript);
     },
+    
+    /**
+     * Turns the character into a 'superior figure' (i.e. 'superscript')
+     * @param {Number} start selection start
+     * @param {Number} end selection end
+     * @returns {fabric.Text} thisArg
+     * @chainable
+     */
+    unsetSuperscript: function(start, end) {
+      return this._resetScript(start, end, this.unsuperscript);
+    },
+
+    /**
+     * Turns the character into an 'inferior figure' (i.e. 'subscript')
+     * @param {Number} start selection start
+     * @param {Number} end selection end
+     * @returns {fabric.Text} thisArg
+     * @chainable
+     */
+    unsetSubscript: function(start, end) {
+      return this._resetScript(start, end, this.unsubscript);
+    },
 
     /**
      * Applies 'schema' at given position
@@ -1005,6 +1046,22 @@
       return this;
     },
 
+    /**
+     * Remove 'schema' at given position
+     * @private
+     * @param {Number} start selection start
+     * @param {Number} end selection end
+     * @param {Number} schema
+     * @returns {fabric.Text} thisArg
+     * @chainable
+     */
+    _resetScript: function(start, end, schema) {
+      var loc = this.get2DCursorLocation(start, true),
+          fontSize = this.getValueOfPropertyAt(loc.lineIndex, loc.charIndex, 'fontSize'),
+          style = { fontSize: fontSize / schema.size, deltaY: schema.baseline };
+      this.setSelectionStyles(style, start, end);
+      return this;
+    },
     /**
      * @private
      * @param {Object} prevStyle

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -731,6 +731,50 @@
     assert.equal(text.styles[0][2].fontSize, styleFontSize * schema.size, 'character 2: fontSize has been decreased');
     assert.equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * schema.baseline, 'character 2: deltaY has been increased');
   });
+  
+  QUnit.test('text unsuperscript', function(assert) {
+    var text = new fabric.Text('xxx', { styles: {
+      0: { 0: { stroke: 'black', fill: 'blue' }, 1:  { fill: 'blue' }, 2:  { fontSize: 4, deltaY: 20 }}
+    } });
+    assert.ok(typeof text.unsetSuperscript === 'function');
+
+    var size = text.fontSize;
+    var schema = text.unsuperscript;
+    var styleFontSize = text.styles[0][2].fontSize;
+    var styleDeltaY = text.styles[0][2].deltaY;
+    text.unsetSuperscript(1, 2).unsetSuperscript(2, 3);
+
+    assert.equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize is not set');
+    assert.equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
+
+    assert.equal(text.styles[0][1].fontSize, size / schema.size, 'character 1: fontSize has been set');
+    assert.equal(text.styles[0][1].deltaY, schema.baseline, 'character 1: deltaY has been set');
+
+    assert.equal(text.styles[0][2].fontSize, styleFontSize / schema.size, 'character 2: fontSize has been decreased');
+    assert.equal(text.styles[0][2].deltaY, schema.baseline, 'character 2: deltaY has been decreased');
+  });
+
+  QUnit.test('text unsubscript', function(assert) {
+    var text = new fabric.Text('xxx', { styles: {
+      0: { 0: { stroke: 'black', fill: 'blue' }, 1:  { fill: 'blue' }, 2:  { fontSize: 4, deltaY: 20 }}
+    } });
+    assert.ok(typeof text.unsetSubscript === 'function');
+
+    var size = text.fontSize;
+    var schema = text.unsubscript;
+    var styleFontSize = text.styles[0][2].fontSize;
+    var styleDeltaY = text.styles[0][2].deltaY;
+    text.unsetSubscript(1,2).unsetSubscript(2,3);
+
+    assert.equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize is not set');
+    assert.equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
+
+    assert.equal(text.styles[0][1].fontSize, size / schema.size, 'character 1: fontSize has been set');
+    assert.equal(text.styles[0][1].deltaY, schema.baseline, 'character 1: deltaY has been set');
+
+    assert.equal(text.styles[0][2].fontSize, styleFontSize / schema.size, 'character 2: fontSize has been decreased');
+    assert.equal(text.styles[0][2].deltaY, schema.baseline, 'character 2: deltaY has been increased');
+  });
 
   QUnit.test('getHeightOfLine measures height of aline', function(assert) {
     var text = new fabric.Text('xxx\n');

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -731,7 +731,7 @@
     assert.equal(text.styles[0][2].fontSize, styleFontSize * schema.size, 'character 2: fontSize has been decreased');
     assert.equal(text.styles[0][2].deltaY, styleDeltaY + styleFontSize * schema.baseline, 'character 2: deltaY has been increased');
   });
-  
+
   QUnit.test('text unsuperscript', function(assert) {
     var text = new fabric.Text('xxx', { styles: {
       0: { 0: { stroke: 'black', fill: 'blue' }, 1:  { fill: 'blue' }, 2:  { fontSize: 4, deltaY: 20 }}
@@ -741,7 +741,7 @@
     var size = text.fontSize;
     var schema = text.unsuperscript;
     var styleFontSize = text.styles[0][2].fontSize;
-    var styleDeltaY = text.styles[0][2].deltaY;
+    text.setSuperscript(1, 2).setSuperscript(2, 3);
     text.unsetSuperscript(1, 2).unsetSuperscript(2, 3);
 
     assert.equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize is not set');
@@ -763,7 +763,7 @@
     var size = text.fontSize;
     var schema = text.unsubscript;
     var styleFontSize = text.styles[0][2].fontSize;
-    var styleDeltaY = text.styles[0][2].deltaY;
+    text.setSubscript(1,2).setSubscript(2,3);
     text.unsetSubscript(1,2).unsetSubscript(2,3);
 
     assert.equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize is not set');

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -747,10 +747,10 @@
     assert.equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize is not set');
     assert.equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
 
-    assert.equal(text.styles[0][1].fontSize, size / schema.size, 'character 1: fontSize has been set');
+    assert.equal(text.styles[0][1].fontSize, size, 'character 1: fontSize has been set');
     assert.equal(text.styles[0][1].deltaY, schema.baseline, 'character 1: deltaY has been set');
 
-    assert.equal(text.styles[0][2].fontSize, styleFontSize / schema.size, 'character 2: fontSize has been decreased');
+    assert.equal(text.styles[0][2].fontSize, styleFontSize, 'character 2: fontSize has been decreased');
     assert.equal(text.styles[0][2].deltaY, schema.baseline, 'character 2: deltaY has been decreased');
   });
 
@@ -769,10 +769,10 @@
     assert.equal(text.styles[0][0].fontSize, undefined, 'character 0: fontSize is not set');
     assert.equal(text.styles[0][0].deltaY, undefined, 'character 0: deltaY is not set');
 
-    assert.equal(text.styles[0][1].fontSize, size / schema.size, 'character 1: fontSize has been set');
+    assert.equal(text.styles[0][1].fontSize, size, 'character 1: fontSize has been set');
     assert.equal(text.styles[0][1].deltaY, schema.baseline, 'character 1: deltaY has been set');
 
-    assert.equal(text.styles[0][2].fontSize, styleFontSize / schema.size, 'character 2: fontSize has been decreased');
+    assert.equal(text.styles[0][2].fontSize, styleFontSize, 'character 2: fontSize has been decreased');
     assert.equal(text.styles[0][2].deltaY, schema.baseline, 'character 2: deltaY has been increased');
   });
 


### PR DESCRIPTION
As per current implementation there is no way to unsubscript or unsuperscript which is equally important as subscript and superscript. So added support for the same. 
