### PR TITLE
Update _fireSelectionEvents method

### DIFF
--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -10814,6 +10814,7 @@ fabric.PatternBrush = fabric.util.createClass(fabric.PencilBrush, /** @lends fab
       oldObjects.forEach(function(oldObject) {
         if (objects.indexOf(oldObject) === -1) {
           somethingChanged = true;
+          opt.object = oldObject;
           oldObject.fire('deselected', opt);
           removed.push(oldObject);
         }
@@ -10821,6 +10822,7 @@ fabric.PatternBrush = fabric.util.createClass(fabric.PencilBrush, /** @lends fab
       objects.forEach(function(object) {
         if (oldObjects.indexOf(object) === -1) {
           somethingChanged = true;
+          opt.object = object;
           object.fire('selected', opt);
           added.push(object);
         }


### PR DESCRIPTION
The object:selected and object:deselected events doesn't return the latest selected object and last selected object. Attaching the objects in 'opt' while returning the option will let the invoke function to get the returned object.
Before, calling 'selected' or 'deselected' returned the object in event.selected[i] and event.deselected[i]. But it was deleted soon after returning.
This patch will ensure that these events will return the last or latest selected object.