### PR TITLE
Fire "selection:changed" on click only if the selection is actually changed

### DIFF
--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -179,7 +179,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       this.selectionStart = newSelection;
       this.selectionEnd = newSelection;
     }
-    if (this.isEditing) {
+    if (this.isEditing && (start !== newSelection || end !== newSelection)) {
       this._fireSelectionChanged();
       this._updateTextarea();
     }


### PR DESCRIPTION
The library shouldn't fire "selection:changed" and don't need to update textarea if user is clicked on the same cursor position because the selection coordinates remain the same.

Test case http://jsfiddle.net/Da7SP/3383/

![](https://media.giphy.com/media/loM6MelEbvXL6AugEc/giphy.gif)