### PR TITLE
fix toDataurl and zoom change

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1077,7 +1077,7 @@
       if (!this._cacheCanvas) {
         this._createCacheCanvas();
       }
-      if (this.isCacheDirty(false)) {
+      if (this.isCacheDirty()) {
         this.statefullCache && this.saveState({ propertySet: 'cacheProperties' });
         this.drawObject(this._cacheContext, options.forClipping);
         this.dirty = false;

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -931,13 +931,11 @@
         ctx.restore();
       }
       if (path) {
-        if (path.isCacheDirty()) {
-          // needed to setup a couple of variables
-          path.shouldCache();
-          path.canvas = this;
-          path._transformDone = true;
-          path.renderCache({ forClipping: true });
-        }
+        path.canvas = this;
+        // needed to setup a couple of variables
+        path.shouldCache();
+        path._transformDone = true;
+        path.renderCache({ forClipping: true });
         this.drawClipPathOnCanvas(ctx);
       }
       this._renderOverlay(ctx);
@@ -956,7 +954,7 @@
       ctx.save();
       ctx.transform(v[0], v[1], v[2], v[3], v[4], v[5]);
       // DEBUG: uncomment this line, comment the following
-      // ctx.globalAlpha = 0.4
+      // ctx.globalAlpha = 0.4;
       ctx.globalCompositeOperation = 'destination-in';
       path.transform(ctx);
       ctx.scale(1 / path.zoomX, 1 / path.zoomY);


### PR DESCRIPTION
There is a fundamental error in how we handle isCacheDirty.
CacheDirty can be used ONCE and then render, or the next evaluation will be often FALSE for zoom and size changes.

This fix #5271 and more bugs that no one reported yet.