### PR TITLE
Fix aligning guidelines

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -1,7 +1,5 @@
 /**
  * Should objects be aligned by a bounding box?
- * [Bug] Scaled objects sometimes can not be aligned by edges
- *
  */
 function initAligningGuidelines(canvas) {
 

--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -34,8 +34,8 @@ function initAligningGuidelines(canvas) {
     ctx.lineWidth = aligningLineWidth;
     ctx.strokeStyle = aligningLineColor;
     ctx.beginPath();
-    ctx.moveTo(((x1+viewportTransform[4])*zoom), ((y1+viewportTransform[5])*zoom));
-    ctx.lineTo(((x2+viewportTransform[4])*zoom), ((y2+viewportTransform[5])*zoom));
+    ctx.moveTo(x1 * zoom + viewportTransform[4], y1 * zoom + viewportTransform[5]);
+    ctx.lineTo(x2 * zoom + viewportTransform[4], y2 * zoom + viewportTransform[5]);
     ctx.stroke();
     ctx.restore();
   }


### PR DESCRIPTION
Scaled objects sometimes were not aligned by edges and panning with zoom were drawing wrong guides, this fixes it