### PR TITLE
Fix typo in resize_filter.class.js.

### DIFF
--- a/src/filters/resize_filter.class.js
+++ b/src/filters/resize_filter.class.js
@@ -31,7 +31,7 @@
     /**
      * Resize type
      * for webgl resizyType is just lanczos, for canvas2d can be:
-     * bilinear, hermite, sliceHacl, lanczos.
+     * bilinear, hermite, sliceHack, lanczos.
      * @param {String} resizeType
      * @default
      */


### PR DESCRIPTION
The `sliceHack` filter had a typo in the documentation; was referred to as `sliceHacl`.