### PR TITLE
feat(fabric.Pattern): remove the ability to restore patterns from functions.

### DIFF
--- a/src/pattern.class.js
+++ b/src/pattern.class.js
@@ -66,11 +66,6 @@
         callback && callback(this);
         return;
       }
-      // function string
-      if (typeof fabric.util.getFunctionBody(options.source) !== 'undefined') {
-        this.source = new Function(fabric.util.getFunctionBody(options.source));
-        callback && callback(this);
-      }
       else {
         // img src string
         var _this = this;
@@ -91,12 +86,8 @@
       var NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
           source, object;
 
-      // callback
-      if (typeof this.source === 'function') {
-        source = String(this.source);
-      }
       // <img> element
-      else if (typeof this.source.src === 'string') {
+      if (typeof this.source.src === 'string') {
         source = this.source.src;
       }
       // <canvas> element
@@ -177,8 +168,7 @@
      * @return {CanvasPattern}
      */
     toLive: function(ctx) {
-      var source = typeof this.source === 'function' ? this.source() : this.source;
-
+      var source = this.source;
       // if the image failed to load, return, and allow rest to continue loading
       if (!source) {
         return '';

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -805,15 +805,6 @@
     },
 
     /**
-     * Returns string representation of function body
-     * @param {Function} fn Function to get body of
-     * @return {String} Function body
-     */
-    getFunctionBody: function(fn) {
-      return (String(fn).match(/function[^{]*\{([\s\S]*)\}/) || {})[1];
-    },
-
-    /**
      * Returns true if context has transparent pixel
      * at specified location (taking tolerance into account)
      * @param {CanvasRenderingContext2D} ctx context

--- a/test/unit/pattern.js
+++ b/test/unit/pattern.js
@@ -55,14 +55,6 @@
     assert.equal(object.offsetX, 0);
     assert.equal(object.offsetY, 0);
     assert.equal(object.patternTransform, null);
-
-    var patternWithGetSource = new fabric.Pattern({
-      source: function () {return fabric.document.createElement('canvas');}
-    });
-
-    var object2 = patternWithGetSource.toObject();
-    assert.equal(object2.source, 'function () {return fabric.document.createElement(\'canvas\');}');
-    assert.equal(object2.repeat, 'repeat');
   });
 
   QUnit.test('toObject with custom props', function(assert) {
@@ -109,27 +101,6 @@
     assert.ok(typeof pattern.toLive === 'function');
     var created = pattern.toLive(canvas.contextContainer);
     assert.equal(created.toString(), '[object CanvasPattern]', 'is a gradient for canvas radial');
-  });
-
-  QUnit.test('pattern serialization / deserialization (function)', function(assert) {
-    var patternSourceCanvas, padding;
-
-    var pattern = new fabric.Pattern({
-      source: function() {
-        patternSourceCanvas.setDimensions({
-          width: img.width + padding,
-          height: img.height + padding
-        });
-        return patternSourceCanvas.getElement();
-      },
-      repeat: 'repeat'
-    });
-
-    var obj = pattern.toObject();
-    var patternDeserialized = new fabric.Pattern(obj);
-
-    assert.equal(typeof patternDeserialized.source, 'function');
-    assert.equal(patternDeserialized.repeat, 'repeat');
   });
 
   QUnit.test('pattern serialization / deserialization (image source)', function(assert) {

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -695,19 +695,6 @@
     assert.ok(typeof destination.ffffffffff === 'undefined');
   });
 
-  QUnit.test('fabric.util.getFunctionBody', function(assert) {
-    assert.equal(fabric.util.getFunctionBody('function(){}'), '');
-
-    assert.equal(fabric.util.getFunctionBody('function(){return 1 + 2}'),
-      'return 1 + 2');
-
-    assert.equal(fabric.util.getFunctionBody('function () {\n  return "blah" }'),
-      '\n  return "blah" ');
-
-    assert.equal(fabric.util.getFunctionBody('function foo (a , boo_bar, baz123 )\n{\n if (1) { alert(12345) } }'),
-      '\n if (1) { alert(12345) } ');
-  });
-
   QUnit.test('getKlass', function(assert) {
     assert.equal(fabric.util.getKlass('circle'), fabric.Circle);
     assert.equal(fabric.util.getKlass('rect'), fabric.Rect);


### PR DESCRIPTION
close #1621

BREAKING: patterns that uses functions are no more supported

Pattern will transition to fabric v4, but will be sort of deprectated.
A new Pattern will be created, that will allow to define patterns with fabric objects.