### PR TITLE
Implemented `cornerRegionSize` option for objects' controls region size.

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -43,21 +43,44 @@
           continue;
         }
 
-        lines = this._getImageLines(this.oCoords[i].corner);
+        lines = fabric.util.object.clone(this._getImageLines(this.oCoords[i].corner), true);
+
+        var t = 'topline',
+            b = 'bottomline',
+            l = 'leftline',
+            r = 'rightline',
+            size = this.cornerRegionSize;
+
+        lines[t].d.x += size;
+        lines[t].o.x -= size;
+        lines[t].d.y += size;
+        lines[t].o.y += size;
+        lines[b].d.x += size;
+        lines[b].o.x -= size;
+        lines[b].d.y -= size;
+        lines[b].o.y -= size;
+        lines[l].d.x -= size;
+        lines[l].o.x -= size;
+        lines[l].d.y -= size;
+        lines[l].o.y += size;
+        lines[r].d.x += size;
+        lines[r].o.x += size;
+        lines[r].d.y += size;
+        lines[r].o.y -= size;
 
         // debugging
 
-        // canvas.contextTop.fillRect(lines.bottomline.d.x, lines.bottomline.d.y, 2, 2);
-        // canvas.contextTop.fillRect(lines.bottomline.o.x, lines.bottomline.o.y, 2, 2);
+        // canvas.getContext('2d').fillRect(lines.bottomline.d.x, lines.bottomline.d.y, 2, 2);
+        // canvas.getContext('2d').fillRect(lines.bottomline.o.x, lines.bottomline.o.y, 2, 2);
 
-        // canvas.contextTop.fillRect(lines.leftline.d.x, lines.leftline.d.y, 2, 2);
-        // canvas.contextTop.fillRect(lines.leftline.o.x, lines.leftline.o.y, 2, 2);
+        // canvas.getContext('2d').fillRect(lines.leftline.d.x, lines.leftline.d.y, 2, 2);
+        // canvas.getContext('2d').fillRect(lines.leftline.o.x, lines.leftline.o.y, 2, 2);
 
-        // canvas.contextTop.fillRect(lines.topline.d.x, lines.topline.d.y, 2, 2);
-        // canvas.contextTop.fillRect(lines.topline.o.x, lines.topline.o.y, 2, 2);
+        // canvas.getContext('2d').fillRect(lines.topline.d.x, lines.topline.d.y, 2, 2);
+        // canvas.getContext('2d').fillRect(lines.topline.o.x, lines.topline.o.y, 2, 2);
 
-        // canvas.contextTop.fillRect(lines.rightline.d.x, lines.rightline.d.y, 2, 2);
-        // canvas.contextTop.fillRect(lines.rightline.o.x, lines.rightline.o.y, 2, 2);
+        // canvas.getContext('2d').fillRect(lines.rightline.d.x, lines.rightline.d.y, 2, 2);
+        // canvas.getContext('2d').fillRect(lines.rightline.o.x, lines.rightline.o.y, 2, 2);
 
         xPoints = this._findCrossPoints({ x: ex, y: ey }, lines);
         if (xPoints !== 0 && xPoints % 2 === 1) {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -170,6 +170,13 @@
     cornerSize:               13,
 
     /**
+     * Size of object's controlling corners' touch/click region (in pixels)
+     * @type Number
+     * @default
+     */
+    cornerRegionSize:         0,
+
+    /**
      * When true, object's controlling corners are rendered as transparent inside (i.e. stroke instead of fill)
      * @type Boolean
      * @default


### PR DESCRIPTION
On touch devices it is really hard to resize/rotate objects with the corner controls. They need to be bigger, bug bigger corner controls look ugly.

This pull request introduces new option in `fabric.Object` called `cornerRegionSize` (default `0`). It adds (in px) extra invisible region around corner controls, so the clickable/touchable area is big enough while the controls can be kept small.