### PR TITLE
could we add validation on fabric.Image.fromObject

### DIFF
--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -437,6 +437,13 @@
     });
   });
 
+  QUnit.skip('fromOject validates object or throws error (before doing anything else)'), function(assert) {
+    // check src attribute presence
+    // validated src attribute is a string
+    // validate src attribute is a valid url
+    // validate none or either presence of [scaleX, scaleY] OR [width, height] BUT NOT BOTH. (ignoring any scaleX and scaleY which value is 1)
+  }
+
   QUnit.test('fromObject does not mutate data', function(assert) {
     var done = assert.async();
     assert.ok(typeof fabric.Image.fromObject === 'function');


### PR DESCRIPTION
This is an idea to be discussed and hopefully developped ahead to become a mergeable PR.

Our use case is server side (NodeJs) image building from stored json data.
For some reason, fabricJs silently fail to build expected image.
I found some of those potentials reasons.

The purpose of this PR is to

1. check validity of object before building image
2. handle unvalid cases to give feedback to dev

Is this ok for you @asturur ? Shall I go ehead with this PR ?

For point 1 : could you help listing most recurring error/mis used people get you know from issues.
For point 2: I guess we should throw errors and cath them else where... whats your opinion ?