### PR TITLE
Update rect.class.js - fix issue with incorrect <rect> tags in SVG

### DIFF
--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -184,8 +184,8 @@
 
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
-	parsedAttributes.height  = parsedAttributes.height || 0;
-	parsedAttributes.width  = parsedAttributes.width || 0;
+    parsedAttributes.height  = parsedAttributes.height || 0;
+    parsedAttributes.width  = parsedAttributes.width || 0;
     var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
     rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
     callback(rect);

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -184,6 +184,8 @@
 
     parsedAttributes.left = parsedAttributes.left || 0;
     parsedAttributes.top  = parsedAttributes.top  || 0;
+	parsedAttributes.height  = parsedAttributes.height || 0;
+	parsedAttributes.width  = parsedAttributes.width || 0;
     var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
     rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
     callback(rect);


### PR DESCRIPTION
issue where svg containing `<rect>` tag missing height or width will have incorrect height or width (inherits from canvas height/width)

May also be fixable by changing the line where it extends from options, but this seems less dangerous.

image of issue.
![image](https://user-images.githubusercontent.com/48246135/54550444-eb701980-49a3-11e9-8962-8a9b8b6580c6.png)

malformed <rect> tag (note missing height)
`<rect x="171.5" y="289.63" width="94.59"  transform="translate(-140.68 239.31) rotate(-44.96)" fill="#F8485E" stroke="none"></rect>`