### PR TITLE
fix load SVG with the broken image

### DIFF
--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -714,7 +714,7 @@
    */
   fabric.Image.fromURL = function(url, callback, imgOptions) {
     fabric.util.loadImage(url, function(img) {
-      callback && callback(new fabric.Image(img, imgOptions));
+      callback && callback(!img ? null : new fabric.Image(img, imgOptions));
     }, null, imgOptions && imgOptions.crossOrigin);
   };
 


### PR DESCRIPTION
If we try to load SVG with the broken image (ERR_CONNECTION_TIMED_OUT, not 404) it will be error