### PR TITLE
Hooks to allow overriding text align at a line level

### DIFF
--- a/src/mixins/itext.svg_export.js
+++ b/src/mixins/itext.svg_export.js
@@ -112,7 +112,7 @@
     _setSVGTextLineText: function(textSpans, lineIndex, textLeftOffset, textTopOffset) {
       // set proper line offset
       var lineHeight = this.getHeightOfLine(lineIndex),
-          isJustify = this.textAlign.indexOf('justify') !== -1,
+          isJustify = this._getLineTextAlign(lineIndex).indexOf('justify') !== -1,
           actualStyle,
           nextStyle,
           charsToRender = '',

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -406,7 +406,6 @@
 
       var selectionStart = this.inCompositionMode ? this.hiddenTextarea.selectionStart : this.selectionStart,
           selectionEnd = this.inCompositionMode ? this.hiddenTextarea.selectionEnd : this.selectionEnd,
-          isJustify = this.textAlign.indexOf('justify') !== -1,
           start = this.get2DCursorLocation(selectionStart),
           end = this.get2DCursorLocation(selectionEnd),
           startLine = start.lineIndex,
@@ -417,7 +416,8 @@
       for (var i = startLine; i <= endLine; i++) {
         var lineOffset = this._getLineLeftOffset(i) || 0,
             lineHeight = this.getHeightOfLine(i),
-            realLineHeight = 0, boxStart = 0, boxEnd = 0;
+            realLineHeight = 0, boxStart = 0, boxEnd = 0,
+            isJustify = this._getLineTextAlign(i).indexOf('justify') !== -1;
 
         if (i === startLine) {
           boxStart = this.__charBounds[startLine][startChar].left;

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -99,10 +99,8 @@
       if (this.dynamicMinWidth > this.width) {
         this._set('width', this.dynamicMinWidth);
       }
-      if (this.textAlign.indexOf('justify') !== -1) {
-        // once text is measured we need to make space fatter to make justified text.
-        this.enlargeSpaces();
-      }
+      // once text is measured we need to make space fatter to make justified text.
+      this.enlargeSpaces();
       // clear cache and re-calculate height
       this.height = this.calcTextHeight();
       this.saveState({ propertySet: '_dimensionAffectingProps' });

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -759,4 +759,16 @@
     assert.equal(fabric.charWidthsCache[text.fontFamily.toLowerCase()].normal_normal[zwc], 0, 'zwc is a 0 width char');
     assert.equal(box.kernedWidth, box2.kernedWidth, '2 measurements of the same string return the same number');
   });
+
+  QUnit.test('_getLineTextAlign returns textAlign', function(assert) {
+    var text = new fabric.Text('');
+    assert.equal(text._getLineTextAlign(), 'left');
+    assert.equal(text._getLineTextAlign(0), 'left');
+    assert.equal(text._getLineTextAlign(1), 'left');
+
+    text.textAlign = 'justify-right';
+    assert.equal(text._getLineTextAlign(), 'justify-right');
+    assert.equal(text._getLineTextAlign(0), 'justify-right');
+    assert.equal(text._getLineTextAlign(1), 'justify-right');
+  });
 })();


### PR DESCRIPTION
For my use case, I need to be able to change text alignment on a per line basis.
This PR creates a method called per line that consumers can override to return different text alignments for different lines. It satisfies my requirement, and should satisfy most similar requirements, without drastic changes to any fabric data structures. The default implementation does not change any fabric behavior (as evidenced by none of the tests breaking).
Thanks! Let me know if there is anything else you need!