### PR TITLE
removing docker from travis since we are not using it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 
-services:
-  - docker
-
 node_js:
   - "10"
 


### PR DESCRIPTION
I thought `serivces: docker` was needed to use a set of containers that would start up faster than full VM. I just misunderstood it, it looks like we are just running on standard VMs