### PR TITLE
enable image caching just in case

### DIFF
--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -485,6 +485,23 @@
       this._renderPaintInOrder(ctx);
     },
 
+    /**
+     * Decide if the object should cache or not. Create its own cache level
+     * objectCaching is a global flag, wins over everything
+     * needsItsOwnCache should be used when the object drawing method requires
+     * a cache step. None of the fabric classes requires it.
+     * Generally you do not cache objects in groups because the group outside is cached.
+     * This is the special image version where we would like to avoid caching where possible.
+     * Essentially images do not benefit from caching. They may require caching, and in that
+     * case we do it. Also caching an image usually ends in a loss of details.
+     * A full performance audit should be done.
+     * @return {Boolean}
+     */
+    shouldCache: function() {
+      this.ownCaching = this.objectCaching && this.needsItsOwnCache();
+      return this.ownCaching;
+    },
+
     _renderFill: function(ctx) {
       var w = this.width, h = this.height, sW = w * this._filterScalingX, sH = h * this._filterScalingY,
           x = -w / 2, y = -h / 2, elementToDraw = this._element;


### PR DESCRIPTION
Avoid caching images if is not necessary.
Image cache as always been disabled, we had to enable it for clipPath to work.
If a clipPath is not present, images will continue to be not cached, unless we find from a performance audit that we get benefits.