### PR TITLE
fix: sometimes active selector did not render when setActive

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1541,6 +1541,7 @@
       var currentActives = this.getActiveObjects();
       this._setActiveObject(object, e);
       this._fireSelectionEvents(currentActives, e);
+      this.renderAll();
       return this;
     },
 


### PR DESCRIPTION
the active selector did not render when I triggered the setActiveObject API by click a button outside canvas.