### PR TITLE
Added deprecation warning for Object.transformMatrix

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -372,6 +372,12 @@
 
     /**
      * Transform matrix (similar to SVG's transform matrix)
+     * This property has been depreacted. Since caching and and qrDecompose this
+     * property can be handled with the standard top,left,scaleX,scaleY,angle and skewX.
+     * A documentation example on how to parse and merge a transformMatrix will be provided before
+     * completely removing it in fabric 4.0
+     * If you are starting a project now, DO NOT use it.
+     * @deprecated since 3.2.0
      * @type Array
      */
     transformMatrix:          null,


### PR DESCRIPTION
I was planning to remove this since long, i never deprecated it.

I do not even think this property works right now with caching and controls, and with the addition of qrDecompose is no more usefull for fabricJS internals.

Objects imported from SVG will probably carry a transformMatrix property for the brief time of parsing, that will be then deleted at the end of parse process.

But the property won't be render functional anymore