### PR TITLE
Fix splitByGrapheme and circle ToSVG

### DIFF
--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -106,7 +106,7 @@
           '<path d="M ' + startX + ' ' + startY,
           ' A ' + this.radius + ' ' + this.radius,
           ' 0 ', +largeFlag + ' 1', ' ' + endX + ' ' + endY,
-          '"', 'COMMON_PARTS', ' />\n'
+          '" ', 'COMMON_PARTS', ' />\n'
         ];
       }
       return svgString;

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -68,7 +68,7 @@
      * Use this regular expression to split strings in breakable lines
      * @private
      */
-    _wordJoiners: /[ \t\r\u200B\u200C]/,
+    _wordJoiners: /[ \t\r]/,
 
     /**
      * Use this boolean property in order to split strings that have no white space concept.

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -127,7 +127,7 @@
           charCount++;
           realLineCount++;
         }
-        else if (this._reSpaceAndTab.test(textInfo.graphemeText[charCount]) && i > 0) {
+        else if (!this.graphemeSplit && this._reSpaceAndTab.test(textInfo.graphemeText[charCount]) && i > 0) {
           // this case deals with space's that are removed from end of lines when wrapping
           realLineCharCount++;
           charCount++;
@@ -349,7 +349,7 @@
           lineWidth += additionalSpace;
         }
 
-        if (!lineJustStarted) {
+        if (!lineJustStarted && !splitByGrapheme) {
           line.push(infix);
         }
         line = line.concat(word);

--- a/test/unit/circle.js
+++ b/test/unit/circle.js
@@ -150,8 +150,8 @@
     var circle = new fabric.Circle({ width: 100, height: 100, radius: 10, endAngle: Math.PI });
     var svg = circle.toSVG();
     var svgClipPath = circle.toClipPathSVG();
-    assert.equal(svg, '<g transform=\"matrix(1 0 0 1 10.5 10.5)\"  >\n<path d=\"M 10 0 A 10 10 0 0 1 -10 0\"style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"   />\n</g>\n');
-    assert.equal(svgClipPath, '\t<path d=\"M 10 0 A 10 10 0 0 1 -10 0\"transform=\"matrix(1 0 0 1 10.5 10.5)\"  />\n', 'half circle as clipPath');
+    assert.equal(svg, '<g transform=\"matrix(1 0 0 1 10.5 10.5)\"  >\n<path d=\"M 10 0 A 10 10 0 0 1 -10 0\" style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"   />\n</g>\n');
+    assert.equal(svgClipPath, '\t<path d=\"M 10 0 A 10 10 0 0 1 -10 0\" transform=\"matrix(1 0 0 1 10.5 10.5)\"  />\n', 'half circle as clipPath');
   });
 
   QUnit.test('fromElement', function(assert) {

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -131,7 +131,7 @@
     assert.equal(textbox.textLines[0], 'xa', 'first line match expectations spacing 800');
   });
   QUnit.test('wrapping with different things', function(assert) {
-    var textbox = new fabric.Textbox('xa\u200Bxb\u200Bxc\u200Cxd\u200Cxe ya yb id', {
+    var textbox = new fabric.Textbox('xa xb\txc\rxd xe ya yb id', {
       width: 16,
     });
     assert.equal(textbox.textLines[0], 'xa', '0 line match expectations');


### PR DESCRIPTION
Add a missing space to circle.toSVG
Correctly fix splitByGrapheme click calculation

close #5540