### PR TITLE
Canvas selectable

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -131,6 +131,13 @@
      * @default
      */
     interactive:            true,
+    
+    /**
+     * Indicates if canvas objects can be selected
+     * @type Boolean
+     * @default
+     */
+    selectable:             true,
 
     /**
      * Indicates whether group selection should be enabled

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -131,7 +131,7 @@
      * @default
      */
     interactive:            true,
-    
+
     /**
      * Indicates if canvas objects can be selected
      * @type Boolean

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -702,7 +702,7 @@
         target = this._activeObject;
       }
 
-      if (this.selection && (!target ||
+      if (this.selection && this.selectable && (!target ||
         (!target.selectable && !target.isEditing && target !== this._activeObject))) {
         this._groupSelector = {
           ex: pointer.x,
@@ -712,7 +712,7 @@
         };
       }
 
-      if (target) {
+      if (this.selectable && target) {
         var alreadySelected = target === this._activeObject;
         if (target.selectable) {
           this.setActiveObject(target, e);

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -13,7 +13,7 @@
      */
     _shouldGroup: function(e, target) {
       var activeObject = this._activeObject;
-      return activeObject && this._isSelectionKeyPressed(e) && target && target.selectable && this.selection &&
+      return activeObject && this._isSelectionKeyPressed(e) && target && target.selectable && this.selectable && this.selection &&
             (activeObject !== target || activeObject.type === 'activeSelection') && !target.onSelect({ e: e });
     },
 

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -13,8 +13,10 @@
      */
     _shouldGroup: function(e, target) {
       var activeObject = this._activeObject;
-      return activeObject && this._isSelectionKeyPressed(e) && target && target.selectable && this.selectable && this.selection &&
-            (activeObject !== target || activeObject.type === 'activeSelection') && !target.onSelect({ e: e });
+      return activeObject && this._isSelectionKeyPressed(e) && target && target.selectable &&
+            this.selectable && this.selection &&
+            (activeObject !== target || activeObject.type === 'activeSelection') &&
+            !target.onSelect({ e: e });
     },
 
     /**

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -726,7 +726,7 @@
     var event = {};
     event[canvas.selectionKey] = true;
     var returned = canvas._shouldGroup(event, rect);
-    assert.equal(returned, false, '_shouldGroup return null if canvas.selectable is false');
+    assert.equal(returned, false, '_shouldGroup return false if canvas.selectable is false');
     canvas.selectable = true;
   });
 

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -674,7 +674,6 @@
     assert.equal(returned, false, 'if onSelect returns true, shouldGroup return false');
   });
 
-
   QUnit.test('_shouldGroup return true if onSelect return false and selectionKey is true', function(assert) {
     var rect = new fabric.Rect();
     var rect2 = new fabric.Rect();
@@ -689,7 +688,7 @@
     assert.equal(returned, true, 'if onSelect returns false, shouldGroup return true');
   });
 
-  QUnit.test('_shouldGroup return null if selectionKey is false', function(assert) {
+  QUnit.test('_shouldGroup return false if selectionKey is false', function(assert) {
     var rect = new fabric.Rect();
     var rect2 = new fabric.Rect();
     rect.onSelect = function() {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -674,24 +674,6 @@
     assert.equal(returned, false, 'if onSelect returns true, shouldGroup return false');
   });
 
-  QUnit.test('_shouldGroup if canvas.selection is true or false', function(assert) {
-    var rect = new fabric.Rect();
-    var rect2 = new fabric.Rect();
-    rect.onSelect = function() {
-      return true;
-    };
-    canvas._activeObject = rect2;
-    canvas.selectable = false;
-
-    var event = {};
-    var returned = canvas._shouldGroup(event, rect);
-    assert.equal(returned, null, '_shouldGroup return null if canvas.selectable is false');
-    canvas.selectable = true;
-
-    var event2 = {};
-    var returned2 = canvas._shouldGroup(event2, rect);
-    assert.equal(returned2, true, '_shouldGroup return true if canvas.selectable is true');
-  });
 
   QUnit.test('_shouldGroup return true if onSelect return false and selectionKey is true', function(assert) {
     var rect = new fabric.Rect();
@@ -707,7 +689,7 @@
     assert.equal(returned, true, 'if onSelect returns false, shouldGroup return true');
   });
 
-  QUnit.test('_shouldGroup return false if selectionKey is false', function(assert) {
+  QUnit.test('_shouldGroup return null if selectionKey is false', function(assert) {
     var rect = new fabric.Rect();
     var rect2 = new fabric.Rect();
     rect.onSelect = function() {
@@ -719,6 +701,33 @@
     event[selectionKey] = false;
     var returned = canvas._shouldGroup(event, rect);
     assert.equal(returned, false, 'shouldGroup return false');
+  });
+
+  QUnit.test('_shouldGroup return true if canvas.selectable is true', function(assert) {
+    var rect = new fabric.Rect();
+    var rect2 = new fabric.Rect();
+    rect.onSelect = function() {
+      return;
+    };
+    canvas._activeObject = rect2;
+    var event = {};
+    event[canvas.selectionKey] = true;
+    var returned = canvas._shouldGroup(event, rect);
+    assert.equal(returned, true, '_shouldGroup return true if canvas.selectable is true');
+  });
+
+  QUnit.test('_shouldGroup return false if canvas.selectable is false', function(assert) {
+    canvas.selectable = false;
+    var rect = new fabric.Rect();
+    rect.onSelect = function() {
+      return;
+    };
+    canvas._activeObject = rect;
+    var event = {};
+    event[canvas.selectionKey] = true;
+    var returned = canvas._shouldGroup(event, rect);
+    assert.equal(returned, false, '_shouldGroup return null if canvas.selectable is false');
+    canvas.selectable = true;
   });
 
   QUnit.test('_fireSelectionEvents fires multiple things', function(assert) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -674,6 +674,25 @@
     assert.equal(returned, false, 'if onSelect returns true, shouldGroup return false');
   });
 
+  QUnit.test('_shouldGroup if canvas.selection is true or false', function(assert) {
+    var rect = new fabric.Rect();
+    var rect2 = new fabric.Rect();
+    rect.onSelect = function() {
+      return true;
+    };
+    canvas._activeObject = rect2;
+    canvas.selectable = false;
+
+    var event = {};
+    var returned = canvas._shouldGroup(event, rect);
+    assert.equal(returned, null, '_shouldGroup return null if canvas.selectable is false');
+    canvas.selectable = true;
+
+    var event2 = {};
+    var returned2 = canvas._shouldGroup(event2, rect);
+    assert.equal(returned2, true, '_shouldGroup return true if canvas.selectable is true');
+  });
+
   QUnit.test('_shouldGroup return true if onSelect return false and selectionKey is true', function(assert) {
     var rect = new fabric.Rect();
     var rect2 = new fabric.Rect();

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -170,10 +170,16 @@
     canvas.__onMouseDown(e);
     assert.deepEqual(canvas._groupSelector, expectedGroupSelector, 'a new groupSelector is created');
     canvas.__onMouseUp(e);
+    canvas.discardActiveObject();
     canvas.selectable = false;
     canvas.__onMouseDown(e);
     assert.deepEqual(canvas._groupSelector, null, 'while canvas is not selectable');
+    canvas.__onMouseUp(e);
     canvas.selectable = true;
+    canvas.__onMouseDown(e);
+    assert.deepEqual(canvas._groupSelector, expectedGroupSelector, 'while canvas is selectable');
+    canvas.__onMouseUp(e);
+    canvas.discardActiveObject();
   });
 
   QUnit.test('specific bug #5317 for shift+click and active selection', function(assert) {

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -170,6 +170,10 @@
     canvas.__onMouseDown(e);
     assert.deepEqual(canvas._groupSelector, expectedGroupSelector, 'a new groupSelector is created');
     canvas.__onMouseUp(e);
+    canvas.selectable = false;
+    canvas.__onMouseDown(e);
+    assert.deepEqual(canvas._groupSelector, null, 'while canvas is not selectable');
+    canvas.selectable = true;
   });
 
   QUnit.test('specific bug #5317 for shift+click and active selection', function(assert) {


### PR DESCRIPTION
This prevents all objects on the canvas from being selectable. This is different than selection which disallows group selection.

This allows better control over selections on the canvas without having to loop through every object and set `object.selectable`.

```
const enablePan = canvas => () => {
  canvas.selection = false;
  canvas.selectable = false;

  const down = () => {};

  canvas.on('mouse:down', down);

  return function disable() {
    canvas.off('mouse:down', down);
    canvas.selection = true;
    canvas.selectable = true;
  };
};
```