### PR TITLE
Add a config boolean to force putImageData when copying images back from gl.

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -179,6 +179,15 @@ fabric.boundsOfCurveCache = { };
  */
 fabric.cachesBoundsOfCurve = true;
 
+/**
+ * Skip performance testing of setupGLContext and force the use of putImageData that seems to be the one that works best on
+ * Chrome + old hardware. if your users are experiencing empty images after filtering you may try to force this to true
+ * this has to be set before instantiating the filtering backend ( before filtering the first image )
+ * @type Boolean
+ * @default false
+ */
+fabric.forceGLPutImageData = false;
+
 fabric.initFilterBackend = function() {
   if (fabric.enableGLFiltering && fabric.isWebglSupported && fabric.isWebglSupported(fabric.textureSize)) {
     console.log('max texture size: ' + fabric.maxTextureSize);

--- a/src/filters/webgl_backend.class.js
+++ b/src/filters/webgl_backend.class.js
@@ -92,8 +92,7 @@
      * putImageData is faster than drawImage for that specific operation.
      */
     chooseFastestCopyGLTo2DMethod: function(width, height) {
-      var canMeasurePerf = typeof window.performance !== 'undefined';
-      var canUseImageData;
+      var canMeasurePerf = typeof window.performance !== 'undefined', canUseImageData;
       try {
         new ImageData(1, 1);
         canUseImageData = true;
@@ -113,6 +112,11 @@
       var targetCanvas = fabric.util.createCanvasElement();
       // eslint-disable-next-line no-undef
       var imageBuffer = new ArrayBuffer(width * height * 4);
+      if (fabric.forceGLPutImageData) {
+        this.imageBuffer = imageBuffer;
+        this.copyGLTo2D = copyGLTo2DPutImageData;
+        return;
+      }
       var testContext = {
         imageBuffer: imageBuffer,
         destinationWidth: width,


### PR DESCRIPTION
close #5175

When using fabric + gl filtering some old hardware sometimes is returning transparent  textures.

When using putImageData this problem never happen, so we are adding a boolean to force the usage of that method even if it could be slightly less performant.