### PR TITLE
Fixing onSelect being called when objects were not intersected

### DIFF
--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -139,8 +139,7 @@
             (allowIntersect && currentObject.containsPoint(selectionX1Y1)) ||
             (allowIntersect && currentObject.containsPoint(selectionX2Y2))
         ) {
-          
-            group.push(currentObject);
+          group.push(currentObject);
           // only add one object if it's a click
           if (isClick) {
             break;
@@ -148,7 +147,7 @@
         }
       }
 
-      if(group.length > 1) {
+      if (group.length > 1) {
         group = group.filter(function(object) {
           return !object.onSelect({ e: e });
         });

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -149,7 +149,9 @@
       }
 
       if(group.length > 1) {
-        group = group.filter((object) => !object.onSelect({ e: e }));
+        group = group.filter(function(object) {
+          return !object.onSelect({ e: e });
+        });
       }
 
       return group;

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -139,17 +139,17 @@
             (allowIntersect && currentObject.containsPoint(selectionX1Y1)) ||
             (allowIntersect && currentObject.containsPoint(selectionX2Y2))
         ) {
-          if(currentObject.onSelect({ e: e })) {
+          
             group.push(currentObject);
-          } else {
-            continue;
-          }
-
           // only add one object if it's a click
           if (isClick) {
             break;
           }
         }
+      }
+
+      if(group.length > 1) {
+        group = group.filter((object) => !object.onSelect({ e: e }));
       }
 
       return group;

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -130,7 +130,7 @@
       for (var i = this._objects.length; i--; ) {
         currentObject = this._objects[i];
 
-        if (!currentObject || !currentObject.selectable || !currentObject.visible || currentObject.onSelect({ e: e })) {
+        if (!currentObject || !currentObject.selectable || !currentObject.visible) {
           continue;
         }
 
@@ -139,7 +139,11 @@
             (allowIntersect && currentObject.containsPoint(selectionX1Y1)) ||
             (allowIntersect && currentObject.containsPoint(selectionX2Y2))
         ) {
-          group.push(currentObject);
+          if(currentObject.onSelect({ e: e })) {
+            group.push(currentObject);
+          } else {
+            continue;
+          }
 
           // only add one object if it's a click
           if (isClick) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -592,6 +592,53 @@
     assert.equal(collected[0], rect2, 'contains rect2 but not rect 1');
   });
 
+  QUnit.test('_collectObjects does not call onSelect on objects that are not intersected', function(assert) {
+    canvas.selectionFullyContained = false;
+    var rect1 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
+    var rect2 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 10 });
+    var onSelectRect1CallCount = 0;
+    var onSelectRect2CallCount = 0;
+    rect1.onSelect = function() {
+      onSelectRect1CallCount++;
+      return false;
+    };
+    rect2.onSelect = function() {
+      onSelectRect2CallCount++;
+      return false;
+    };
+    canvas.add(rect1, rect2);
+    // Intersects none
+    canvas._groupSelector = {
+      top: 1,
+      left: 1,
+      ex: 25,
+      ey: 25
+    };
+    canvas._collectObjects();
+    var onSelectCalls = onSelectRect1CallCount + onSelectRect2CallCount;
+    assert.equal(onSelectCalls, 0, 'none of the onSelect methods was called');
+    // Intersects one
+    canvas._groupSelector = {
+      top: 5,
+      left: 5,
+      ex: 0,
+      ey: 0
+    };
+    canvas._collectObjects();
+    assert.equal(onSelectRect1CallCount, 0, 'rect1 onSelect was not called. It will be called in _setActiveObject()');
+    assert.equal(onSelectRect2CallCount, 0, 'rect2 onSelect was not called');
+    // Intersects both
+    canvas._groupSelector = {
+      top: 5,
+      left: 15,
+      ex: 0,
+      ey: 0
+    };
+    canvas._collectObjects();
+    assert.equal(onSelectRect1CallCount, 1, 'rect1 onSelect was called');
+    assert.equal(onSelectRect2CallCount, 1, 'rect2 onSelect was called');
+  });
+
   QUnit.test('_shouldGroup return false if onSelect return true', function(assert) {
     var rect = new fabric.Rect();
     var rect2 = new fabric.Rect();


### PR DESCRIPTION
PR fixing the bug stated on the issue #5596

The onSelect method is only called after we determine that the multiselect intersects the object. If the onSelect returns 'false' we discard them from the group.

close #5596