### PR TITLE
fix(fabric.Group): willDrawShadow has to always take in account children items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [4.0.0-beta.4]
 
-fix(fabric.Group): will draw shadow will call parent method.
+fix(fabric.Group): will draw shadow will call parent method. [#6116](https://github.com/fabricjs/fabric.js/pull/6116)
 
 ## [4.0.0-beta.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## [4.0.0-beta.4]
+
+fix(fabric.Group): will draw shadow will call parent method.
+
 ## [4.0.0-beta.3]
 
-fix: control offset rendering code had extras `beginPath` that would clear all but not the last of them [#6114](https://github.com/fabricjs/fabric.js/pull/6114)
+fix(controls): control offset rendering code had extras `beginPath` that would clear all but not the last of them [#6114](https://github.com/fabricjs/fabric.js/pull/6114)
 
 ## [4.0.0-beta.2]
 
-fix: Control.getVisibility will always receive the fabric.Object argument.
+fix(controls): Control.getVisibility will always receive the fabric.Object argument.
 
 ## [4.0.0-beta.1]
 

--- a/HEADER.js
+++ b/HEADER.js
@@ -1,6 +1,6 @@
 /*! Fabric.js Copyright 2008-2015, Printio (Juriy Zaytsev, Maxim Chernyak) */
 
-var fabric = fabric || { version: '4.0.0-beta.3' };
+var fabric = fabric || { version: '4.0.0-beta.4' };
 if (typeof exports !== 'undefined') {
   exports.fabric = fabric;
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fabric",
   "description": "Object model for HTML5 canvas, and SVG-to-canvas parser. Backed by jsdom and node-canvas.",
   "homepage": "http://fabricjs.com/",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-beta.4",
   "author": "Juriy Zaytsev <kangax@gmail.com>",
   "contributors": [
     {

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -303,8 +303,8 @@
      * @return {Boolean}
      */
     willDrawShadow: function() {
-      if (this.shadow) {
-        return fabric.Object.prototype.willDrawShadow.call(this);
+      if (fabric.Object.prototype.willDrawShadow.call(this)) {
+        return true;
       }
       for (var i = 0, len = this._objects.length; i < len; i++) {
         if (this._objects[i].willDrawShadow()) {

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -747,6 +747,10 @@
     assert.equal(group3.willDrawShadow(), true, 'group will cast shadow because group itself has shadow and one offsetX different than 0');
     group3.shadow = { offsetX: 0, offsetY: -2 };
     assert.equal(group3.willDrawShadow(), true, 'group will cast shadow because group itself has shadow and one offsetY different than 0');
+    rect1.shadow = { offsetX: 1, offsetY: 2, };
+    group3.shadow = { offsetX: 0, offsetY: 0 };
+    assert.equal(group3.willDrawShadow(), true, 'group will cast shadow because group itself will not, but rect 1 will');
+
   });
 
   QUnit.test('group shouldCache', function(assert) {


### PR DESCRIPTION
A group shadow with shadow but no offsets, would have returned false from its on willDrawShadow call.
The shortcut would not have take in account children items.