### PR TITLE
Added requestRenderAllBound

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -61,6 +61,7 @@
     initialize: function(el, options) {
       options || (options = { });
       this.renderAndResetBound = this.renderAndReset.bind(this);
+      this.requestRenderAllBound = this.requestRenderAll.bind(this);
       this._initStatic(el, options);
       this._initInteractive();
       this._createCacheCanvas();


### PR DESCRIPTION
As `requestRenderAllBound` is undefined in `_initStatic` method of `fabric.Canvas` class `initialize` method. Here is [jsfiddle](https://jsfiddle.net/durga598/utaodqwm/).