### PR TITLE
Fix repository URL of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fabric/fabric.js"
+    "url": "https://github.com/fabricjs/fabric.js"
   },
   "bugs": {
-    "url": "https://github.com/fabric/fabric.js/issues"
+    "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Changed the URL to prevent the repository URL of https://www.npmjs.com/package/fabric from becoming dead link.