### PR TITLE
perPixelTargetFind not working in nested group.

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1158,6 +1158,7 @@
 
       var ignoreZoom = true,
           pointer = this.getPointer(e, ignoreZoom),
+          globalPointer = pointer,
           activeObject = this._activeObject,
           aObjects = this.getActiveObjects(),
           activeTarget, activeTargetSubs;
@@ -1167,7 +1168,7 @@
       // if active group just exits.
       this.targets = [];
 
-      if (aObjects.length > 1 && !skipGroup && activeObject === this._searchPossibleTargets([activeObject], pointer)) {
+      if (aObjects.length > 1 && !skipGroup && activeObject === this._searchPossibleTargets([activeObject], pointer, globalPointer)) {
         return activeObject;
       }
       // if we hit the corner of an activeObject, let's return that.
@@ -1175,7 +1176,7 @@
         return activeObject;
       }
       if (aObjects.length === 1 &&
-        activeObject === this._searchPossibleTargets([activeObject], pointer)) {
+        activeObject === this._searchPossibleTargets([activeObject], pointer, globalPointer)) {
         if (!this.preserveObjectStacking) {
           return activeObject;
         }
@@ -1185,7 +1186,7 @@
           this.targets = [];
         }
       }
-      var target = this._searchPossibleTargets(this._objects, pointer);
+      var target = this._searchPossibleTargets(this._objects, pointer, globalPointer);
       if (e[this.altSelectionKey] && target && activeTarget && target !== activeTarget) {
         target = activeTarget;
         this.targets = activeTargetSubs;
@@ -1196,13 +1197,14 @@
     /**
      * @private
      */
-    _checkTarget: function(pointer, obj) {
+    _checkTarget: function(pointer, obj, globalPointer) {
+      globalPointer = globalPointer || pointer;
       if (obj &&
           obj.visible &&
           obj.evented &&
           this.containsPoint(null, obj, pointer)){
         if ((this.perPixelTargetFind || obj.perPixelTargetFind) && !obj.isEditing) {
-          var isTransparent = this.isTargetTransparent(obj, pointer.x, pointer.y);
+          var isTransparent = this.isTargetTransparent(obj, globalPointer.x, globalPointer.y);
           if (!isTransparent) {
             return true;
           }
@@ -1216,18 +1218,18 @@
     /**
      * @private
      */
-    _searchPossibleTargets: function(objects, pointer) {
+    _searchPossibleTargets: function(objects, pointer, pointerOnCanvas) {
 
       // Cache all targets where their bounding box contains point.
       var target, i = objects.length, normalizedPointer, subTarget;
       // Do not check for currently grouped objects, since we check the parent group itself.
       // until we call this function specifically to search inside the activeGroup
       while (i--) {
-        if (this._checkTarget(pointer, objects[i])) {
+        if (this._checkTarget(pointer, objects[i], pointerOnCanvas)) {
           target = objects[i];
           if (target.subTargetCheck && target instanceof fabric.Group) {
             normalizedPointer = this._normalizePointer(target, pointer);
-            subTarget = this._searchPossibleTargets(target._objects, normalizedPointer);
+            subTarget = this._searchPossibleTargets(target._objects, normalizedPointer, pointerOnCanvas);
             subTarget && this.targets.push(subTarget);
           }
           break;

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1158,7 +1158,6 @@
 
       var ignoreZoom = true,
           pointer = this.getPointer(e, ignoreZoom),
-          globalPointer = pointer,
           activeObject = this._activeObject,
           aObjects = this.getActiveObjects(),
           activeTarget, activeTargetSubs;
@@ -1170,7 +1169,7 @@
 
       if (aObjects.length > 1 &&
         !skipGroup &&
-        activeObject === this._searchPossibleTargets([activeObject],pointer, globalPointer)) {
+        activeObject === this._searchPossibleTargets([activeObject], pointer)) {
         return activeObject;
       }
       // if we hit the corner of an activeObject, let's return that.
@@ -1178,7 +1177,7 @@
         return activeObject;
       }
       if (aObjects.length === 1 &&
-        activeObject === this._searchPossibleTargets([activeObject], pointer, globalPointer)) {
+        activeObject === this._searchPossibleTargets([activeObject], pointer)) {
         if (!this.preserveObjectStacking) {
           return activeObject;
         }
@@ -1188,7 +1187,7 @@
           this.targets = [];
         }
       }
-      var target = this._searchPossibleTargets(this._objects, pointer, globalPointer);
+      var target = this._searchPossibleTargets(this._objects, pointer);
       if (e[this.altSelectionKey] && target && activeTarget && target !== activeTarget) {
         target = activeTarget;
         this.targets = activeTargetSubs;
@@ -1225,22 +1224,23 @@
      * Function used to search inside objects an object that contains pointer in bounding box or that contains pointerOnCanvas when painted
      * @param {Array} [objects] objects array to look into
      * @param {Object} [pointer] x,y object of point coordinates we want to check.
-     * @param {Object} [pointerOnCanvas] x,y object of point coordinates relative to canvas used to search per pixel target.
      * @return {fabric.Object} object that contains pointer
      * @private
      */
-    _searchPossibleTargets: function(objects, pointer, pointerOnCanvas) {
-      pointerOnCanvas = pointerOnCanvas || pointer;
+    _searchPossibleTargets: function(objects, pointer) {
       // Cache all targets where their bounding box contains point.
-      var target, i = objects.length, normalizedPointer, subTarget;
+      var target, i = objects.length, subTarget;
       // Do not check for currently grouped objects, since we check the parent group itself.
       // until we call this function specifically to search inside the activeGroup
       while (i--) {
-        if (this._checkTarget(pointer, objects[i], pointerOnCanvas)) {
+        var objToCheck = objects[i];
+        if (this._checkTarget(objToCheck.group && objToCheck.group.type !== 'activeSelection'
+          ? this._normalizePointer(objToCheck.group, pointer)
+          : pointer,
+        objToCheck, pointer)) {
           target = objects[i];
           if (target.subTargetCheck && target instanceof fabric.Group) {
-            normalizedPointer = this._normalizePointer(target, pointer);
-            subTarget = this._searchPossibleTargets(target._objects, normalizedPointer, pointerOnCanvas);
+            subTarget = this._searchPossibleTargets(target._objects, pointer);
             subTarget && this.targets.push(subTarget);
           }
           break;

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1197,6 +1197,11 @@
     },
 
     /**
+     * Checks point is inside the object.
+     * @param {Object} [pointer] x,y object of point coordinates we want to check.
+     * @param {fabric.Object} obj Object to test against
+     * @param {Object} [globalPointer] x,y object of point coordinates relative to canvas used to search per pixel target.
+     * @return {Boolean} true if point is contained within an area of given object
      * @private
      */
     _checkTarget: function(pointer, obj, globalPointer) {
@@ -1218,6 +1223,11 @@
     },
 
     /**
+     * Method that determines what object we are interacting with.
+     * @param {Array} objects array of objects to test agains.
+     * @param {Object} [pointer] x,y object of point coordinates we want to check.
+     * @param {Object} [pointerOnCanvas] x,y object of point coordinates relative to canvas used to search per pixel target.
+     * @return {fabric.Object} object that contains pointer
      * @private
      */
     _searchPossibleTargets: function(objects, pointer, pointerOnCanvas) {

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1223,8 +1223,8 @@
     },
 
     /**
-     * Method that determines what object we are interacting with.
-     * @param {Array} objects array of objects to test agains.
+     * Function used to search inside objects an object that contains pointer in bounding box or that contains pointerOnCanvas when painted
+     * @param {Array} [objects] objects array to look into
      * @param {Object} [pointer] x,y object of point coordinates we want to check.
      * @param {Object} [pointerOnCanvas] x,y object of point coordinates relative to canvas used to search per pixel target.
      * @return {fabric.Object} object that contains pointer

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1205,7 +1205,6 @@
      * @private
      */
     _checkTarget: function(pointer, obj, globalPointer) {
-      globalPointer = globalPointer || pointer;
       if (obj &&
           obj.visible &&
           obj.evented &&
@@ -1231,7 +1230,7 @@
      * @private
      */
     _searchPossibleTargets: function(objects, pointer, pointerOnCanvas) {
-
+      pointerOnCanvas = pointerOnCanvas || pointer;
       // Cache all targets where their bounding box contains point.
       var target, i = objects.length, normalizedPointer, subTarget;
       // Do not check for currently grouped objects, since we check the parent group itself.

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1167,9 +1167,7 @@
       // if active group just exits.
       this.targets = [];
 
-      if (aObjects.length > 1 &&
-        !skipGroup &&
-        activeObject === this._searchPossibleTargets([activeObject], pointer)) {
+      if (aObjects.length > 1 && !skipGroup && activeObject === this._searchPossibleTargets([activeObject], pointer)) {
         return activeObject;
       }
       // if we hit the corner of an activeObject, let's return that.

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1168,7 +1168,9 @@
       // if active group just exits.
       this.targets = [];
 
-      if (aObjects.length > 1 && !skipGroup && activeObject === this._searchPossibleTargets([activeObject], pointer, globalPointer)) {
+      if (aObjects.length > 1 &&
+        !skipGroup &&
+        activeObject === this._searchPossibleTargets([activeObject],pointer, globalPointer)) {
         return activeObject;
       }
       // if we hit the corner of an activeObject, let's return that.

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -792,30 +792,61 @@
 
   QUnit.test('findTarget with perPixelTargetFind in nested group', function(assert) {
     assert.ok(typeof canvas.findTarget === 'function');
-    var triangle = makeTriangle({ left: 0, top: 0 }),
-        target,
-        group1 = new fabric.Group([triangle], {
-          subTargetCheck: true
-        }),
-        group2 = new fabric.Group([group1], {
-          subTargetCheck: true
-        });
+    var triangle = makeTriangle({ left: 0, top: 0, width: 30, height: 30, fill: 'yellow' }),
+        circle = new fabric.Circle({ radius: 30, top: 0, left: 30, fill: 'blue' }),
+        circle2 = new fabric.Circle({ scaleX: 2, scaleY: 2, radius: 10, top: 120, left: -20, fill: 'purple' }),
+        rect = new fabric.Rect({ width: 100, height: 80, top: 50, left: 60, fill: 'green' }),
+        group1 = new fabric.Group([triangle, circle], { subTargetCheck: true }),
+        group2 = new fabric.Group([group1, circle2, rect], { subTargetCheck: true }),
+        group3 = new fabric.Group([group2], { subTargetCheck: true }),
+        target;
 
-    canvas.add(group2);
-    target = canvas.findTarget({
-      clientX: 5, clientY: 5
-    });
-    assert.equal(target, group2, 'Should return the triangle by bounding box');
+    canvas.add(group3);
     canvas.perPixelTargetFind = true;
     target = canvas.findTarget({
       clientX: 5, clientY: 5
     });
-    assert.equal(target, null, 'Should return null because of transparency checks');
+    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 1');
+    target = canvas.findTarget({
+      clientX: 21, clientY: 9
+    });
+    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 2');
+    target = canvas.findTarget({
+      clientX: 37, clientY: 7
+    });
+    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 3');
+    target = canvas.findTarget({
+      clientX: 89, clientY: 47
+    });
+    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 4');
+    target = canvas.findTarget({
+      clientX: 16, clientY: 122
+    });
+    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 4');
     target = canvas.findTarget({
       clientX: 15, clientY: 15
     });
-    assert.equal(target, group2, 'Should return the group2 now');
-    assert.equal(canvas.targets[0], group1, 'First subTargets should be group1');
+    assert.equal(target, group3, 'Should return the group3 now');
+    assert.equal(canvas.targets.length, 3, 'Subtargets length should be 3');
+    assert.equal(canvas.targets[0], triangle, 'The deepest target should be triangle');
+    target = canvas.findTarget({
+      clientX: 50, clientY: 20
+    });
+    assert.equal(target, group3, 'Should return the group3 now');
+    assert.equal(canvas.targets.length, 3, 'Subtargets length should be 3');
+    assert.equal(canvas.targets[0], circle, 'The deepest target should be circle');
+    target = canvas.findTarget({
+      clientX: 100, clientY: 90
+    });
+    assert.equal(target, group3, 'Should return the group3 now');
+    assert.equal(canvas.targets.length, 2, 'Subtargets length should be 2');
+    assert.equal(canvas.targets[0], rect, 'The deepest target should be rect');
+    target = canvas.findTarget({
+      clientX: 9, clientY: 145
+    });
+    assert.equal(target, group3, 'Should return the group3 now');
+    assert.equal(canvas.targets.length, 2, 'Subtargets length should be 2');
+    assert.equal(canvas.targets[0], circle2, 'The deepest target should be circle2');
     canvas.perPixelTargetFind = false;
     canvas.remove(triangle);
   });

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -806,23 +806,23 @@
     target = canvas.findTarget({
       clientX: 5, clientY: 5
     });
-    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 1');
+    assert.equal(target, null, 'Should return null because of transparency checks case 1');
     target = canvas.findTarget({
       clientX: 21, clientY: 9
     });
-    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 2');
+    assert.equal(target, null, 'Should return null because of transparency checks case 2');
     target = canvas.findTarget({
       clientX: 37, clientY: 7
     });
-    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 3');
+    assert.equal(target, null, 'Should return null because of transparency checks case 3');
     target = canvas.findTarget({
       clientX: 89, clientY: 47
     });
-    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 4');
+    assert.equal(target, null, 'Should return null because of transparency checks case 4');
     target = canvas.findTarget({
       clientX: 16, clientY: 122
     });
-    assert.equal(target, null, 'Should return null because of transparency checks on coordinates 4');
+    assert.equal(target, null, 'Should return null because of transparency checks case 5');
     target = canvas.findTarget({
       clientX: 15, clientY: 15
     });

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -848,7 +848,7 @@
     assert.equal(canvas.targets.length, 2, 'Subtargets length should be 2');
     assert.equal(canvas.targets[0], circle2, 'The deepest target should be circle2');
     canvas.perPixelTargetFind = false;
-    canvas.remove(triangle);
+    canvas.remove(group3);
   });
 
   QUnit.test('findTarget on activegroup', function(assert) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -790,6 +790,36 @@
     canvas.remove(triangle);
   });
 
+  QUnit.test('findTarget with perPixelTargetFind in nested group', function(assert) {
+    assert.ok(typeof canvas.findTarget === 'function');
+    var triangle = makeTriangle({ left: 0, top: 0 }),
+        target,
+        group1 = new fabric.Group([triangle], {
+          subTargetCheck: true
+        }),
+        group2 = new fabric.Group([group1], {
+          subTargetCheck: true
+        });
+
+    canvas.add(group2);
+    target = canvas.findTarget({
+      clientX: 5, clientY: 5
+    });
+    assert.equal(target, group2, 'Should return the triangle by bounding box');
+    canvas.perPixelTargetFind = true;
+    target = canvas.findTarget({
+      clientX: 5, clientY: 5
+    });
+    assert.equal(target, null, 'Should return null because of transparency checks');
+    target = canvas.findTarget({
+      clientX: 15, clientY: 15
+    });
+    assert.equal(target, group2, 'Should return the group2 now');
+    assert.equal(canvas.targets[0], group1, 'First subTargets should be group1');
+    canvas.perPixelTargetFind = false;
+    canvas.remove(triangle);
+  });
+
   QUnit.test('findTarget on activegroup', function(assert) {
     var rect1 = makeRect({ left: 0, top: 0 }), target;
     var rect2 = makeRect({ left: 20, top: 20 });

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -793,11 +793,13 @@
   QUnit.test('findTarget with perPixelTargetFind in nested group', function(assert) {
     assert.ok(typeof canvas.findTarget === 'function');
     var triangle = makeTriangle({ left: 0, top: 0, width: 30, height: 30, fill: 'yellow' }),
+        triangle2 = makeTriangle({ left: 100, top: 120, width: 30, height: 30, angle: 100, fill: 'pink' }),
         circle = new fabric.Circle({ radius: 30, top: 0, left: 30, fill: 'blue' }),
         circle2 = new fabric.Circle({ scaleX: 2, scaleY: 2, radius: 10, top: 120, left: -20, fill: 'purple' }),
         rect = new fabric.Rect({ width: 100, height: 80, top: 50, left: 60, fill: 'green' }),
-        group1 = new fabric.Group([triangle, circle], { subTargetCheck: true }),
-        group2 = new fabric.Group([group1, circle2, rect], { subTargetCheck: true }),
+        rect2 = new fabric.Rect({ width: 50, height: 30, top: 10, left: 110, fill: 'red', skewX: 40, skewY: 20 }),
+        group1 = new fabric.Group([triangle, circle, rect2], { subTargetCheck: true }),
+        group2 = new fabric.Group([group1, circle2, rect, triangle2], { subTargetCheck: true }),
         group3 = new fabric.Group([group2], { subTargetCheck: true }),
         target;
 
@@ -824,6 +826,14 @@
     });
     assert.equal(target, null, 'Should return null because of transparency checks case 5');
     target = canvas.findTarget({
+      clientX: 127, clientY: 37
+    });
+    assert.equal(target, null, 'Should return null because of transparency checks case 6');
+    target = canvas.findTarget({
+      clientX: 87, clientY: 139
+    });
+    assert.equal(target, null, 'Should return null because of transparency checks case 7');
+    target = canvas.findTarget({
       clientX: 15, clientY: 15
     });
     assert.equal(target, group3, 'Should return the group3 now');
@@ -836,6 +846,12 @@
     assert.equal(canvas.targets.length, 3, 'Subtargets length should be 3');
     assert.equal(canvas.targets[0], circle, 'The deepest target should be circle');
     target = canvas.findTarget({
+      clientX: 117, clientY: 16
+    });
+    assert.equal(target, group3, 'Should return the group3 now');
+    assert.equal(canvas.targets.length, 3, 'Subtargets length should be 2');
+    assert.equal(canvas.targets[0], rect2, 'The deepest target should be rect2');
+    target = canvas.findTarget({
       clientX: 100, clientY: 90
     });
     assert.equal(target, group3, 'Should return the group3 now');
@@ -847,6 +863,12 @@
     assert.equal(target, group3, 'Should return the group3 now');
     assert.equal(canvas.targets.length, 2, 'Subtargets length should be 2');
     assert.equal(canvas.targets[0], circle2, 'The deepest target should be circle2');
+    target = canvas.findTarget({
+      clientX: 66, clientY: 143
+    });
+    assert.equal(target, group3, 'Should return the group3 now');
+    assert.equal(canvas.targets.length, 2, 'Subtargets length should be 2');
+    assert.equal(canvas.targets[0], triangle2, 'The deepest target should be triangle2');
     canvas.perPixelTargetFind = false;
     canvas.remove(group3);
   });


### PR DESCRIPTION
perPixelTargetFind property is not working with object in nested group. When I replace isTargetTransparent methods params with pointer relative to canvas, everything works fine.