### PR TITLE
docs: Fix simple typo, usefull -> useful

### DIFF
--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -10069,7 +10069,7 @@ fabric.PatternBrush = fabric.util.createClass(fabric.PencilBrush, /** @lends fab
         ey: pointer.y,
         lastX: pointer.x,
         lastY: pointer.y,
-        // unsure they are usefull anymore.
+        // unsure they are useful anymore.
         // left: target.left,
         // top: target.top,
         theta: degreesToRadians(target.angle),
@@ -26447,7 +26447,7 @@ fabric.Image.filters.BaseFilter.fromObject = function(object, callback) {
     /**
      * Returns 2d representation (lineIndex and charIndex) of cursor (or selection start)
      * @param {Number} [selectionStart] Optional index. When not given, current selectionStart is used.
-     * @param {Boolean} [skipWrapping] consider the location for unwrapped lines. usefull to manage styles.
+     * @param {Boolean} [skipWrapping] consider the location for unwrapped lines. useful to manage styles.
      */
     get2DCursorLocation: function(selectionStart, skipWrapping) {
       if (typeof selectionStart === 'undefined') {

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -680,7 +680,7 @@
             ey: pointer.y,
             lastX: pointer.x,
             lastY: pointer.y,
-            // unsure they are usefull anymore.
+            // unsure they are useful anymore.
             // left: target.left,
             // top: target.top,
             theta: degreesToRadians(target.angle),

--- a/src/mixins/text_style.mixin.js
+++ b/src/mixins/text_style.mixin.js
@@ -162,7 +162,7 @@
     /**
      * Returns 2d representation (lineIndex and charIndex) of cursor (or selection start)
      * @param {Number} [selectionStart] Optional index. When not given, current selectionStart is used.
-     * @param {Boolean} [skipWrapping] consider the location for unwrapped lines. usefull to manage styles.
+     * @param {Boolean} [skipWrapping] consider the location for unwrapped lines. useful to manage styles.
      */
     get2DCursorLocation: function(selectionStart, skipWrapping) {
       if (typeof selectionStart === 'undefined') {


### PR DESCRIPTION
There is a small typo in dist/fabric.js, src/canvas.class.js, src/mixins/text_style.mixin.js.

Should read `useful` rather than `usefull`.

