### PR TITLE
Register + store events

### DIFF
--- a/build.js
+++ b/build.js
@@ -135,6 +135,7 @@ var filesToInclude = [
   'src/util/dom_style.js',
   'src/util/dom_misc.js',
   'src/util/dom_request.js',
+  'src/util/register_events.js',
 
   'src/log.js',
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -627,6 +627,12 @@
     absolutePositioned: false,
 
     /**
+     * List of stored events.
+     * @type array
+     */
+    events: [],
+
+    /**
      * Constructor
      * @param {Object} [options] Options object
      */
@@ -634,6 +640,52 @@
       if (options) {
         this.setOptions(options);
       }
+      this._startEvents();
+    },
+
+    /**
+     * Start the events stored on the object.
+     * @private
+     */
+    _startEvents: function () {
+      this.events.forEach(this._startEvent.bind(this));
+    },
+
+    /**
+     * Start the given event stored on the object.
+     * @private
+     */
+    _startEvent: function (event) {
+      var _this = this;
+      var name = event.name, trigger = event.trigger;
+
+      if (fabric.events[name]) {
+        _this.on(trigger, function (event) {
+          fabric.events[name](event, _this);
+        });
+      }
+      else {
+        throw new Error('This event [' + name + '] does not exist.');
+      }
+    },
+
+    /**
+     * Add an event to the object.
+     */
+    addEvent: function (name, trigger) {
+      var event = {
+        name: name,
+        trigger: trigger || 'added'
+      };
+      this.set({ events: this.events.concat(event) });
+      this._startEvent(event);
+    },
+
+    /**
+     * Remove an event from the object.
+     */
+    removeEvent: function (event) {
+      this.events.splice(this.events.indexOf(event), 1);
     },
 
     /**
@@ -853,6 +905,10 @@
             skewX:                    toFixed(this.skewX, NUM_FRACTION_DIGITS),
             skewY:                    toFixed(this.skewY, NUM_FRACTION_DIGITS),
           };
+
+      if (this.events.length > 0) {
+        object.events = JSON.parse(JSON.stringify(this.events));
+      }
 
       if (this.clipPath) {
         object.clipPath = this.clipPath.toObject(propertiesToInclude);

--- a/src/util/register_events.js
+++ b/src/util/register_events.js
@@ -1,0 +1,7 @@
+(function() {
+  function registerEvent(name, method) {
+    fabric.events[name] = method;
+  }
+  fabric.events = {};
+  fabric.util.registerEvent = registerEvent;
+})();

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -956,4 +956,29 @@
     assert.equal(canvas._addEventOptions(opt, { action: 'drag' }), 'moved', 'drag => moved');
     assert.equal(opt.by, undefined, 'by => undefined');
   });
+
+
+  QUnit.test('event with registered event', function (assert) {
+    var done = assert.async();
+    var object = new fabric.Object({});
+    fabric.util.registerEvent('method', function (event, object) {
+      assert.ok(true, 'method calls operation function');
+      done();
+    });
+    object.addEvent('method', 'mousedown');
+    object.fire('mousedown');
+  });
+
+  QUnit.test('event with stored event', function (assert) {
+    var done = assert.async();
+    var object = new fabric.Object({});
+    fabric.util.registerEvent('method', function (event, object) {
+      assert.ok(true, 'method calls operation function');
+      done();
+    });
+    object.addEvent('method', 'mousedown');
+    fabric.Object._fromObject('Object', object.toJSON(), function (newObject) {
+      newObject.fire('mousedown');
+    });
+  });
 })();


### PR DESCRIPTION
This is yet another feature i've been adding for my own project and thought this may be useful for others, so here it is:

- This PR allows for registering "global" events, which can then be reused simply by name across shapes:
```js
fabric.util.registerEvent('alert', function(event, object) {
  alert(`You have triggered the alert event on object "${object.name}" at position { x: ${event.e.x}, y: ${event.e.y} }`)
})
```

- This PR allows for storing events in the JSON representation of an object with an extra "trigger" option for custom interaction on a given event:
```js
object.addEvent('alert', 'mousedown')
fabric.Object._fromObject('Object', object.toJSON(), function(newObject) {
  newObject.events => [{
    name: 'alert',
    trigger: 'mousedown'
  }]
})
```
Here is a working example: https://jsfiddle.net/brfojpq0/1/

Tests are included for registering events and storing events.

PS: sorry for all the PRs, i'm just sharing my own extensions of your amazing package 