### PR TITLE
clipPath for groups with fromJson

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -558,11 +558,12 @@
    */
   fabric.Group.fromObject = function(object, callback) {
     fabric.util.enlivenObjects(object.objects, function(enlivenedObjects) {
-      fabric.util.enlivenObjects([object.clipPath], function(enlivedClipPath) {
-        var options = fabric.util.object.clone(object, true);
-        options.clipPath = enlivedClipPath[0];
-        delete options.objects;
-        callback && callback(new fabric.Group(enlivenedObjects, options, true));
+      var options = fabric.util.object.clone(object, true);
+      delete options.objects;
+      fabric.util.enlivenObjects([options.clipPath], function(enlivedProps) {
+        options.clipPath = enlivedProps[0];
+        var group = new fabric.Group(enlivenedObjects, options, true)
+        callback && callback(group);
       });
     });
   };


### PR DESCRIPTION
Hi there,
In #5266 was just discussed and solved for the Image object. But also the Group object needs some love to be able to handle the new clipPath objects correctly, when loaded from JSON.
I ported the proposed solution for the Image class to the Group class. This pull request solved the issue for me with the groups who have a clipPath.
Anyways, thank you very much for the great work on this framework. I am following its development  quite long now and the switch to 2.X was a very nice thing to see. Great work!

