### PR TITLE
Issue-5185: Ensure fabric.Image exists

### DIFF
--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -20420,6 +20420,7 @@ function copyGLTo2DPutImageData(gl, pipelineState) {
  * @tutorial {@link http://fabricjs.com/fabric-intro-part-2#image_filters}
  * @see {@link http://fabricjs.com/image-filters|ImageFilters demo}
  */
+fabric.Image = fabric.Image || { };
 fabric.Image.filters = fabric.Image.filters || { };
 
 /**


### PR DESCRIPTION
This just ensues that `fabric.Image` exists before setting `fabric.Image.filters`. Simply appeases the typescript gods in strict mode and is harmless to existing js.