### PR TITLE
fix bug in method Image.setSrc()

### DIFF
--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -383,7 +383,7 @@
       fabric.util.loadImage(src, function(img) {
         this.setElement(img, options);
         this._setWidthHeight();
-        callback(this);
+        callback && callback(this);
       }, this, options && options.crossOrigin);
       return this;
     },


### PR DESCRIPTION
In the document, the parameter `callback` in setSrc is optional.