### PR TITLE
If it's a file, then create a node-canvas image

### DIFF
--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -368,7 +368,7 @@
       // IE10 / IE11-Fix: SVG contents from data: URI
       // will only be available if the IMG is present
       // in the DOM (and visible)
-      if (url.substring(0,14) === 'data:image/svg') {
+      if (!fabric.isLikelyNode && url.substring(0,14) === 'data:image/svg') {
         img.onload = null;
         fabric.util.loadImageInDom(img, onLoadCallback);
       }
@@ -624,7 +624,9 @@
      * @return {HTMLImageElement} HTML image element
      */
     createImage: function() {
-      return fabric.document.createElement('img');
+      return fabric.isLikelyNode
+        ? new (require('canvas').Image)()
+        : fabric.document.createElement('img');
     },
 
     /**


### PR DESCRIPTION
This PR is followed after https://github.com/fabricjs/fabric.js/issues/6047 and brings back the capability to create an image from file (buffer) as well.

