### PR TITLE
Fix for when toObjects is called on a canvas with a clipPath

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1177,7 +1177,7 @@
         objects: this._toObjects(methodName, propertiesToInclude),
       };
       if (clipPath) {
-        data.clipPath = this._toObjectMethod(clipPath, methodName, propertiesToInclude);
+        data.clipPath = this.clipPath;
       }
       extend(data, this.__serializeBgOverlay(methodName, propertiesToInclude));
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1177,7 +1177,7 @@
         objects: this._toObjects(methodName, propertiesToInclude),
       };
       if (clipPath) {
-        data.clipPath = this.clipPath;
+        data.clipPath = this._toObject(this.clipPath, methodName, propertiesToInclude);
       }
       extend(data, this.__serializeBgOverlay(methodName, propertiesToInclude));
 

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1297,7 +1297,42 @@
     var expectedObject = {
       'version': fabric.version,
       objects: canvasWithClipPath.getObjects(),
-      'clipPath': clipPath.toObject()
+      clipPath: {
+        type: 'rect',
+        version: fabric.version,
+        originX: 'left',
+        originY: 'top',
+        left: 0,
+        top: 0,
+        width: 10,
+        height: 10,
+        fill: 'rgb(0,0,0)',
+        stroke: null,
+        strokeWidth: 1,
+        strokeDashArray: null,
+        strokeLineCap: 'butt',
+        strokeDashOffset: 0,
+        strokeLineJoin: 'miter',
+        strokeMiterLimit: 4,
+        scaleX: 1,
+        scaleY: 1,
+        angle: 0,
+        flipX: false,
+        flipY: false,
+        opacity: 1,
+        shadow: null,
+        visible: true,
+        clipTo: null,
+        backgroundColor: '',
+        fillRule: 'nonzero',
+        paintFirst: 'fill',
+        globalCompositeOperation: 'source-over',
+        transformMatrix: null,
+        skewX: 0,
+        skewY: 0,
+        rx: 0,
+        ry: 0
+      }
     };
 
     assert.ok(typeof canvasWithClipPath.toObject === 'function');
@@ -1315,6 +1350,7 @@
       'version': fabric.version,
       objects: canvas.getObjects()
     };
+
     assert.deepEqual(expectedObject, canvas.toDatalessObject());
 
     var rect = makeRect();

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1290,6 +1290,22 @@
     assert.equal(canvas.toObject().objects[0].type, rect.type);
   });
 
+
+  QUnit.test('toObject with clipPath', function(assert) {
+    var canvasWithClipPath = new fabric.Canvas(null, { clipPath: new fabric.Rect() });
+    var expectedObject = {
+      'version': fabric.version,
+      objects: canvasWithClipPath.getObjects()
+    };
+    assert.ok(typeof canvasWithClipPath.toObject === 'function');
+    assert.deepEqual(expectedObject, canvasWithClipPath.toObject());
+
+    var rect = makeRect();
+    canvasWithClipPath.add(rect);
+
+    assert.equal(canvasWithClipPath.toObject().objects[0].type, rect.type);
+  });
+
   QUnit.test('toDatalessObject', function(assert) {
     assert.ok(typeof canvas.toDatalessObject === 'function');
     var expectedObject = {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1301,7 +1301,7 @@
     };
 
     assert.ok(typeof canvasWithClipPath.toObject === 'function');
-    assert.deepEqual(JSON.stringify(expectedObject), JSON.stringify(canvasWithClipPath.toObject()));
+    assert.deepEqual(expectedObject, canvasWithClipPath.toObject());
 
     var rect = makeRect();
     canvasWithClipPath.add(rect);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1292,13 +1292,16 @@
 
 
   QUnit.test('toObject with clipPath', function(assert) {
-    var canvasWithClipPath = new fabric.Canvas(null, { clipPath: new fabric.Rect() });
+    var clipPath = makeRect();
+    var canvasWithClipPath = new fabric.Canvas(null, { clipPath: clipPath });
     var expectedObject = {
       'version': fabric.version,
-      objects: canvasWithClipPath.getObjects()
+      objects: canvasWithClipPath.getObjects(),
+      'clipPath': clipPath.toObject()
     };
+    
     assert.ok(typeof canvasWithClipPath.toObject === 'function');
-    assert.deepEqual(expectedObject, canvasWithClipPath.toObject());
+    assert.deepEqual(JSON.stringify(expectedObject), JSON.stringify(canvasWithClipPath.toObject()));
 
     var rect = makeRect();
     canvasWithClipPath.add(rect);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1299,7 +1299,7 @@
       objects: canvasWithClipPath.getObjects(),
       'clipPath': clipPath.toObject()
     };
-    
+
     assert.ok(typeof canvasWithClipPath.toObject === 'function');
     assert.deepEqual(JSON.stringify(expectedObject), JSON.stringify(canvasWithClipPath.toObject()));
 


### PR DESCRIPTION
## Details

Regarding issue: https://github.com/fabricjs/fabric.js/issues/5549

### Bugs
* The private method `_toObjectMethod` is calling itself recursively if a clipPath is present on the root canvas.
* In addition to that, it is called with the first argument being the clipPath `klass` object itself, instead of the expected argument  `String` `methodName`, which breaks the subsequent to `toObject` method. The reason it breaks is because it's trying to find a method with `methodName`, but because it's an `object` it fails and throws an error.

### Fix
* remove the _seemingly redundant_ recursive call of `_toObjectMethod` and instead apply the clipPath to the scoped variable `data` if `clipPath` exists, and returns that instead. This results in the expected behaviour when applying a clipPath with no errors.