### PR TITLE
avoid run selection logic on mouseup for clicks

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -359,7 +359,7 @@
         shouldRender = transform.actionPerformed;
       }
 
-      if (target || !isClick) {
+      if (!isClick) {
         this._maybeGroupObjects(e);
         shouldRender || (shouldRender = this._shouldRender(target));
       }


### PR DESCRIPTION
Run the grouping logic just in case of selection drags.
The mouseup click should not generate selections

close #5203