### PR TITLE
Add pressure property to fabric.util.getPointer

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1307,6 +1307,7 @@
       }
 
       var pointer = getPointer(e),
+          pressure = pointer.pressure,
           upperCanvasEl = this.upperCanvasEl,
           bounds = upperCanvasEl.getBoundingClientRect(),
           boundsWidth = bounds.width || 0,
@@ -1342,7 +1343,8 @@
 
       return {
         x: pointer.x * cssScale.width,
-        y: pointer.y * cssScale.height
+        y: pointer.y * cssScale.height,
+        pressure: pressure
       };
     },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1275,7 +1275,7 @@
         pointer,
         fabric.util.invertTransform(this.viewportTransform)
       );
-      if (typeof pointer.pressure !== "undefined") p.pressure = pointer.pressure;
+      if (typeof pointer.pressure !== 'undefined') {p.pressure = pointer.pressure;}
       return p;
     },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1267,14 +1267,16 @@
 
     /**
      * Returns pointer coordinates without the effect of the viewport
-     * @param {Object} pointer with "x" and "y" number values
-     * @return {Object} object with "x" and "y" number values
+     * @param {Object} pointer with "x", "y", and optional "pressure" number values
+     * @return {Object} object with "x", "y", and optional "pressure" number values
      */
     restorePointerVpt: function(pointer) {
-      return fabric.util.transformPoint(
+      var p = fabric.util.transformPoint(
         pointer,
         fabric.util.invertTransform(this.viewportTransform)
       );
+      if (typeof pointer.pressure !== "undefined") p.pressure = pointer.pressure;
+      return p;
     },
 
     /**

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -51,15 +51,22 @@
 
     addOrRemove: function(functor, eventjsFunctor) {
       functor(fabric.window, 'resize', this._onResize);
-      functor(this.upperCanvasEl, 'mousedown', this._onMouseDown);
-      functor(this.upperCanvasEl, 'mousemove', this._onMouseMove, addEventOptions);
-      functor(this.upperCanvasEl, 'mouseout', this._onMouseOut);
-      functor(this.upperCanvasEl, 'mouseenter', this._onMouseEnter);
+      if (typeof window.PointerEvent !== 'undefined') {
+        functor(this.upperCanvasEl, 'pointerdown', this._onMouseDown);
+        functor(this.upperCanvasEl, 'pointermove', this._onMouseMove, addEventOptions);
+        functor(this.upperCanvasEl, 'pointerout', this._onMouseOut);
+        functor(this.upperCanvasEl, 'pointerenter', this._onMouseEnter);
+      } else {
+        functor(this.upperCanvasEl, 'mousedown', this._onMouseDown);
+        functor(this.upperCanvasEl, 'mousemove', this._onMouseMove, addEventOptions);
+        functor(this.upperCanvasEl, 'mouseout', this._onMouseOut);
+        functor(this.upperCanvasEl, 'mouseenter', this._onMouseEnter);
+        functor(this.upperCanvasEl, 'touchstart', this._onMouseDown, addEventOptions);
+        functor(this.upperCanvasEl, 'touchmove', this._onMouseMove, addEventOptions);
+      }
       functor(this.upperCanvasEl, 'wheel', this._onMouseWheel);
       functor(this.upperCanvasEl, 'contextmenu', this._onContextMenu);
       functor(this.upperCanvasEl, 'dblclick', this._onDoubleClick);
-      functor(this.upperCanvasEl, 'touchstart', this._onMouseDown, addEventOptions);
-      functor(this.upperCanvasEl, 'touchmove', this._onMouseMove, addEventOptions);
       functor(this.upperCanvasEl, 'dragover', this._onDragOver);
       functor(this.upperCanvasEl, 'dragenter', this._onDragEnter);
       functor(this.upperCanvasEl, 'dragleave', this._onDragLeave);

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -56,7 +56,8 @@
         functor(this.upperCanvasEl, 'pointermove', this._onMouseMove, addEventOptions);
         functor(this.upperCanvasEl, 'pointerout', this._onMouseOut);
         functor(this.upperCanvasEl, 'pointerenter', this._onMouseEnter);
-      } else {
+      }
+      else {
         functor(this.upperCanvasEl, 'mousedown', this._onMouseDown);
         functor(this.upperCanvasEl, 'mousemove', this._onMouseMove, addEventOptions);
         functor(this.upperCanvasEl, 'mouseout', this._onMouseOut);

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -51,7 +51,7 @@
 
     addOrRemove: function(functor, eventjsFunctor) {
       functor(fabric.window, 'resize', this._onResize);
-      if (typeof window.PointerEvent !== 'undefined') {
+      if (fabric.window && fabric.window.PointerEvent) {
         functor(this.upperCanvasEl, 'pointerdown', this._onMouseDown);
         functor(this.upperCanvasEl, 'pointermove', this._onMouseMove, addEventOptions);
         functor(this.upperCanvasEl, 'pointerout', this._onMouseOut);

--- a/src/util/dom_event.js
+++ b/src/util/dom_event.js
@@ -184,7 +184,7 @@
   fabric.util.removeListener = removeListener;
 
   /**
-   * Cross-browser wrapper for getting event's coordinates
+   * Cross-browser wrapper for getting event's coordinates and pressure
    * @memberOf fabric.util
    * @param {Event} event Event object
    */
@@ -197,7 +197,8 @@
         scroll = fabric.util.getScrollLeftTop(element);
     return {
       x: pointerX(event) + scroll.left,
-      y: pointerY(event) + scroll.top
+      y: pointerY(event) + scroll.top,
+      pressure: pressure(event)
     };
   }
 
@@ -207,6 +208,19 @@
 
       pointerY = function(event) {
         return event.clientY;
+      },
+
+      pressure = function(ev) {
+        // TouchEvent
+        if (ev.touches && ev.touches.length > 0) {
+          return ev.touches[0].force;
+        }
+        // MouseEvent, PointerEvent (ev.pointerType: "mouse")
+        if (ev.pointerType === "mouse" || typeof ev.pressure !== "number") {
+          return 0.5;
+        }
+        // PointerEvent (ev.pointerType: pen" | "touch")
+        return ev.pressure;
       };
 
   function _getPointer(event, pageProp, clientProp) {

--- a/src/util/dom_event.js
+++ b/src/util/dom_event.js
@@ -216,7 +216,7 @@
           return ev.touches[0].force;
         }
         // MouseEvent, PointerEvent (ev.pointerType: "mouse")
-        if (ev.pointerType === "mouse" || typeof ev.pressure !== "number") {
+        if (ev.pointerType === 'mouse' || typeof ev.pressure !== 'number') {
           return 0.5;
         }
         // PointerEvent (ev.pointerType: pen" | "touch")


### PR DESCRIPTION
I am interested in adding pressure support to fabric.js, and as its first step, this pull request allows custom `BaseBrush` subclasses to access pressure data.

To do so, this pull request implements the following three changes.

1. use `PointerEvent` instead of `MouseEvent` or `TouchEvent` whenever possible so that the pressure value can be retrieved from `PointerEvent.pressure`
2. as a fallback, retrieve the pressure value from `Touch.force`
3. update the return value of the `fabric.util.getPointer` method to include the pressure value

- `Touch`: https://developer.mozilla.org/en-US/docs/Web/API/Touch
- `PointerEvent`: https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent

With these small changes, I hope I can start implementing a custom brush (as well as a custom path) that shows strokes of changing widths according to the pressure values.