### PR TITLE
fix: Check HTMLDocument constructor exists first for IE10

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -10,9 +10,7 @@ else if (typeof define === 'function' && define.amd) {
 }
 /* _AMD_END_ */
 if (typeof document !== 'undefined' && typeof window !== 'undefined') {
-  var DocumentConstructor = typeof HTMLDocument !== 'undefined' ? HTMLDocument : Document;
-
-  if (document instanceof DocumentConstructor) {
+  if (document instanceof (typeof HTMLDocument !== 'undefined' ? HTMLDocument : Document)) {
     fabric.document = document;
   }
   else {

--- a/HEADER.js
+++ b/HEADER.js
@@ -10,7 +10,9 @@ else if (typeof define === 'function' && define.amd) {
 }
 /* _AMD_END_ */
 if (typeof document !== 'undefined' && typeof window !== 'undefined') {
-  if (document instanceof HTMLDocument) {
+  var DocumentConstructor = typeof HTMLDocument !== 'undefined' ? HTMLDocument : Document;
+
+  if (document instanceof DocumentConstructor) {
     fabric.document = document;
   }
   else {


### PR DESCRIPTION
## AS-IS
- IE10 is supported browser. But `HTMLDocument` constructor is not exists in IE10.
- `fabric.js` bundle file using `HTMLDocument` constructor for check `document` is instance of it.

## TO-BE
- Use `Document` constructor instead of `HTMLDocument` constructor if `HTMLDocument` is not exists in browser global variable.

## Resolution
- Check `HTMLDocument` exists first.
  - If not, Use `Document` for check `document` is instance of it.


ref: #5677