### PR TITLE
Maintain style when replacing a line of text

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -177,8 +177,12 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         removedText = this._text.slice(this.selectionStart, this.selectionStart - charDiff);
       }
     }
+    var copiedStyle;
     insertedText = nextText.slice(textareaSelection.selectionEnd - charDiff, textareaSelection.selectionEnd);
     if (removedText && removedText.length) {
+      if (insertedText.length) {
+        copiedStyle = this.getSelectionStyles(this.selectionStart, this.selectionEnd, true);
+      }
       if (this.selectionStart !== this.selectionEnd) {
         this.removeStyleFromTo(this.selectionStart, this.selectionEnd);
       }
@@ -195,7 +199,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         this.insertNewStyleBlock(insertedText, this.selectionStart, fabric.copiedTextStyle);
       }
       else {
-        this.insertNewStyleBlock(insertedText, this.selectionStart);
+        this.insertNewStyleBlock(insertedText, this.selectionStart, copiedStyle);
       }
     }
     this.updateFromTextArea();


### PR DESCRIPTION
Fixes a bug where, when an entire line of text is replaced by typing over it, the style is reset.  Please see my comment in issue #6094 for more information: https://github.com/fabricjs/fabric.js/issues/6094#issuecomment-589755471