### PR TITLE
feat(controls): visibility call fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [4.0.0-beta.2]
+
+fix: Control.getVisibility will always receive the fabric.Object argument.
+
+## [4.0.0-beta.1]
+
+breaking: All your old control code override will not work
+breaking: `uniScaleTransform` has been renamed in `uniformScaling`, meaning changed and  the default  value swapped. The behaviour is unchanged, but now the description and the name match.
+breaking: LockScalingFlip with the scaling flip behaviour are missing now, maybe reimplemented later.
+breaking: Object.lockUniScaling is removed. Alternatives to get the same identical functionality with less code are being evaluated.
+breaking: Canvas.onBeforeScaleRotate is removed, developers need to migrate to the event `before:transform’
+
+
 ## [3.6.1]
 - fix(gradient, text): ISSUE-6014 ISSUE-6077 support percentage gradient in text [#6090](https://github.com/fabricjs/fabric.js/pull/6090)
 - fix(filters): ISSUE-6072 convolution filter is off by one [#6088](https://github.com/fabricjs/fabric.js/pull/6088)

--- a/HEADER.js
+++ b/HEADER.js
@@ -1,6 +1,6 @@
 /*! Fabric.js Copyright 2008-2015, Printio (Juriy Zaytsev, Maxim Chernyak) */
 
-var fabric = fabric || { version: '3.6.1' };
+var fabric = fabric || { version: '4.0.0-beta.2' };
 if (typeof exports !== 'undefined') {
   exports.fabric = fabric;
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fabric",
   "description": "Object model for HTML5 canvas, and SVG-to-canvas parser. Backed by jsdom and node-canvas.",
   "homepage": "http://fabricjs.com/",
-  "version": "4.0.0-beta1",
+  "version": "4.0.0-beta.2",
   "author": "Juriy Zaytsev <kangax@gmail.com>",
   "contributors": [
     {

--- a/src/control.class.js
+++ b/src/control.class.js
@@ -156,7 +156,7 @@
      * @param {fabric.Object} object on which the control is displayed
      * @return {Boolean}
      */
-    getVisibility: function(/*fabricObject, name */) {
+    getVisibility: function(/*fabricObject */) {
       return this.visible;
     },
 
@@ -213,7 +213,7 @@
     */
     render: function(ctx, left, top, styleOverride, fabricObject) {
       styleOverride = styleOverride || {};
-      if (!this.getVisibility(fabricObject, this.name)) {
+      if (!this.getVisibility(fabricObject)) {
         return;
       }
       switch (styleOverride.cornerStyle || fabricObject.cornerStyle) {

--- a/src/control.class.js
+++ b/src/control.class.js
@@ -213,7 +213,7 @@
     */
     render: function(ctx, left, top, styleOverride, fabricObject) {
       styleOverride = styleOverride || {};
-      if (!this.getVisibility()) {
+      if (!this.getVisibility(fabricObject, this.name)) {
         return;
       }
       switch (styleOverride.cornerStyle || fabricObject.cornerStyle) {

--- a/src/controls.render.js
+++ b/src/controls.render.js
@@ -8,7 +8,7 @@
 
   function renderCircleControl (ctx, left, top, styleOverride, fabricObject) {
     styleOverride = styleOverride || {};
-    if (!this.getVisibility(fabricObject, this.name)) {
+    if (!this.getVisibility(fabricObject)) {
       return;
     }
     var size = styleOverride.cornerSize || fabricObject.cornerSize,
@@ -32,7 +32,7 @@
 
   function renderSquareControl(ctx, left, top, styleOverride, fabricObject) {
     styleOverride = styleOverride || {};
-    if (!this.getVisibility(fabricObject, this.name)) {
+    if (!this.getVisibility(fabricObject)) {
       return;
     }
     var size = styleOverride.cornerSize || fabricObject.cornerSize,

--- a/src/controls.render.js
+++ b/src/controls.render.js
@@ -8,7 +8,7 @@
 
   function renderCircleControl (ctx, left, top, styleOverride, fabricObject) {
     styleOverride = styleOverride || {};
-    if (!this.getVisibility()) {
+    if (!this.getVisibility(fabricObject, this.name)) {
       return;
     }
     var size = styleOverride.cornerSize || fabricObject.cornerSize,
@@ -32,7 +32,7 @@
 
   function renderSquareControl(ctx, left, top, styleOverride, fabricObject) {
     styleOverride = styleOverride || {};
-    if (!this.getVisibility()) {
+    if (!this.getVisibility(fabricObject, this.name)) {
       return;
     }
     var size = styleOverride.cornerSize || fabricObject.cornerSize,

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -459,7 +459,7 @@
           finalMatrix = multiplyMatrices(vpt, startMatrix),
           dim = this._getTransformedDimensions(),
           coords = {};
-      this.forEachControl(function(control, fabricObject, key) {
+      this.forEachControl(function(control, key, fabricObject) {
         coords[key] = control.positionHandler(dim, finalMatrix, fabricObject);
       });
 

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -193,7 +193,7 @@
           // in this moment, the ctx is centered on the object.
           // width and height of the above function are the size of the bbox.
           ctx.beginPath();
-          if (control.withConnection && control.getVisibility(fabricObject, key)) {
+          if (control.withConnection && control.getVisibility(fabricObject)) {
             // reset movement for each control
             shouldStroke = true;
             ctx.moveTo(control.x * width, control.y * height);
@@ -285,7 +285,7 @@
      * @returns {Boolean} true if the specified control is visible, false otherwise
      */
     isControlVisible: function(controlKey) {
-      return this.controls[controlKey] && this.controls[controlKey].getVisibility(this, controlKey);
+      return this.controls[controlKey] && this.controls[controlKey].getVisibility(this);
     },
 
     /**
@@ -332,7 +332,7 @@
     _getControlsVisibility: function() {
       var visibility = {};
       this.forEachControl(function(control, key, fabricObject) {
-        visibility[key] = control.getVisibility(fabricObject, key);
+        visibility[key] = control.getVisibility(fabricObject);
       });
       return visibility;
     },

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -62,7 +62,7 @@
      */
     forEachControl: function(fn) {
       for (var i in this.controls) {
-        fn(this.controls[i], this, i);
+        fn(this.controls[i], i, this);
       };
     },
 
@@ -189,11 +189,11 @@
       );
 
       if (hasControls) {
-        this.forEachControl(function(control) {
+        this.forEachControl(function(control, key, fabricObject) {
           // in this moment, the ctx is centered on the object.
           // width and height of the above function are the size of the bbox.
           ctx.beginPath();
-          if (control.withConnection && control.getVisibility()) {
+          if (control.withConnection && control.getVisibility(fabricObject, key)) {
             // reset movement for each control
             shouldStroke = true;
             ctx.moveTo(control.x * width, control.y * height);
@@ -331,7 +331,7 @@
      */
     _getControlsVisibility: function() {
       var visibility = {};
-      this.forEachControl(function(control, fabricObject, key) {
+      this.forEachControl(function(control, key, fabricObject) {
         visibility[key] = control.getVisibility(fabricObject, key);
       });
       return visibility;


### PR DESCRIPTION
The getVisibility call accepts as argument the instance of the object we are looking at and its name, we are not actually passing them in as of now.

Should name really be needed? the API should push people to write clean simple handlers and not handlers that do many things depending on the control they are.