### PR TITLE
Fix splitByGrapheme selection

### DIFF
--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -197,7 +197,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         height = 0,
         charIndex = 0,
         lineIndex = 0,
-        missingNewlineOffset = this.splitByGrapheme ? 0 : 1,
         lineLeftOffset,
         line;
 
@@ -206,7 +205,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         height += this.getHeightOfLine(i) * this.scaleY;
         lineIndex = i;
         if (i > 0) {
-          charIndex += this._textLines[i - 1].length + missingNewlineOffset;
+          charIndex += this._textLines[i - 1].length + this.missingNewlineOffset(i);
         }
       }
       else {

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -197,6 +197,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         height = 0,
         charIndex = 0,
         lineIndex = 0,
+        missingNewlineOffset = this.splitByGrapheme ? 0 : 1,
         lineLeftOffset,
         line;
 
@@ -205,7 +206,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         height += this.getHeightOfLine(i) * this.scaleY;
         lineIndex = i;
         if (i > 0) {
-          charIndex += this._textLines[i - 1].length + 1;
+          charIndex += this._textLines[i - 1].length + missingNewlineOffset;
         }
       }
       else {

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -295,9 +295,8 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     var charIndex = cursorLocation.charIndex,
         widthBeforeCursor = this._getWidthBeforeCursor(lineIndex, charIndex),
         indexOnOtherLine = this._getIndexOnLine(lineIndex + 1, widthBeforeCursor),
-        textAfterCursor = this._textLines[lineIndex].slice(charIndex),
-        missingNewlineOffset = this.splitByGrapheme ? 0 : 1;
-    return textAfterCursor.length + indexOnOtherLine + 1 + missingNewlineOffset;
+        textAfterCursor = this._textLines[lineIndex].slice(charIndex);
+    return textAfterCursor.length + indexOnOtherLine + 1 + this.missingNewlineOffset(lineIndex);
   },
 
   /**
@@ -333,9 +332,10 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         widthBeforeCursor = this._getWidthBeforeCursor(lineIndex, charIndex),
         indexOnOtherLine = this._getIndexOnLine(lineIndex - 1, widthBeforeCursor),
         textBeforeCursor = this._textLines[lineIndex].slice(0, charIndex),
-        missingNewlineOffset = this.splitByGrapheme ? 1 : 0;
+        missingNewlineOffset = this.missingNewlineOffset(lineIndex - 1);
     // return a negative offset
-    return -this._textLines[lineIndex - 1].length + indexOnOtherLine - textBeforeCursor.length + missingNewlineOffset;
+    return -this._textLines[lineIndex - 1].length
+     + indexOnOtherLine - textBeforeCursor.length + (1 - missingNewlineOffset);
   },
 
   /**

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -295,8 +295,9 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     var charIndex = cursorLocation.charIndex,
         widthBeforeCursor = this._getWidthBeforeCursor(lineIndex, charIndex),
         indexOnOtherLine = this._getIndexOnLine(lineIndex + 1, widthBeforeCursor),
-        textAfterCursor = this._textLines[lineIndex].slice(charIndex);
-    return textAfterCursor.length + indexOnOtherLine + 2;
+        textAfterCursor = this._textLines[lineIndex].slice(charIndex),
+        missingNewlineOffset = this.splitByGrapheme ? 0 : 1;
+    return textAfterCursor.length + indexOnOtherLine + 1 + missingNewlineOffset;
   },
 
   /**
@@ -331,9 +332,10 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     var charIndex = cursorLocation.charIndex,
         widthBeforeCursor = this._getWidthBeforeCursor(lineIndex, charIndex),
         indexOnOtherLine = this._getIndexOnLine(lineIndex - 1, widthBeforeCursor),
-        textBeforeCursor = this._textLines[lineIndex].slice(0, charIndex);
+        textBeforeCursor = this._textLines[lineIndex].slice(0, charIndex),
+        missingNewlineOffset = this.splitByGrapheme ? 1 : 0;
     // return a negative offset
-    return -this._textLines[lineIndex - 1].length + indexOnOtherLine - textBeforeCursor.length;
+    return -this._textLines[lineIndex - 1].length + indexOnOtherLine - textBeforeCursor.length + missingNewlineOffset;
   },
 
   /**

--- a/src/mixins/text_style.mixin.js
+++ b/src/mixins/text_style.mixin.js
@@ -166,8 +166,8 @@
       if (typeof selectionStart === 'undefined') {
         selectionStart = this.selectionStart;
       }
-      var lines = skipWrapping ? this._unwrappedTextLines : this._textLines;
-      var len = lines.length;
+      var lines = skipWrapping ? this._unwrappedTextLines : this._textLines,
+          len = lines.length, missingNewlineOffset = this.splitByGrapheme ? 0 : 1;
       for (var i = 0; i < len; i++) {
         if (selectionStart <= lines[i].length) {
           return {
@@ -175,7 +175,7 @@
             charIndex: selectionStart
           };
         }
-        selectionStart -= lines[i].length + 1;
+        selectionStart -= lines[i].length + missingNewlineOffset;
       }
       return {
         lineIndex: i - 1,

--- a/src/mixins/text_style.mixin.js
+++ b/src/mixins/text_style.mixin.js
@@ -147,7 +147,7 @@
       var loc = this.get2DCursorLocation(index);
 
       if (!this._getLineStyle(loc.lineIndex)) {
-        this._setLineStyle(loc.lineIndex, {});
+        this._setLineStyle(loc.lineIndex);
       }
 
       if (!this._getStyleDeclaration(loc.lineIndex, loc.charIndex)) {
@@ -295,19 +295,20 @@
 
     /**
      * @param {Number} lineIndex
+     * @return {Boolean} if the line exists or not
      * @private
      */
     _getLineStyle: function(lineIndex) {
-      return this.styles[lineIndex];
+      return !!this.styles[lineIndex];
     },
 
     /**
+     * Set the line style to an empty object so that is initialized
      * @param {Number} lineIndex
-     * @param {Object} style
      * @private
      */
-    _setLineStyle: function(lineIndex, style) {
-      this.styles[lineIndex] = style;
+    _setLineStyle: function(lineIndex) {
+      this.styles[lineIndex] = {};
     },
 
     /**

--- a/src/mixins/text_style.mixin.js
+++ b/src/mixins/text_style.mixin.js
@@ -167,7 +167,7 @@
         selectionStart = this.selectionStart;
       }
       var lines = skipWrapping ? this._unwrappedTextLines : this._textLines,
-          len = lines.length, missingNewlineOffset = this.splitByGrapheme ? 0 : 1;
+          len = lines.length;
       for (var i = 0; i < len; i++) {
         if (selectionStart <= lines[i].length) {
           return {
@@ -175,7 +175,7 @@
             charIndex: selectionStart
           };
         }
-        selectionStart -= lines[i].length + missingNewlineOffset;
+        selectionStart -= lines[i].length + this.missingNewlineOffset(i);
       }
       return {
         lineIndex: i - 1,

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -417,6 +417,16 @@
     },
 
     /**
+     * Detect if a line has a linebreak and so we need to account for it when moving
+     * and counting style.
+     * It return always for text and Itext.
+     * @return Number
+     */
+    missingNewlineOffset: function() {
+      return 1;
+    },
+
+    /**
      * Returns string representation of an instance
      * @return {String} String representation of text object
      */

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -391,6 +391,18 @@
     },
 
     /**
+     * Detect if a line has a linebreak and so we need to account for it when moving
+     * and counting style.
+     * @return Number
+     */
+    missingNewlineOffset: function(lineIndex) {
+      if (this.splitByGrapheme) {
+        return this.isEndOfWrapping(lineIndex) ? 1 : 0;
+      }
+      return 1;
+    },
+
+    /**
     * Gets lines of text to render in the Textbox. This function calculates
     * text wrapping on the fly every time it is called.
     * @param {String} text text to split

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -127,7 +127,7 @@
           charCount++;
           realLineCount++;
         }
-        else if (!this.graphemeSplit && this._reSpaceAndTab.test(textInfo.graphemeText[charCount]) && i > 0) {
+        else if (!this.splitByGrapheme && this._reSpaceAndTab.test(textInfo.graphemeText[charCount]) && i > 0) {
           // this case deals with space's that are removed from end of lines when wrapping
           realLineCharCount++;
           charCount++;

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -234,34 +234,27 @@
     },
 
     /**
-    * probably broken need a fix
+     * probably broken need a fix
+     * Returns the real style line that correspond to the wrapped lineIndex line
+     * Used just to verify if the line does exist or not.
      * @param {Number} lineIndex
+     * @returns {Boolean} if the line exists or not
      * @private
      */
     _getLineStyle: function(lineIndex) {
       var map = this._styleMap[lineIndex];
-      return this.styles[map.line];
+      return !!this.styles[map.line];
     },
 
     /**
-     * probably broken need a fix
+     * Set the line style to an empty object so that is initialized
      * @param {Number} lineIndex
      * @param {Object} style
      * @private
      */
-    _setLineStyle: function(lineIndex, style) {
+    _setLineStyle: function(lineIndex) {
       var map = this._styleMap[lineIndex];
-      this.styles[map.line] = style;
-    },
-
-    /**
-     * probably broken need a fix
-     * @param {Number} lineIndex
-     * @private
-     */
-    _deleteLineStyle: function(lineIndex) {
-      var map = this._styleMap[lineIndex];
-      delete this.styles[map.line];
+      this.styles[map.line] = {};
     },
 
     /**

--- a/test/unit/itext_key_behaviour.js
+++ b/test/unit/itext_key_behaviour.js
@@ -341,4 +341,11 @@
     assert.equal(iText.styles[2][0].fill, 'col5', 'style 2 0 has been inserted col5');
     assert.equal(iText.styles[2][1].fill, 'blue', 'style 2 1 has been inserted blue');
   });
+
+  QUnit.test('missingNewlineOffset', function(assert) {
+    var iText = new fabric.IText('由石墨\n分裂的石墨分\n裂\n由石墨分裂由石墨分裂的石\n墨分裂');
+
+    var offset = iText.missingNewlineOffset(0);
+    assert.equal(offset, 1, 'it returns always 1');
+  });
 })();

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -254,8 +254,8 @@
   });
 
   QUnit.test('get2DCursorLocation with splitByGrapheme', function(assert) {
-    var iText = new fabric.Textbox('由石墨分裂的石墨分裂由石墨分裂由石墨分裂的石墨分裂',
-      { width: 120, splitByGrapheme: true });
+    var iText = new fabric.Textbox('aaaaaaaaaaaaaaaaaaaaaaaa',
+      { width: 60, splitByGrapheme: true });
     var loc = iText.get2DCursorLocation();
 
     // [ [ '由', '石', '墨' ],

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -292,27 +292,27 @@
   });
 
   QUnit.test('missingNewlineOffset with splitByGrapheme', function(assert) {
-    var texbox = new fabric.Textbox('由石墨\n分裂的石墨分\n裂\n由石墨分裂由石墨分裂的石\n墨分裂',
-      { width: 160, splitByGrapheme: true });
+    var textbox = new fabric.Textbox('aaa\naaaaaa\na\naaaaaaaaaaaa\naaa',
+      { width: 80, splitByGrapheme: true });
 
-    // [ [ '由', '石', '墨' ],
-    //   [ '分', '裂', '的', '石' ],
-    //   [ '墨', '分' ],
-    //   [ '裂' ],
-    //   [ '由', '石', '墨', '分' ],
-    //   [ '裂', '由', '石', '墨' ],
-    //   [ '分', '裂', '的', '石' ],
-    //   [ '墨', '分', '裂' ] ]
+    // [ [ 'a', 'a', 'a' ],
+    //   [ 'a', 'a', 'a', 'a' ],
+    //   [ 'a', 'a' ],
+    //   [ 'a' ],
+    //   [ 'a', 'a', 'a', 'a' ],
+    //   [ 'a', 'a', 'a', 'a' ],
+    //   [ 'a', 'a', 'a', 'a' ],
+    //   [ 'a', 'a', 'a' ] ]
 
-    var offset = texbox.missingNewlineOffset(0);
+    var offset = textbox.missingNewlineOffset(0);
     assert.equal(offset, 1, 'line 0 is interrupted by a \n so has an offset of 1');
 
-    offset = texbox.missingNewlineOffset(1);
+    offset = textbox.missingNewlineOffset(1);
     assert.equal(offset, 0, 'line 1 is wrapped without a \n so it does have an extra char count');
   });
 
   QUnit.test('missingNewlineOffset with normal split', function(assert) {
-    var texbox = new fabric.Textbox('由石墨\n分裂的石墨分\n裂\n由石墨分裂由石墨分裂的石\n墨分裂',
+    var texbox = new fabric.Textbox('aaa\naaaaaa\na\naaaaaaaaaaaa\naaa',
       { width: 160 });
 
     var offset = texbox.missingNewlineOffset(0);


### PR DESCRIPTION
Add selection offsets to compensate for missing newlines in text.

close #5572 

Now selection is good, but text that contains new lines cannot yet be splitted with splitByGrapheme