### PR TITLE
text shadow with underline

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -451,8 +451,8 @@
     _render: function(ctx) {
       this._setTextStyles(ctx);
       this._renderTextLinesBackground(ctx);
-      this._renderTextDecoration(ctx, 'underline');
       this._renderText(ctx);
+      this._renderTextDecoration(ctx, 'underline');
       this._renderTextDecoration(ctx, 'overline');
       this._renderTextDecoration(ctx, 'linethrough');
     },


### PR DESCRIPTION
Text shadow not working with underline while `objectcaching` is false. #5196