### PR TITLE
fix(fabric.Image): ISSUE-6397 modify crossOrigin behaviour for setSerc

### DIFF
--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -30,14 +30,6 @@
     type: 'image',
 
     /**
-     * crossOrigin value (one of "", "anonymous", "use-credentials")
-     * @see https://developer.mozilla.org/en-US/docs/HTML/CORS_settings_attributes
-     * @type String
-     * @default
-     */
-    crossOrigin: '',
-
-    /**
      * Width of a stroke.
      * For image quality a stroke multiple of 2 gives better results.
      * @type Number
@@ -208,15 +200,10 @@
     },
 
     /**
-     * Sets crossOrigin value (on an instance and corresponding image element)
-     * @return {fabric.Image} thisArg
-     * @chainable
+     * Get the crossOrigin value (of the corresponding image element)
      */
-    setCrossOrigin: function(value) {
-      this.crossOrigin = value;
-      this._element.crossOrigin = value;
-
-      return this;
+    getCrossOrigin: function() {
+      return this._originalElement && this._originalElement.crossOrigin;
     },
 
     /**
@@ -287,9 +274,10 @@
       var object = extend(
         this.callSuper(
           'toObject',
-          ['crossOrigin', 'cropX', 'cropY'].concat(propertiesToInclude)
+          ['cropX', 'cropY'].concat(propertiesToInclude)
         ), {
           src: this.getSrc(),
+          crossOrigin: this.getCrossOrigin(),
           filters: filters,
         });
       if (this.resizeFilter) {
@@ -392,6 +380,8 @@
      * @param {String} src Source string (URL)
      * @param {Function} [callback] Callback is invoked when image has been loaded (and all filters have been applied)
      * @param {Object} [options] Options object
+     * @param {String} [options.crossOrigin] crossOrigin value (one of "", "anonymous", "use-credentials")
+     * @see https://developer.mozilla.org/en-US/docs/HTML/CORS_settings_attributes
      * @return {fabric.Image} thisArg
      * @chainable
      */
@@ -595,9 +585,6 @@
       options || (options = { });
       this.setOptions(options);
       this._setWidthHeight(options);
-      if (this._element && this.crossOrigin) {
-        this._element.crossOrigin = this.crossOrigin;
-      }
     },
 
     /**

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -203,7 +203,7 @@
      * Get the crossOrigin value (of the corresponding image element)
      */
     getCrossOrigin: function() {
-      return this._originalElement && this._originalElement.crossOrigin;
+      return this._originalElement && (this._originalElement.crossOrigin || null);
     },
 
     /**

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -361,7 +361,10 @@
       // https://github.com/kangax/fabric.js/commit/d0abb90f1cd5c5ef9d2a94d3fb21a22330da3e0a#commitcomment-4513767
       // see https://code.google.com/p/chromium/issues/detail?id=315152
       //     https://bugzilla.mozilla.org/show_bug.cgi?id=935069
-      if (url.indexOf('data') !== 0 && crossOrigin) {
+      // crossOrigin null is the same as not set.
+      if (url.indexOf('data') !== 0 &&
+        crossOrigin !== undefined &&
+        crossOrigin !== null) {
         img.crossOrigin = crossOrigin;
       }
 

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -102,7 +102,7 @@
     fillRule: 'nonzero',
     paintFirst: 'fill',
     globalCompositeOperation: 'source-over',
-    crossOrigin: '',
+    crossOrigin: null,
     skewX: 0,
     skewY: 0,
     cropX: 0,

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -64,7 +64,7 @@
     globalCompositeOperation: 'source-over',
     skewX:                    0,
     skewY:                    0,
-    crossOrigin:              '',
+    crossOrigin:              null,
     cropX:                    0,
     cropY:                    0
   };
@@ -397,7 +397,7 @@
   QUnit.test('crossOrigin', function(assert) {
     var done = assert.async();
     createImageObject(function(image) {
-      assert.equal(image.getCrossOrigin(), '', 'initial crossOrigin value should be set');
+      assert.equal(image.getCrossOrigin(), null, 'initial crossOrigin value should be set');
 
       var elImage = _createImageElement();
       elImage.crossOrigin = 'anonymous';
@@ -419,9 +419,9 @@
         done();
         return;
       }
-
+      console.log(objRepr);
       fabric.Image.fromObject(objRepr, function(img) {
-        assert.equal(img.getCrossOrigin(), 'anonymous');
+        assert.equal(img.getCrossOrigin(), null, 'image without src return no element');
         done();
       });
     });

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -152,6 +152,25 @@
     });
   });
 
+  QUnit.test('setSrc with crossOrigin', function(assert) {
+    var done = assert.async();
+    createImageObject(function(image) {
+      image.width = 100;
+      image.height = 100;
+      assert.ok(typeof image.setSrc === 'function');
+      assert.equal(image.width, 100);
+      assert.equal(image.height, 100);
+      image.setSrc(IMG_SRC, function() {
+        assert.equal(image.width, IMG_WIDTH);
+        assert.equal(image.height, IMG_HEIGHT);
+        assert.equal(image.getCrossOrigin(), 'anonymous', 'setSrc will respect crossOrigin');
+        done();
+      }, {
+        crossOrigin: 'anonymous'
+      });
+    });
+  });
+
   QUnit.test('toObject with no element', function(assert) {
     var done = assert.async();
     createImageObject(function(image) {
@@ -378,20 +397,22 @@
   QUnit.test('crossOrigin', function(assert) {
     var done = assert.async();
     createImageObject(function(image) {
-      assert.equal(image.crossOrigin, '', 'initial crossOrigin value should be set');
+      assert.equal(image.getCrossOrigin(), '', 'initial crossOrigin value should be set');
 
       var elImage = _createImageElement();
       elImage.crossOrigin = 'anonymous';
       image = new fabric.Image(elImage);
-      assert.equal(image.crossOrigin, '', 'crossOrigin value on an instance takes precedence');
+      assert.equal(image.getCrossOrigin(), 'anonymous', 'crossOrigin value will respect the image element value');
 
       var objRepr = image.toObject();
-      assert.equal(objRepr.crossOrigin, '', 'toObject should return proper crossOrigin value');
+      assert.equal(objRepr.crossOrigin, 'anonymous', 'toObject should return proper crossOrigin value');
 
       var elImage2 = _createImageElement();
-      elImage2.crossOrigin = 'anonymous';
+      elImage2.crossOrigin = 'use-credentials';
       image.setElement(elImage2);
-      assert.equal(elImage2.crossOrigin, 'anonymous', 'setElement should set proper crossOrigin on an img element');
+      assert.equal(
+        elImage2.crossOrigin, 'use-credentials', 'setElement should not try to change element crossOrigin'
+      );
 
       // fromObject doesn't work on Node :/
       if (fabric.isLikelyNode) {
@@ -400,7 +421,7 @@
       }
 
       fabric.Image.fromObject(objRepr, function(img) {
-        assert.equal(img.crossOrigin, '');
+        assert.equal(img.getCrossOrigin(), 'anonymous');
         done();
       });
     });


### PR DESCRIPTION
Image.crossOrigin does not make sense.
crossOrigin is a property of the image element, and is needed to load and reload from object the image.
The developer should not be able to change it at will.

changes:
- add getCrossOriginMethod to read only the actual value
Breaking:
- removing setCrossOrigin method
- avoid setSrc to change element crossOrigin after load.

close #6397