### PR TITLE
fixed make xhr loading in ie11

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -464,7 +464,6 @@
    */
   function parseUseDirectives(doc) {
     var nodelist = _getMultipleNodes(doc, ['use', 'svg:use']), i = 0;
-
     while (nodelist.length && i < nodelist.length) {
       var el = nodelist[i],
           xlink = (el.getAttribute('xlink:href') || el.getAttribute('href')).substr(1),

--- a/src/util/dom_request.js
+++ b/src/util/dom_request.js
@@ -4,24 +4,6 @@
     return url + (/\?/.test(url) ? '&' : '?') + param;
   }
 
-  var makeXHR = (function() {
-    var factories = [
-      function() { return new fabric.window.XMLHttpRequest(); },
-      function() { return new ActiveXObject('Microsoft.XMLHTTP'); },
-      function() { return new ActiveXObject('Msxml2.XMLHTTP'); },
-      function() { return new ActiveXObject('Msxml2.XMLHTTP.3.0'); }
-    ];
-    for (var i = factories.length; i--; ) {
-      try {
-        var req = factories[i]();
-        if (req) {
-          return factories[i];
-        }
-      }
-      catch (err) { }
-    }
-  })();
-
   function emptyFn() { }
 
   /**
@@ -40,7 +22,7 @@
 
     var method = options.method ? options.method.toUpperCase() : 'GET',
         onComplete = options.onComplete || function() { },
-        xhr = makeXHR(),
+        xhr = new fabric.window.XMLHttpRequest(),
         body = options.body || options.parameters;
 
     /** @ignore */

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -491,7 +491,7 @@
      */
     groupSVGElements: function(elements, options, path) {
       var object;
-      if (elements.length === 1) {
+      if (elements && elements.length === 1) {
         return elements[0];
       }
       if (options) {


### PR DESCRIPTION
close #5214 #5304

All the supported browsers know how to handle an xhr object, no need of the special code.