### PR TITLE
Set _clickHandlerInitalized to false when adding iText to canvas

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -28,7 +28,7 @@
       this.on('added', function() {
         var canvas = _this.canvas;
         if (canvas) {
-          _this._restoreClickHandlerProps();
+          _this._clickHandlerInitialized = false;
 
           if (!canvas._hasITextHandlers) {
             canvas._hasITextHandlers = true;
@@ -928,14 +928,6 @@
       else if (this.selectionEnd < 0) {
         this.selectionEnd = 0;
       }
-    },
-
-    /**
-     * Restores click handler props to default values
-     * @private
-     */
-    _restoreClickHandlerProps: function() {
-      this._clickHandlerInitialized = false;
-    },
+    }
   });
 })();

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -28,6 +28,8 @@
       this.on('added', function() {
         var canvas = _this.canvas;
         if (canvas) {
+          _this._restoreClickHandlerProps();
+
           if (!canvas._hasITextHandlers) {
             canvas._hasITextHandlers = true;
             _this._initCanvasHandlers(canvas);
@@ -926,6 +928,14 @@
       else if (this.selectionEnd < 0) {
         this.selectionEnd = 0;
       }
-    }
+    },
+
+    /**
+     * Restores click handler props to default values
+     * @private
+     */
+    _restoreClickHandlerProps: function() {
+      this._clickHandlerInitialized = false;
+    },
   });
 })();

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -831,16 +831,16 @@
       });
     });
 
-    QUnit.test('_restoreClickHandlerProps', function(assert) {
+    QUnit.test('_restoreClickHandlerProps', function (assert) {
       var iText = new fabric.IText('test');
-  
+
       iText._clickHandlerInitialized = true;
-  
+
       iText._restoreClickHandlerProps();
-  
+
       assert.notOk(
         iText._clickHandlerInitialized,
-        "set to false by _restoreClickHandlerProps"
+        'set to false by _restoreClickHandlerProps'
       );
     });
   });

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -830,5 +830,18 @@
         fabric.devicePixelRatio = 1;
       });
     });
+
+    QUnit.test('_restoreClickHandlerProps', function(assert) {
+      var iText = new fabric.IText('test');
+  
+      iText._clickHandlerInitialized = true;
+  
+      iText._restoreClickHandlerProps();
+  
+      assert.notOk(
+        iText._clickHandlerInitialized,
+        "set to false by _restoreClickHandlerProps"
+      );
+    });
   });
 })();

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -831,16 +831,15 @@
       });
     });
 
-    QUnit.test('_restoreClickHandlerProps', function (assert) {
+    QUnit.test('restore _clickHandlerInitialized on added', function (assert) {
       var iText = new fabric.IText('test');
-
       iText._clickHandlerInitialized = true;
 
-      iText._restoreClickHandlerProps();
+      canvas.add(iText);
 
       assert.notOk(
         iText._clickHandlerInitialized,
-        'set to false by _restoreClickHandlerProps'
+        'set to false on added'
       );
     });
   });


### PR DESCRIPTION
A fix for issue #6213 .

Sets `_clickHandlerInitialized` on the iText instance to false when it gets added to the canvas. This handles the case when an iText instance gets added to more than one Canvas instance - in this case, the listener needs to be initialized again.