### PR TITLE
Fix a bug in the skewing logic

### DIFF
--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -573,8 +573,10 @@
 
     /*
      * Calculate object bounding box dimensions from its properties scale, skew.
-     * @param {Number} skewX, a value to override current skewX
-     * @param {Number} skewY, a value to override current skewY
+     * The skewX and skewY parameters are used in the skewing logic path and
+     * do not provide something useful to common use cases.
+     * @param {Number} [skewX], a value to override current skewX
+     * @param {Number} [skewY], a value to override current skewY
      * @private
      * @return {Object} .x width dimension
      * @return {Object} .y height dimension
@@ -624,8 +626,8 @@
           transformMatrix = fabric.util.calcDimensionsMatrix({
             scaleX: this.scaleX,
             scaleY: this.scaleY,
-            skewX: this.skewX,
-            skewY: this.skewY,
+            skewX: skewX,
+            skewY: skewY,
           }),
           bbox = fabric.util.makeBoundingBoxFromPoints(points, transformMatrix);
       return this._finalizeDimensions(bbox.width, bbox.height);

--- a/test/unit/object_geometry.js
+++ b/test/unit/object_geometry.js
@@ -882,4 +882,16 @@
     assert.equal(cObj.isPartiallyOnScreen(true), true, 'after zooming object is partially onScreen and offScreen');
   });
 
+  QUnit.test('_getTransformedDimensions', function(assert) {
+    var cObj = new fabric.Object({
+      left: 50, top: 50, width: 100, height: 100, strokeWidth: 2,
+      scaleX: 3, scaleY: 4, skewX: 45, skewY: 45,
+    });
+    var dim = cObj._getTransformedDimensions();
+    assert.equal(Math.round(dim.x), 918, 'width is 918');
+    assert.equal(dim.y, 816, 'height is 816');
+    var dim2 = cObj._getTransformedDimensions(0, 0);
+    assert.equal(dim2.x, 306, 'width without skew is 306');
+    assert.equal(dim2.y, 408, 'height without skew is 408');
+  });
 })();


### PR DESCRIPTION
Using always this.skewX and this.skewY we were not using the provided one in the arguments.
As a result, skewing an object with skewX and skewY was resulting in jumps.