### PR TITLE
ISSUE 5814: Paths in path created not cleared properly when removing all objects.

### DIFF
--- a/src/brushes/pencil_brush.class.js
+++ b/src/brushes/pencil_brush.class.js
@@ -280,7 +280,7 @@
       var path = this.createPath(pathData);
       this.canvas.clearContext(this.canvas.contextTop);
       this.canvas.add(path);
-      this.canvas.renderAll();
+      this.canvas.requestRenderAll();
       path.setCoords();
       this._resetShadow();
 


### PR DESCRIPTION
Change renderAll in finalizePath for pencil brush to requestRenderAll to be in line with other brushes.
resolves 
Fixes #5814