### PR TITLE
Consistent return in stopObserving() and fire() methods.

### DIFF
--- a/src/mixins/observable.mixin.js
+++ b/src/mixins/observable.mixin.js
@@ -60,7 +60,7 @@
    */
   function stopObserving(eventName, handler) {
     if (!this.__eventListeners) {
-      return;
+      return this;
     }
 
     // remove all key/value pairs (event name -> event handler)
@@ -93,12 +93,12 @@
    */
   function fire(eventName, options) {
     if (!this.__eventListeners) {
-      return;
+      return this;
     }
 
     var listenersForEvent = this.__eventListeners[eventName];
     if (!listenersForEvent) {
-      return;
+      return this;
     }
 
     for (var i = 0, len = listenersForEvent.length; i < len; i++) {


### PR DESCRIPTION
Consistent return in stopObserving() and fire().
Methods are declared to be chainable and always return this reference, but in some cases return undefined.