### PR TITLE
Fix clipPath in node.js error #5260

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -697,7 +697,8 @@
     descendants.filter(function(el) {
       return el.nodeName.replace('svg:', '') === 'clipPath';
     }).forEach(function(el) {
-      clipPaths[el.id] = fabric.util.toArray(el.getElementsByTagName('*')).filter(function(el) {
+      var id = el.getAttribute('id');
+      clipPaths[id] = fabric.util.toArray(el.getElementsByTagName('*')).filter(function(el) {
         return fabric.svgValidTagNamesRegEx.test(el.nodeName.replace('svg:', ''));
       });
     });


### PR DESCRIPTION
changed clipPaths[el.id] to el.getAttribute('id') for better support node.js