### PR TITLE
strokeUniform property

### DIFF
--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -592,8 +592,16 @@
       if (skewX === 0 && skewY === 0) {
         return { x: dimensions.x * this.scaleX, y: dimensions.y * this.scaleY };
       }
-      var dimX = dimensions.x / 2, dimY = dimensions.y / 2,
-          points = [
+      var dimX, dimY;
+      if (this.strokeUniform) {
+        dimX = this.width / 2;
+        dimY = this.width / 2;
+      }
+      else {
+        dimX = dimensions.x / 2;
+        dimY = dimensions.y / 2;
+      }
+      var points = [
             {
               x: -dimX,
               y: -dimY
@@ -616,7 +624,10 @@
         points[i] = fabric.util.transformPoint(points[i], transformMatrix);
       }
       bbox = fabric.util.makeBoundingBoxFromPoints(points);
-      return { x: bbox.width, y: bbox.height };
+      return this.strokeUniform ?
+        { x: bbox.width + this.strokeWidth, y: bbox.height + this.strokeWidth }
+        :
+        { x: bbox.width, y: bbox.height };
     },
 
     /*

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -595,7 +595,7 @@
       var dimX, dimY;
       if (this.strokeUniform) {
         dimX = this.width / 2;
-        dimY = this.width / 2;
+        dimY = this.height / 2;
       }
       else {
         dimX = dimensions.x / 2;

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -561,6 +561,16 @@
     noScaleCache:              true,
 
     /**
+     * When `false`, the stoke width will scale with the object.
+     * When `true`, the stroke will always match the exact pixel size entered for stroke width.
+     * default to false
+     * since 2.5.1
+     * @type Boolean
+     * @default false
+     */
+    strokeUniform:              false,
+
+    /**
      * When set to `true`, object's cache will be rerendered next render call.
      * since 1.7.0
      * @type Boolean
@@ -1323,6 +1333,9 @@
       else {
         alternative && alternative(ctx);
       }
+      if (this.strokeUniform) {
+        ctx.setLineDash(ctx.getLineDash().map(function(value) { return value * ctx.lineWidth; }));
+      }
     },
 
     /**
@@ -1460,6 +1473,9 @@
       }
 
       ctx.save();
+      if (this.strokeUniform) {
+        ctx.scale(1 / this.scaleX, 1 / this.scaleY);
+      }
       this._setLineDash(ctx, this.strokeDashArray, this._renderDashedStroke);
       this._applyPatternGradientTransform(ctx, this.stroke);
       ctx.stroke();

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -564,7 +564,9 @@
      * When `false`, the stoke width will scale with the object.
      * When `true`, the stroke will always match the exact pixel size entered for stroke width.
      * default to false
-     * since 2.5.1
+     * @since 2.6.0
+     * @type Boolean
+     * @default false
      * @type Boolean
      * @default false
      */


### PR DESCRIPTION
new Object property strokeUniform allows the stroke width to always stay the same width as object scales.

This code has the stroke staying uniform but I'm still doing something wrong with the bounding box as it's still growing and shrinking as if the stroke would be scaling.

![example5](https://user-images.githubusercontent.com/87616/50998652-1cd8ee80-14f6-11e9-820b-4a1ff6c32437.gif)
