### PR TITLE
added font size to the font cache key

### DIFF
--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -1310,7 +1310,7 @@ fabric.CommonMethods = {
      * @memberOf fabric.util
      * @param  {Object} options
      * @param  {Number} [options.angle] angle in degrees
-     * @return {Number[]} transform matrix
+     * @return {Array[Number]} transform matrix
      */
     calcRotateMatrix: function(options) {
       if (!options.angle) {
@@ -1337,7 +1337,7 @@ fabric.CommonMethods = {
      * @param  {Boolean} [options.flipY]
      * @param  {Number} [options.skewX]
      * @param  {Number} [options.skewX]
-     * @return {Number[]} transform matrix
+     * @return {Array[Number]} transform matrix
      */
     calcDimensionsMatrix: function(options) {
       var scaleX = typeof options.scaleX === 'undefined' ? 1 : options.scaleX,
@@ -1382,7 +1382,7 @@ fabric.CommonMethods = {
      * @param  {Number} [options.skewX]
      * @param  {Number} [options.translateX]
      * @param  {Number} [options.translateY]
-     * @return {Number[]} transform matrix
+     * @return {Array[Number]} transform matrix
      */
     composeMatrix: function(options) {
       var matrix = [1, 0, 0, 1, options.translateX || 0, options.translateY || 0],
@@ -1405,7 +1405,7 @@ fabric.CommonMethods = {
      * @param  {Number} scaleX
      * @param  {Number} scaleY
      * @param  {Number} skewX
-     * @return {Number[]} transform matrix
+     * @return {Array[Number]} transform matrix
      */
     customTransformMatrix: function(scaleX, scaleY, skewX) {
       return fabric.util.composeMatrix({ scaleX: scaleX, scaleY: scaleY, skewX: skewX });
@@ -5788,7 +5788,7 @@ fabric.ElementsParser = function(elements, callback, options, reviver, parsingOp
      * Imported from svg gradients, is not applied with the current transform in the center.
      * Before this transform is applied, the origin point is at the top left corner of the object
      * plus the addition of offsetY and offsetX.
-     * @type Number[]
+     * @type Array[Number]
      * @default null
      */
     gradientTransform: null,
@@ -5798,15 +5798,14 @@ fabric.ElementsParser = function(elements, callback, options, reviver, parsingOp
      * If `pixels`, the number of coords are in the same unit of width / height.
      * If set as `percentage` the coords are still a number, but 1 means 100% of width
      * for the X and 100% of the height for the y. It can be bigger than 1 and negative.
-     * allowed values pixels or percentage.
-     * @type String
+     * @type String pixels || percentage
      * @default 'pixels'
      */
     gradientUnits: 'pixels',
 
     /**
-     * Gradient type linear or radial
-     * @type String
+     * Gradient type
+     * @type String linear || radial
      * @default 'pixels'
      */
     type: 'linear',
@@ -5818,7 +5817,7 @@ fabric.ElementsParser = function(elements, callback, options, reviver, parsingOp
      * @param {Object} [options.gradientUnits] gradient units
      * @param {Object} [options.offsetX] SVG import compatibility
      * @param {Object} [options.offsetY] SVG import compatibility
-     * @param {Object[]} options.colorStops contains the colorstops.
+     * @param {Array[Object]} options.colorStops contains the colorstops.
      * @param {Object} options.coords contains the coords of the gradient
      * @param {Number} [options.coords.x1] X coordiante of the first point for linear or of the focal point for radial
      * @param {Number} [options.coords.y1] Y coordiante of the first point for linear or of the focal point for radial
@@ -14562,7 +14561,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
      * @param {Function} [callback] Callback to invoke when image set as a pattern
      * @return {fabric.Object} thisArg
      * @chainable
-     * @deprecated since 3.5.0
      * @see {@link http://jsfiddle.net/fabricjs/QT3pa/|jsFiddle demo}
      * @example <caption>Set pattern</caption>
      * object.setPatternFill({
@@ -14583,7 +14581,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
      * @param {Number} [options.offsetY=0] Shadow vertical offset
      * @return {fabric.Object} thisArg
      * @chainable
-     * @deprecated since 3.5.0
      * @see {@link http://jsfiddle.net/fabricjs/7gvJG/|jsFiddle demo}
      * @example <caption>Set shadow with string notation</caption>
      * object.setShadow('2px 2px 10px rgba(0,0,0,0.2)');
@@ -14605,7 +14602,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
      * Sets "color" of an instance (alias of `set('fill', &hellip;)`)
      * @param {String} color Color value
      * @return {fabric.Object} thisArg
-     * @deprecated since 3.5.0
      * @chainable
      */
     setColor: function(color) {
@@ -20389,8 +20385,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     },
 
     /**
-     * needed to check if image needs resize
-     * @private
+     * @private, needed to check if image needs resize
      */
     _needsResize: function() {
       var scale = this.getTotalObjectScaling();
@@ -25309,7 +25304,7 @@ fabric.Image.filters.BaseFilter.fromObject = function(object, callback) {
         fabric.charWidthsCache[fontFamily] = { };
       }
       var cache = fabric.charWidthsCache[fontFamily],
-          cacheProp = decl.fontStyle.toLowerCase() + '_' + (decl.fontWeight + '') + '_'+( decl.fontSize + '').toLowerCase();
+          cacheProp = decl.fontStyle.toLowerCase() + '_' + (decl.fontWeight + '').toLowerCase();
       if (!cache[cacheProp]) {
         cache[cacheProp] = { };
       }

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -605,7 +605,7 @@
         fabric.charWidthsCache[fontFamily] = { };
       }
       var cache = fabric.charWidthsCache[fontFamily],
-          cacheProp = decl.fontStyle.toLowerCase() + '_' + (decl.fontWeight + '') + '_'+( decl.fontSize + '').toLowerCase();
+          cacheProp = `${decl.fontStyle.toLowerCase()}_${decl.fontWeight}_${decl.fontSize}`.toLowerCase();
       if (!cache[cacheProp]) {
         cache[cacheProp] = { };
       }

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -605,7 +605,7 @@
         fabric.charWidthsCache[fontFamily] = { };
       }
       var cache = fabric.charWidthsCache[fontFamily],
-          cacheProp = decl.fontStyle.toLowerCase() + '_' + (decl.fontWeight + '').toLowerCase();
+          cacheProp = decl.fontStyle.toLowerCase() + '_' + (decl.fontWeight + '') + '_'+( decl.fontSize + '').toLowerCase();
       if (!cache[cacheProp]) {
         cache[cacheProp] = { };
       }

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -752,11 +752,11 @@
   QUnit.test('_measureChar handles 0 width chars', function(assert) {
     fabric.charWidthsCache = {};
     var zwc =  '\u200b';
-    var text = new fabric.Text('');
+    var text = new fabric.Text('',{fontSize:10});
     var style = text.getCompleteStyleDeclaration(0, 0);
     var box = text._measureChar('a', style, zwc, style);
     var box2 = text._measureChar('a', style, zwc, style);
-    assert.equal(fabric.charWidthsCache[text.fontFamily.toLowerCase()].normal_normal[zwc], 0, 'zwc is a 0 width char');
+    assert.equal(fabric.charWidthsCache[text.fontFamily.toLowerCase()].normal_normal_10[zwc], 0, 'zwc is a 0 width char');
     assert.equal(box.kernedWidth, box2.kernedWidth, '2 measurements of the same string return the same number');
   });
 

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -396,12 +396,12 @@
     assert.equal(text.styles[0], undefined, 'the styles got empty and has been removed');
   });
 
-  QUnit.test('getFontCache works with fontWeight numbers', function(assert) {
-    var text = new fabric.Text('xxx', { fontWeight: 400 });
+  QUnit.test('getFontCache works with fontWeight and fontSize numbers', function(assert) {
+    var text = new fabric.Text('xxx', { fontWeight: 400 , fontSize:15});
     text.initDimensions();
     var cache = fabric.charWidthsCache[text.fontFamily.toLowerCase()];
-    var cacheProp = text.fontStyle + '_400';
-    assert.equal(cacheProp in cache, true, '400 is converted to string');
+    var cacheProp = text.fontStyle + '_400_15';
+    assert.equal(cacheProp in cache, true, 'fontWeight and fontSize converted to string');
   });
 
   QUnit.test('getFontCache is case insensitive', function(assert) {


### PR DESCRIPTION
Text boxes were not recalculating their width properly after changing the font size. This caused problems such as the text being cut short as it fell out of the text box. This was because the font cache was not updating when the font size was changed.