### PR TITLE
added disableStyleCopyPaste property

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -115,6 +115,15 @@ fabric.charWidthsCache = { };
 fabric.textureSize = 2048;
 
 /**
+ * When 'true', style information is not retained when copy/pasting text, making
+ * pasted text use destination style.
+ * Defaults to 'false'.
+ * @type Boolean
+ * @default
+ */
+fabric.disableStyleCopyPaste = false;
+
+/**
  * Enable webgl for filtering picture is available
  * A filtering backend will be initialized, this will both take memory and
  * time since a default 2048x2048 canvas will be created for the gl context

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -239,7 +239,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     }
 
     fabric.copiedText = this.getSelectedText();
-    if(!this.disableStyleCopying) {
+    if (!this.disableStyleCopying) {
       fabric.copiedTextStyle = this.getSelectionStyles(this.selectionStart, this.selectionEnd, true);
     }
     this._copyDone = true;

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -239,7 +239,9 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     }
 
     fabric.copiedText = this.getSelectedText();
-    fabric.copiedTextStyle = this.getSelectionStyles(this.selectionStart, this.selectionEnd, true);
+    if(!this.disableStyleCopying) {
+      fabric.copiedTextStyle = this.getSelectionStyles(this.selectionStart, this.selectionEnd, true);
+    }
     this._copyDone = true;
   },
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -191,7 +191,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
       }
     }
     if (insertedText.length) {
-      if (fromPaste && insertedText.join('') === fabric.copiedText) {
+      if (fromPaste && insertedText.join('') === fabric.copiedText && !fabric.disableStyleCopyPaste) {
         this.insertNewStyleBlock(insertedText, this.selectionStart, fabric.copiedTextStyle);
       }
       else {

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -239,8 +239,11 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     }
 
     fabric.copiedText = this.getSelectedText();
-    if (!this.disableStyleCopying) {
+    if (!fabric.disableStyleCopyPaste) {
       fabric.copiedTextStyle = this.getSelectionStyles(this.selectionStart, this.selectionEnd, true);
+    }
+    else {
+      fabric.copiedTextStyle = null;
     }
     this._copyDone = true;
   },

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -216,6 +216,15 @@
     shadow:               null,
 
     /**
+     * When 'true', style information is not retained when copying text to the clipboard,
+     * making pasted text use destination style.
+     * Defaults to 'false'.
+     * @type Boolean
+     * @default
+     */
+    disableStyleCopying:  false,
+
+    /**
      * @private
      */
     _fontSizeFraction: 0.222,

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -216,15 +216,6 @@
     shadow:               null,
 
     /**
-     * When 'true', style information is not retained when copying text to the clipboard,
-     * making pasted text use destination style.
-     * Defaults to 'false'.
-     * @type Boolean
-     * @default
-     */
-    disableStyleCopying:  false,
-
-    /**
      * @private
      */
     _fontSizeFraction: 0.222,


### PR DESCRIPTION
Added a new property `disableStyleCopying` to the text class, as discussed in #4981. Enabling this property essentially turns of the default _Keep Source Formatting_ behavior of the existing copy paste functionality. Useful for applications where a single text style is desired for each text object.

@asturur, do you think we need any unit tests for this?