### PR TITLE
Animation logic improvement: testing concept

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -601,7 +601,7 @@
      * @type Array
      */
     animatableProperties: (
-      'fill stroke strokeWidth top left angle scaleX'
+      'top left angle scaleX'
     ).split(' '),
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1045,17 +1045,6 @@
     /**
      * Renders an object on a specified context
      * @param {CanvasRenderingContext2D} ctx Context to render on
-     * @param {Number} time millisecond after the first frame
-     */
-    renderAtTime: function(ctx, time) {
-      fabric.util.applyAnimationState(this, time);
-      this.render(ctx);
-    },
-
-
-    /**
-     * Renders an object on a specified context
-     * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     render: function(ctx) {
       // do not render if width/height are zeros or object is not visible

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -597,6 +597,14 @@
     ).split(' '),
 
     /**
+     * List of properties for which there is animation support
+     * @type Array
+     */
+    animatableProperties: (
+      'fill stroke strokeWidth top left angle scaleX'
+    ).split(' '),
+
+    /**
      * List of properties to consider for animating colors.
      * @type Array
      */
@@ -1033,6 +1041,17 @@
         (!this.width && !this.height && this.strokeWidth === 0) ||
         !this.visible;
     },
+
+    /**
+     * Renders an object on a specified context
+     * @param {CanvasRenderingContext2D} ctx Context to render on
+     * @param {Number} time millisecond after the first frame
+     */
+    renderAtTime: function(ctx, time) {
+      fabric.util.applyAnimationState(this, time);
+      this.render(ctx);
+    },
+
 
     /**
      * Renders an object on a specified context

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -601,7 +601,7 @@
      * @type Array
      */
     animatableProperties: (
-      'top left angle scaleX'
+      'top left angle scaleX opacity strokeWidth'
     ).split(' '),
 
     /**

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -943,17 +943,10 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Array} objects to render
      */
-    _renderObjects: function(ctx, objects, time) {
+    _renderObjects: function(ctx, objects) {
       var i, len;
       for (i = 0, len = objects.length; i < len; ++i) {
-        if (objects[i]) {
-          if (time) {
-            objects[i].renderAtTime(ctx, time);
-          }
-          else {
-            objects[i].render(ctx);
-          }
-        }
+        objects[i] && objects[i].render(ctx);
       }
     },
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -829,18 +829,6 @@
     },
 
     /**
-     * Renders the canvas
-     * @param {Number} time offset for animations
-     * @return {fabric.Canvas} instance
-     * @chainable
-     */
-    renderAtTime: function (time) {
-      var canvasToDrawOn = this.contextContainer;
-      this.renderCanvas(canvasToDrawOn, this._objects, time);
-      return this;
-    },
-
-    /**
      * Function created to be instance bound at initialization
      * used in requestAnimationFrame rendering
      * Let the fabricJS call it. If you call it manually you could have more
@@ -898,11 +886,10 @@
      * Renders background, objects, overlay and controls.
      * @param {CanvasRenderingContext2D} ctx
      * @param {Array} objects to render
-     * @param {Number} time offset for eventual animations
      * @return {fabric.Canvas} instance
      * @chainable
      */
-    renderCanvas: function(ctx, objects, time) {
+    renderCanvas: function(ctx, objects) {
       var v = this.viewportTransform, path = this.clipPath;
       this.cancelRequestedRender();
       this.calcViewportBoundaries();
@@ -914,7 +901,7 @@
       ctx.save();
       //apply viewport transform once for all rendering process
       ctx.transform(v[0], v[1], v[2], v[3], v[4], v[5]);
-      this._renderObjects(ctx, objects, time);
+      this._renderObjects(ctx, objects);
       ctx.restore();
       if (!this.controlsAboveOverlay && this.interactive) {
         this.drawControls(ctx);

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -829,6 +829,18 @@
     },
 
     /**
+     * Renders the canvas
+     * @param {Number} time offset for animations
+     * @return {fabric.Canvas} instance
+     * @chainable
+     */
+    renderAtTime: function (time) {
+      var canvasToDrawOn = this.contextContainer;
+      this.renderCanvas(canvasToDrawOn, this._objects, time);
+      return this;
+    },
+
+    /**
      * Function created to be instance bound at initialization
      * used in requestAnimationFrame rendering
      * Let the fabricJS call it. If you call it manually you could have more
@@ -886,10 +898,11 @@
      * Renders background, objects, overlay and controls.
      * @param {CanvasRenderingContext2D} ctx
      * @param {Array} objects to render
+     * @param {Number} time offset for eventual animations
      * @return {fabric.Canvas} instance
      * @chainable
      */
-    renderCanvas: function(ctx, objects) {
+    renderCanvas: function(ctx, objects, time) {
       var v = this.viewportTransform, path = this.clipPath;
       this.cancelRequestedRender();
       this.calcViewportBoundaries();
@@ -901,7 +914,7 @@
       ctx.save();
       //apply viewport transform once for all rendering process
       ctx.transform(v[0], v[1], v[2], v[3], v[4], v[5]);
-      this._renderObjects(ctx, objects);
+      this._renderObjects(ctx, objects, time);
       ctx.restore();
       if (!this.controlsAboveOverlay && this.interactive) {
         this.drawControls(ctx);
@@ -943,10 +956,17 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      * @param {Array} objects to render
      */
-    _renderObjects: function(ctx, objects) {
+    _renderObjects: function(ctx, objects, time) {
       var i, len;
       for (i = 0, len = objects.length; i < len; ++i) {
-        objects[i] && objects[i].render(ctx);
+        if (objects[i]) {
+          if (time) {
+            objects[i].renderAtTime(ctx, time);
+          }
+          else {
+            objects[i].render(ctx);
+          }
+        }
       }
     },
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1745,6 +1745,15 @@
       return this.renderOnAddRemove && this.requestRenderAll();
     },
 
+    setObjectsAtTime: function(objects, time) {
+      var i, len;
+      for (i = 0, len = objects.length; i < len; ++i) {
+        if (objects[i]) {
+          fabric.util.applyAnimationState(objects[i], time);
+        }
+      }
+    },
+
     /**
      * Clears a canvas element and dispose objects
      * @return {fabric.Canvas} thisArg

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -94,6 +94,10 @@
     return _cancelAnimFrame.apply(fabric.window, arguments);
   }
 
+  function identityEase(currentTime, startValue) {
+    return startValue;
+  }
+
   function calculateCurrentAnimationValue(startingValue, animation, time) {
     var easing = fabric.util.ease[animation.easing] || identityEase;
     // valid for numbers only written like this.
@@ -119,7 +123,7 @@
       if (!accumulator[property]) {
         accumulator[property] = {
           previouslyEndedAt: 0,
-          previousState: object[property]
+          previousState: object._animatableProperties[property],
         };
       }
       var validAnimation = accumulator[property],
@@ -136,21 +140,27 @@
       // at this point the animation is the valid one.
       validAnimation.animationEndTime = endTime;
       validAnimation.animation = current;
+      return accumulator;
     }, {});
     /**
-     * at this point currentAnimation should look like this:
-     * {
-     *  fill: {
-     *    animationEndTime: 4242 // not more useful at this point
-     *    animation: { ... } // animation data, referencerenced do not mutate
-     *    previousState: 'blue', define the starting value
-     *  }
-     * }
-     */
+       * at this point currentAnimation should look like this:
+       * {
+       *  fill: {
+       *    animationEndTime: 4242 // not more useful at this point
+       *    animation: { ... } // animation data, referencerenced do not mutate
+       *    previousState: 'blue', define the starting value
+       *  }
+       * }
+       */
     Object.keys(validAnimations).forEach(function(key) {
       var data = validAnimations[key];
       // this is over simplified and needs probably to handle edge cases.
-      object[key] = fabric.util.calculateCurrentAnimationValue(data.previousState, data.animation, time);
+      if (!data.animation) {
+        return;
+      }
+      var finalValue = fabric.util.calculateCurrentAnimationValue(data.previousState, data.animation, time);
+      console.log(finalValue);
+      object[key] = finalValue;
     });
   }
 


### PR DESCRIPTION
- Add to canvas a `renderAtTime` method. that will work exactly as `renderAll` but invoking for each object the `renderAtTime` method instead the `render` one

- The object `renderAtTime` method will first calculate the new object properties and then render

- is duty of thedeveloper to call `this.saveState({ propertySet: 'animatableProperties' });` to copy the original values and to restore them calling `this.restoreState({ propertySet: 'animatableProperties' });`

- out of scope but possible: animation canvas viewport ( zoom, panning )


Possible animation format:

```js
fabric.Rect.animation = [
{ property: fill, value: 'red', offset: 33, duration: 4000, easing: 'cubic' },
{ property: scaleX, value: 4, offset: 33, duration: 4000, easing: 'linear' },
{ property: scaleX, value: 1, offset: 4033, duration: 4000, easing: 'linear' },
]
```