### PR TITLE
Fix centering guidelines for canvas with zoom factor

### DIFF
--- a/lib/centering_guidelines.js
+++ b/lib/centering_guidelines.js
@@ -6,8 +6,8 @@
  */
 function initCenteringGuidelines(canvas) {
 
-  var canvasWidth = canvas.getWidth(),
-      canvasHeight = canvas.getHeight(),
+  var canvasWidth = canvas.getWidth() / canvas.getZoom(),
+      canvasHeight = canvas.getHeight() / canvas.getZoom(),
       canvasWidthCenter = canvasWidth / 2,
       canvasHeightCenter = canvasHeight / 2,
       canvasWidthCenterMap = { },


### PR DESCRIPTION
Before:
Center position is incorrect for canvas with a zoom factor applied

After:
Width is now calculated based on canvas width and zoom factor, so center position is now correct