### PR TITLE
Add enablePointerEvents to Canvas init option

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -50,11 +50,12 @@
     },
 
     addOrRemove: function(functor, eventjsFunctor) {
+      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
       functor(fabric.window, 'resize', this._onResize);
-      functor(this.upperCanvasEl, 'mousedown', this._onMouseDown);
-      functor(this.upperCanvasEl, 'mousemove', this._onMouseMove, addEventOptions);
-      functor(this.upperCanvasEl, 'mouseout', this._onMouseOut);
-      functor(this.upperCanvasEl, 'mouseenter', this._onMouseEnter);
+      functor(this.upperCanvasEl, eventTypePrefix + 'down', this._onMouseDown);
+      functor(this.upperCanvasEl, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
+      functor(this.upperCanvasEl, eventTypePrefix + 'out', this._onMouseOut);
+      functor(this.upperCanvasEl, eventTypePrefix + 'enter', this._onMouseEnter);
       functor(this.upperCanvasEl, 'wheel', this._onMouseWheel);
       functor(this.upperCanvasEl, 'contextmenu', this._onContextMenu);
       functor(this.upperCanvasEl, 'dblclick', this._onDoubleClick);
@@ -79,9 +80,10 @@
     removeListeners: function() {
       this.addOrRemove(removeListener, 'remove');
       // if you dispose on a mouseDown, before mouse up, you need to clean document to...
-      removeListener(fabric.document, 'mouseup', this._onMouseUp);
+      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      removeListener(fabric.document, eventTypePrefix + 'up', this._onMouseUp);
       removeListener(fabric.document, 'touchend', this._onMouseUp, addEventOptions);
-      removeListener(fabric.document, 'mousemove', this._onMouseMove, addEventOptions);
+      removeListener(fabric.document, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
       removeListener(fabric.document, 'touchmove', this._onMouseMove, addEventOptions);
     },
 
@@ -148,7 +150,8 @@
       var target = this._hoveredTarget;
       this.fire('mouse:out', { target: target, e: e });
       this._hoveredTarget = null;
-      target && target.fire('mouseout', { e: e });
+      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      target && target.fire(eventTypePrefix + 'out', { e: e });
       if (this._iTextInstances) {
         this._iTextInstances.forEach(function(obj) {
           if (obj.isEditing) {
@@ -239,16 +242,17 @@
       addListener(fabric.document, 'touchend', this._onMouseUp, addEventOptions);
       addListener(fabric.document, 'touchmove', this._onMouseMove, addEventOptions);
 
-      removeListener(this.upperCanvasEl, 'mousemove', this._onMouseMove, addEventOptions);
+      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      removeListener(this.upperCanvasEl, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
       removeListener(this.upperCanvasEl, 'touchmove', this._onMouseMove, addEventOptions);
 
       if (e.type === 'touchstart') {
         // Unbind mousedown to prevent double triggers from touch devices
-        removeListener(this.upperCanvasEl, 'mousedown', this._onMouseDown);
+        removeListener(this.upperCanvasEl, eventTypePrefix + 'down', this._onMouseDown);
       }
       else {
-        addListener(fabric.document, 'mouseup', this._onMouseUp);
-        addListener(fabric.document, 'mousemove', this._onMouseMove, addEventOptions);
+        addListener(fabric.document, eventTypePrefix + 'up', this._onMouseUp);
+        addListener(fabric.document, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
       }
     },
 
@@ -259,13 +263,14 @@
     _onMouseUp: function (e) {
       this.__onMouseUp(e);
       this._resetTransformEventData();
-      removeListener(fabric.document, 'mouseup', this._onMouseUp);
+      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      removeListener(fabric.document, eventTypePrefix + 'up', this._onMouseUp);
       removeListener(fabric.document, 'touchend', this._onMouseUp, addEventOptions);
 
-      removeListener(fabric.document, 'mousemove', this._onMouseMove, addEventOptions);
+      removeListener(fabric.document, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
       removeListener(fabric.document, 'touchmove', this._onMouseMove, addEventOptions);
 
-      addListener(this.upperCanvasEl, 'mousemove', this._onMouseMove, addEventOptions);
+      addListener(this.upperCanvasEl, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
       addListener(this.upperCanvasEl, 'touchmove', this._onMouseMove, addEventOptions);
 
       if (e.type === 'touchend') {
@@ -273,7 +278,7 @@
         // from touch devices
         var _this = this;
         setTimeout(function() {
-          addListener(_this.upperCanvasEl, 'mousedown', _this._onMouseDown);
+          addListener(_this.upperCanvasEl, eventTypePrefix + 'down', _this._onMouseDown);
         }, 400);
       }
     },
@@ -427,11 +432,12 @@
             pointer: this._pointer,
             absolutePointer: this._absolutePointer,
             transform: this._currentTransform
-          };
+          },
+          eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
       this.fire('mouse:' + eventType, options);
-      target && target.fire('mouse' + eventType, options);
+      target && target.fire(eventTypePrefix + eventType, options);
       for (var i = 0; i < targets.length; i++) {
-        targets[i].fire('mouse' + eventType, options);
+        targets[i].fire(eventTypePrefix + eventType, options);
       }
     },
 
@@ -715,12 +721,13 @@
      * @private
      */
     _fireOverOutEvents: function(target, e) {
+      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
       this.fireSyntheticInOutEvents(target, e, {
         targetName: '_hoveredTarget',
         canvasEvtOut: 'mouse:out',
-        evtOut: 'mouseout',
+        evtOut: eventTypePrefix + 'out',
         canvasEvtIn: 'mouse:over',
-        evtIn: 'mouseover',
+        evtIn: eventTypePrefix + 'over',
       });
     },
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -50,27 +50,28 @@
     },
 
     addOrRemove: function(functor, eventjsFunctor) {
-      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
+      var canvasElement = this.upperCanvasEl,
+          eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       functor(fabric.window, 'resize', this._onResize);
-      functor(this.upperCanvasEl, eventTypePrefix + 'down', this._onMouseDown);
-      functor(this.upperCanvasEl, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
-      functor(this.upperCanvasEl, eventTypePrefix + 'out', this._onMouseOut);
-      functor(this.upperCanvasEl, eventTypePrefix + 'enter', this._onMouseEnter);
-      functor(this.upperCanvasEl, 'wheel', this._onMouseWheel);
-      functor(this.upperCanvasEl, 'contextmenu', this._onContextMenu);
-      functor(this.upperCanvasEl, 'dblclick', this._onDoubleClick);
-      functor(this.upperCanvasEl, 'touchstart', this._onMouseDown, addEventOptions);
-      functor(this.upperCanvasEl, 'touchmove', this._onMouseMove, addEventOptions);
-      functor(this.upperCanvasEl, 'dragover', this._onDragOver);
-      functor(this.upperCanvasEl, 'dragenter', this._onDragEnter);
-      functor(this.upperCanvasEl, 'dragleave', this._onDragLeave);
-      functor(this.upperCanvasEl, 'drop', this._onDrop);
+      functor(canvasElement, eventTypePrefix + 'down', this._onMouseDown);
+      functor(canvasElement, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
+      functor(canvasElement, eventTypePrefix + 'out', this._onMouseOut);
+      functor(canvasElement, eventTypePrefix + 'enter', this._onMouseEnter);
+      functor(canvasElement, 'wheel', this._onMouseWheel);
+      functor(canvasElement, 'contextmenu', this._onContextMenu);
+      functor(canvasElement, 'dblclick', this._onDoubleClick);
+      functor(canvasElement, 'touchstart', this._onMouseDown, addEventOptions);
+      functor(canvasElement, 'touchmove', this._onMouseMove, addEventOptions);
+      functor(canvasElement, 'dragover', this._onDragOver);
+      functor(canvasElement, 'dragenter', this._onDragEnter);
+      functor(canvasElement, 'dragleave', this._onDragLeave);
+      functor(canvasElement, 'drop', this._onDrop);
       if (typeof eventjs !== 'undefined' && eventjsFunctor in eventjs) {
-        eventjs[eventjsFunctor](this.upperCanvasEl, 'gesture', this._onGesture);
-        eventjs[eventjsFunctor](this.upperCanvasEl, 'drag', this._onDrag);
-        eventjs[eventjsFunctor](this.upperCanvasEl, 'orientation', this._onOrientationChange);
-        eventjs[eventjsFunctor](this.upperCanvasEl, 'shake', this._onShake);
-        eventjs[eventjsFunctor](this.upperCanvasEl, 'longpress', this._onLongPress);
+        eventjs[eventjsFunctor](canvasElement, 'gesture', this._onGesture);
+        eventjs[eventjsFunctor](canvasElement, 'drag', this._onDrag);
+        eventjs[eventjsFunctor](canvasElement, 'orientation', this._onOrientationChange);
+        eventjs[eventjsFunctor](canvasElement, 'shake', this._onShake);
+        eventjs[eventjsFunctor](canvasElement, 'longpress', this._onLongPress);
       }
     },
 
@@ -242,13 +243,14 @@
       addListener(fabric.document, 'touchend', this._onMouseUp, addEventOptions);
       addListener(fabric.document, 'touchmove', this._onMouseMove, addEventOptions);
 
-      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
-      removeListener(this.upperCanvasEl, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
-      removeListener(this.upperCanvasEl, 'touchmove', this._onMouseMove, addEventOptions);
+      var canvasElement = this.upperCanvasEl,
+          eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
+      removeListener(canvasElement, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
+      removeListener(canvasElement, 'touchmove', this._onMouseMove, addEventOptions);
 
       if (e.type === 'touchstart') {
         // Unbind mousedown to prevent double triggers from touch devices
-        removeListener(this.upperCanvasEl, eventTypePrefix + 'down', this._onMouseDown);
+        removeListener(canvasElement, eventTypePrefix + 'down', this._onMouseDown);
       }
       else {
         addListener(fabric.document, eventTypePrefix + 'up', this._onMouseUp);
@@ -263,15 +265,17 @@
     _onMouseUp: function (e) {
       this.__onMouseUp(e);
       this._resetTransformEventData();
-      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
+      var canvasElement = this.upperCanvasEl,
+          eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
+
       removeListener(fabric.document, eventTypePrefix + 'up', this._onMouseUp);
       removeListener(fabric.document, 'touchend', this._onMouseUp, addEventOptions);
 
       removeListener(fabric.document, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
       removeListener(fabric.document, 'touchmove', this._onMouseMove, addEventOptions);
 
-      addListener(this.upperCanvasEl, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
-      addListener(this.upperCanvasEl, 'touchmove', this._onMouseMove, addEventOptions);
+      addListener(canvasElement, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
+      addListener(canvasElement, 'touchmove', this._onMouseMove, addEventOptions);
 
       if (e.type === 'touchend') {
         // Wait 400ms before rebinding mousedown to prevent double triggers

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -151,8 +151,7 @@
       var target = this._hoveredTarget;
       this.fire('mouse:out', { target: target, e: e });
       this._hoveredTarget = null;
-      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
-      target && target.fire(eventTypePrefix + 'out', { e: e });
+      target && target.fire('mouseout', { e: e });
       if (this._iTextInstances) {
         this._iTextInstances.forEach(function(obj) {
           if (obj.isEditing) {
@@ -436,12 +435,11 @@
             pointer: this._pointer,
             absolutePointer: this._absolutePointer,
             transform: this._currentTransform
-          },
-          eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
+          };
       this.fire('mouse:' + eventType, options);
-      target && target.fire(eventTypePrefix + eventType, options);
+      target && target.fire('mouse' + eventType, options);
       for (var i = 0; i < targets.length; i++) {
-        targets[i].fire(eventTypePrefix + eventType, options);
+        targets[i].fire('mouse' + eventType, options);
       }
     },
 
@@ -725,13 +723,12 @@
      * @private
      */
     _fireOverOutEvents: function(target, e) {
-      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       this.fireSyntheticInOutEvents(target, e, {
         targetName: '_hoveredTarget',
         canvasEvtOut: 'mouse:out',
-        evtOut: eventTypePrefix + 'out',
+        evtOut: 'mouseout',
         canvasEvtIn: 'mouse:over',
-        evtIn: eventTypePrefix + 'over',
+        evtIn: 'mouseover',
       });
     },
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -50,7 +50,7 @@
     },
 
     addOrRemove: function(functor, eventjsFunctor) {
-      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       functor(fabric.window, 'resize', this._onResize);
       functor(this.upperCanvasEl, eventTypePrefix + 'down', this._onMouseDown);
       functor(this.upperCanvasEl, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
@@ -80,7 +80,7 @@
     removeListeners: function() {
       this.addOrRemove(removeListener, 'remove');
       // if you dispose on a mouseDown, before mouse up, you need to clean document to...
-      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       removeListener(fabric.document, eventTypePrefix + 'up', this._onMouseUp);
       removeListener(fabric.document, 'touchend', this._onMouseUp, addEventOptions);
       removeListener(fabric.document, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
@@ -150,7 +150,7 @@
       var target = this._hoveredTarget;
       this.fire('mouse:out', { target: target, e: e });
       this._hoveredTarget = null;
-      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       target && target.fire(eventTypePrefix + 'out', { e: e });
       if (this._iTextInstances) {
         this._iTextInstances.forEach(function(obj) {
@@ -242,7 +242,7 @@
       addListener(fabric.document, 'touchend', this._onMouseUp, addEventOptions);
       addListener(fabric.document, 'touchmove', this._onMouseMove, addEventOptions);
 
-      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       removeListener(this.upperCanvasEl, eventTypePrefix + 'move', this._onMouseMove, addEventOptions);
       removeListener(this.upperCanvasEl, 'touchmove', this._onMouseMove, addEventOptions);
 
@@ -263,7 +263,7 @@
     _onMouseUp: function (e) {
       this.__onMouseUp(e);
       this._resetTransformEventData();
-      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       removeListener(fabric.document, eventTypePrefix + 'up', this._onMouseUp);
       removeListener(fabric.document, 'touchend', this._onMouseUp, addEventOptions);
 
@@ -433,7 +433,7 @@
             absolutePointer: this._absolutePointer,
             transform: this._currentTransform
           },
-          eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+          eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       this.fire('mouse:' + eventType, options);
       target && target.fire(eventTypePrefix + eventType, options);
       for (var i = 0; i < targets.length; i++) {
@@ -721,7 +721,7 @@
      * @private
      */
     _fireOverOutEvents: function(target, e) {
-      var eventTypePrefix = this.get('enablePointerEvents') ? 'pointer' : 'mouse';
+      var eventTypePrefix = this.enablePointerEvents ? 'pointer' : 'mouse';
       this.fireSyntheticInOutEvents(target, e, {
         targetName: '_hoveredTarget',
         canvasEvtOut: 'mouse:out',


### PR DESCRIPTION
In response to discussions in #5587, this PR adds `enablePointerEvents` option to the Canvas constructor.

When the option is enabled by `new Canvas(.., { enablePointerEvents: true })`, `PointerEvent` is used instead of `MouseEvent`.
The use of `PointerEvent` opens up the potential to retrieve pen pressure information and implement a pressure-sensitive brush.