### PR TITLE
ISSUE-5969 Do not crash if style is null when checking if is empty

### DIFF
--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -163,9 +163,11 @@
      * @return {Boolean}
      */
     isEmptyStyles: function(lineIndex) {
-      var offset = 0, nextLineIndex = lineIndex + 1, nextOffset, obj, shouldLimit = false;
-      var map = this._styleMap[lineIndex];
-      var mapNextLine = this._styleMap[lineIndex + 1];
+      if (!this.styles) {
+        return true;
+      }
+      var offset = 0, nextLineIndex = lineIndex + 1, nextOffset, obj, shouldLimit = false,
+          map = this._styleMap[lineIndex], mapNextLine = this._styleMap[lineIndex + 1];
       if (map) {
         lineIndex = map.line;
         offset = map.offset;

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -139,6 +139,14 @@
     assert.equal(textbox.isEmptyStyles(1), true, 'style is empty at line 1');
   });
 
+  QUnit.test('isEmptyStyles does not crash on null styles', function(assert) {
+    var textbox = new fabric.Textbox('x x', { width: 5 });
+    textbox.styles = null;
+    assert.equal(textbox._textLines.length, 2, 'lines are wrapped');
+    assert.equal(textbox._unwrappedTextLines.length, 1, 'there is only one text line');
+    assert.equal(textbox.isEmptyStyles(1), true, 'style is empty');
+  });
+
   QUnit.test('isEmptyStyles alternate lines', function(assert) {
     var textbox = new fabric.Textbox('xa xb xc xd xe\nya yb', {
       width: 5,


### PR DESCRIPTION
close #5969 

Style should never be null, mostly an empty object.
But if it happen, the function should not crash.

