### PR TITLE
Adding existence check for this.canvas on object stacking mixins

### DIFF
--- a/src/mixins/object_stacking.mixin.js
+++ b/src/mixins/object_stacking.mixin.js
@@ -9,7 +9,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) {
       fabric.StaticCanvas.prototype.sendToBack.call(this.group, this);
     }
-    else {
+    else (this.canvas) {
       this.canvas.sendToBack(this);
     }
     return this;
@@ -24,7 +24,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) {
       fabric.StaticCanvas.prototype.bringToFront.call(this.group, this);
     }
-    else {
+    else (this.canvas) {
       this.canvas.bringToFront(this);
     }
     return this;
@@ -40,7 +40,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) {
       fabric.StaticCanvas.prototype.sendBackwards.call(this.group, this, intersecting);
     }
-    else {
+    else (this.canvas) {
       this.canvas.sendBackwards(this, intersecting);
     }
     return this;
@@ -56,7 +56,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) {
       fabric.StaticCanvas.prototype.bringForward.call(this.group, this, intersecting);
     }
-    else {
+    else (this.canvas) {
       this.canvas.bringForward(this, intersecting);
     }
     return this;
@@ -72,7 +72,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group && this.group.type !== 'activeSelection') {
       fabric.StaticCanvas.prototype.moveTo.call(this.group, this, index);
     }
-    else {
+    else (this.canvas) {
       this.canvas.moveTo(this, index);
     }
     return this;

--- a/src/mixins/object_stacking.mixin.js
+++ b/src/mixins/object_stacking.mixin.js
@@ -9,7 +9,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) {
       fabric.StaticCanvas.prototype.sendToBack.call(this.group, this);
     }
-    else (this.canvas) {
+    else if (this.canvas) {
       this.canvas.sendToBack(this);
     }
     return this;
@@ -24,7 +24,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) {
       fabric.StaticCanvas.prototype.bringToFront.call(this.group, this);
     }
-    else (this.canvas) {
+    else if (this.canvas) {
       this.canvas.bringToFront(this);
     }
     return this;
@@ -40,7 +40,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) {
       fabric.StaticCanvas.prototype.sendBackwards.call(this.group, this, intersecting);
     }
-    else (this.canvas) {
+    else if (this.canvas) {
       this.canvas.sendBackwards(this, intersecting);
     }
     return this;
@@ -56,7 +56,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group) {
       fabric.StaticCanvas.prototype.bringForward.call(this.group, this, intersecting);
     }
-    else (this.canvas) {
+    else if (this.canvas) {
       this.canvas.bringForward(this, intersecting);
     }
     return this;
@@ -72,7 +72,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this.group && this.group.type !== 'activeSelection') {
       fabric.StaticCanvas.prototype.moveTo.call(this.group, this, index);
     }
-    else (this.canvas) {
+    else if (this.canvas) {
       this.canvas.moveTo(this, index);
     }
     return this;


### PR DESCRIPTION
Looks to resolve Cannot read property 'bringToFront' of undefined #6065

I was having instances where the canvas instance was null and bringToFront was being called. I added this existence check to all of the object stacking mixins and matches the approach to check for `this.group` in the if block above.