### PR TITLE
Avoid enter editing if there is another active object on the canvas

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -620,7 +620,7 @@
       }
       this._handleEvent(e, 'down');
       // we must renderAll so that we update the visuals
-      shouldRender && this.requestRenderAll();
+      (shouldRender || shouldGroup) && this.requestRenderAll();
     },
 
     /**

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -139,6 +139,15 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       return;
     }
 
+    if (this.canvas) {
+      if (this.canvas._activeObject !== this) {
+        // avoid running this logic when there is an active object
+        // this because is possible with shift click and fast clicks,
+        // to rapidly deselect and reselect this object and trigger an enterEdit
+        return;
+      }
+    }
+
     if (this.__lastSelected && !this.__corner) {
       this.selected = false;
       this.__lastSelected = false;

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -140,7 +140,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     }
 
     if (this.canvas) {
-      if (this.canvas._activeObject !== this) {
+      var currentActive = this.canvas._activeObject;
+      if (currentActive && currentActive !== this) {
         // avoid running this logic when there is an active object
         // this because is possible with shift click and fast clicks,
         // to rapidly deselect and reselect this object and trigger an enterEdit

--- a/test/unit/itext_click_behaviour.js
+++ b/test/unit/itext_click_behaviour.js
@@ -61,6 +61,7 @@
     iText.renderCursorOrSelection = function() {};
     assert.equal(iText.isEditing, false, 'iText not editing');
     iText.canvas = canvas;
+    canvas._activeObject = null;
     iText.selected = true;
     iText.__lastSelected = true;
     iText.mouseUpHandler({ e: {} });

--- a/test/unit/itext_click_behaviour.js
+++ b/test/unit/itext_click_behaviour.js
@@ -68,6 +68,19 @@
     assert.equal(iText.isEditing, true, 'iText entered editing');
     iText.exitEditing();
   });
+  QUnit.test('_mouseUpHandler on a selected object does enter edit if there is an activeObject', function(assert) {
+    var iText = new fabric.IText('test');
+    iText.initDelayedCursor = function() {};
+    iText.renderCursorOrSelection = function() {};
+    assert.equal(iText.isEditing, false, 'iText not editing');
+    iText.canvas = canvas;
+    canvas._activeObject = new fabric.IText('test2');
+    iText.selected = true;
+    iText.__lastSelected = true;
+    iText.mouseUpHandler({ e: {} });
+    assert.equal(iText.isEditing, false, 'iText did not enter editing');
+    iText.exitEditing();
+  });
   QUnit.test('_mouseUpHandler on a selected text in a group DOES NOT enter edit', function(assert) {
     var iText = new fabric.IText('test');
     iText.initDelayedCursor = function() {};


### PR DESCRIPTION
This is a refinement for issue #5152 that  was fixed but only partially.

Closes #5152