### PR TITLE
Create a script for publishing

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -1,0 +1,31 @@
+var cp = require('child_process');
+var path = require('path');
+var fs = require('fs');
+
+// eslint-disable-next-line no-undef
+var pkgPath = path.resolve(__dirname, './package.json');
+var pkgText = fs.readFileSync(pkgPath); // get original pkg text to restore it later
+var pkgObject = JSON.parse(pkgText); // parsed pkg to override its fields
+var args = process.argv.slice(2).join(' '); // args will be passed to npm publish (like --dry-run)
+
+// override package.json with updated fields
+fs.writeFileSync(
+  pkgPath,
+  JSON.stringify(Object.assign(pkgObject, {
+    optionalDependencies: {},
+    version: pkgObject.version + '-browser',
+  }), null, '\t')
+);
+
+// publish -browser version
+cp.execSync('npm publish ' + args);
+
+console.log('Browser package is published');
+
+// restore the original package.json contents
+fs.writeFileSync(pkgPath, pkgText);
+
+// publish the main version (the package is published "above" the -browser version)
+cp.execSync('npm publish ' + args);
+
+console.log('Main package is published');


### PR DESCRIPTION
The script temporarily overrides package.json contents with `optionalDependencies: {}` and `version: 'FABRIC_VERSION-browser'`, publishes it, restores the original package.json and publishes the main version. 
It can be run with `node publish` and it also supports original `npm publish` parameters: `node publish --dry-run`. 
The file is eslinted with .eslintrc.json. Closes #5735.