### PR TITLE
Fix dashed stroke rendering with strokeUniform property

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1381,9 +1381,6 @@
       else {
         alternative && alternative(ctx);
       }
-      if (this.strokeUniform) {
-        ctx.setLineDash(ctx.getLineDash().map(function(value) { return value * ctx.lineWidth; }));
-      }
     },
 
     /**


### PR DESCRIPTION
Fixes issue #5939.

I removed the code lines pointed by @asturur in the following comment:
https://github.com/fabricjs/fabric.js/issues/5939#issuecomment-549788287

It seems that the code was added to prevent "ugly" rendering of short dash array distances, however IMHO this should not be a feature of fabric.js - the user should be solely responsible for properly defining dash arrays. The rationale behind this is that unscaled objects should look the same, regardless of the `strokeUniform` property (see images below).

I used the following code for testing:
```js
canvas.add(new fabric.Rect({
    left: 10,
    top: 10,
    width: 300,
    height: 75,
    fill: '#00ff00',
    stroke: '#000000',
    strokeWidth: 5,
    strokeDashArray: [1, 1],
    strokeUniform: false
}));

canvas.add(new fabric.Rect({
    left: 10,
    top: 120,
    width: 300,
    height: 75,
    fill: '#ffff00',
    stroke: '#000000',
    strokeWidth: 5,
    strokeDashArray: [1, 1],
    strokeUniform: true
}));
```
For unmodified fabric.js code the test produces the following result:
![image](https://user-images.githubusercontent.com/2965511/68288264-5e89e580-0084-11ea-8770-784b39bffc83.png)
As you can see, the strokes look dramatically different.

After modifying the code, the result looks as follows:
![image](https://user-images.githubusercontent.com/2965511/68287836-aa885a80-0083-11ea-823c-3ad8ea2df0f5.png)
The strokes are now identical.