### PR TITLE
Fix parsing number values using scientific notation w/ a capital E.

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -72,7 +72,7 @@ fabric.SHARED_ATTRIBUTES = [
  * Pixel per Inch as a default value set to 96. Can be changed for more realistic conversion.
  */
 fabric.DPI = 96;
-fabric.reNum = '(?:[-+]?(?:\\d+|\\d*\\.\\d+)(?:e[-+]?\\d+)?)';
+fabric.reNum = '(?:[-+]?(?:\\d+|\\d*\\.\\d+)(?:[eE][-+]?\\d+)?)';
 fabric.fontPaths = { };
 fabric.iMatrix = [1, 0, 0, 1, 0, 0];
 

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -246,7 +246,7 @@
     assert.ok(fabric.parsePointsAttribute);
 
     var element = fabric.document.createElement('polygon');
-    element.setAttribute('points', '10,  12           20 ,22,  -0.52,0.001 2.3e2,2.3e-2, 10,-1     ');
+    element.setAttribute('points', '10,  12           20 ,22,  -0.52,0.001 2.3e2,2.3E-2, 10,-1     ');
 
     var actualPoints = fabric.parsePointsAttribute(element.getAttribute('points'));
 
@@ -304,9 +304,9 @@
     parsedValue = fabric.parseTransformAttribute(element.getAttribute('transform'));
     assert.deepEqual(parsedValue, [1,1.3820043381762832,0,1,0,0]);
 
-    element.setAttribute('transform', 'matrix(1,2,3,4,5,6)');
+    element.setAttribute('transform', 'matrix(1,2,3.3,-4,5E1,6e-1)');
     parsedValue = fabric.parseTransformAttribute(element.getAttribute('transform'));
-    assert.deepEqual(parsedValue, [1,2,3,4,5,6]);
+    assert.deepEqual(parsedValue, [1,2,3.3,-4,50,0.6]);
 
     element.setAttribute('transform', 'translate(21,31) translate(11,22)');
     parsedValue = fabric.parseTransformAttribute(element.getAttribute('transform'));


### PR DESCRIPTION
Fixes parsing numbers like `1.2E3` → 1200 in `fabric.reNum`.

Per https://www.w3.org/TR/css-syntax-3/#number-token-diagram, either lowercase `e` or uppercase `E` can be used in scientific notation numbers. (That page is called "CSS Syntax" but the SVG spec at https://www.w3.org/TR/SVG/types.html#InterfaceSVGNumber delegates to that section of the CSS spec.)

I updated the existing tests for parsing `matrix` and `points`. `points` already worked fine because it uses `parseFloat` and not `fabric.reNum`, but the `matrix` test failed before fixing the regular expression.