### PR TITLE
simplify code contributions by fully automating the dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: npm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,12 @@ starting point.
 
 We are very grateful for your pull requests! This is your chance to improve Fabric for everyone else.
 
+### Online one-click setup for making PRs
+
+Contribute to fabricjs using a fully featured online development environment that will automatically with a single click: clone the repo and install the dependencies.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ### Pull request guidelines
 
 Here are a few notes you should take into account:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://secure.travis-ci.org/fabricjs/fabric.js.svg?branch=master)](http://travis-ci.org/#!/kangax/fabric.js)
 [![Code Climate](https://d3s6mut3hikguw.cloudfront.net/github/kangax/fabric.js/badges/gpa.svg)](https://codeclimate.com/github/kangax/fabric.js)
 [![Coverage Status](https://coveralls.io/repos/fabricjs/fabric.js/badge.png?branch=master)](https://coveralls.io/r/kangax/fabric.js?branch=master)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/fabricjs/fabric.js) 
 
 <!-- npm, bower, CDNJS versions, downloads -->
 


### PR DESCRIPTION
Hi! 

We are currently on a mission to simplify contributors onboarding by fully automating the dev setups for OSS projects with Gitpod(a free online VS Code-like IDE).

In the case of this project, with a single click Gitpod will launch a workspace and automatically:

- clone the `fabric-js` repo.
- install the dependencies.

this is how it looks:

![image](https://user-images.githubusercontent.com/46004116/80758702-82b81200-8b4f-11ea-8149-e676b0e72f27.png)

You can give it a try on my fork of the repo via the following link:

https://github.com/nisarhassan12/fabric.js

A lot of popular OSS projects out there are already using Gitpod some of them are:

- https://github.com/freeCodeCamp/freeCodeCamp
- https://github.com/facebook/docusaurus
- https://github.com/mozilla/pdf.js 
- https://github.com/photonstorm/phaser/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/80758569-42589400-8b4f-11ea-8bb1-77d638ad32c3.png)



