### PR TITLE
Fix uniform stroke rendering for objects in groups

### DIFF
--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -565,7 +565,7 @@
      * @return {Object} .y height dimension
      */
     _getNonTransformedDimensions: function() {
-      var strokeWidth = this.strokeUniform ? 0 : this.strokeWidth,
+      var strokeWidth = this.strokeWidth,
           w = this.width + strokeWidth,
           h = this.height + strokeWidth;
       return { x: w, y: h };

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -565,7 +565,7 @@
      * @return {Object} .y height dimension
      */
     _getNonTransformedDimensions: function() {
-      var strokeWidth = this.strokeWidth,
+      var strokeWidth = this.strokeUniform ? 0 : this.strokeWidth,
           w = this.width + strokeWidth,
           h = this.height + strokeWidth;
       return { x: w, y: h };

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -194,7 +194,7 @@
      */
     drawBordersInGroup: function(ctx, options, styleOverride) {
       styleOverride = styleOverride || {};
-      var p = this._getNonTransformedDimensions(),
+      var p = { x: options.width, y: options.height },
           matrix = fabric.util.composeMatrix({
             scaleX: options.scaleX,
             scaleY: options.scaleY,

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -202,8 +202,8 @@
           }),
           wh = fabric.util.transformPoint(p, matrix),
           strokeWidth = 1 / this.borderScaleFactor,
-          width = wh.x + strokeWidth,
-          height = wh.y + strokeWidth;
+          width = wh.x + strokeWidth / (this.strokeUniform ? options.scaleX : 1),
+          height = wh.y + strokeWidth / (this.strokeUniform ? options.scaleY : 1);
 
       ctx.save();
       this._setLineDash(ctx, styleOverride.borderDashArray || this.borderDashArray, null);

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1548,7 +1548,13 @@
 
       ctx.save();
       if (this.strokeUniform) {
-        ctx.scale(1 / this.scaleX, 1 / this.scaleY);
+        var scaleX = this.scaleX;
+        var scaleY = this.scaleY;
+        if (this.group) {
+          scaleX *= this.group.scaleX;
+          scaleY *= this.group.scaleY;
+        }
+        ctx.scale(1 / scaleX, 1 / scaleY);
       }
       this._setLineDash(ctx, this.strokeDashArray, this._renderDashedStroke);
       if (this.stroke.toLive && this.stroke.gradientUnits === 'percentage') {


### PR DESCRIPTION
Fixes the following object rendering issues when using the `strokeUniform: true` property:
- grouped object strokes are stretched after scaling the group despite setting the `strokeUniform` property (issue #5611),
- selection borders are too large for scaled child objects in a selected group (see attached image).
![border_bug](https://user-images.githubusercontent.com/2965511/68156268-ce488500-ff4b-11e9-8163-0f330da7421a.png)
close #5611