### PR TITLE
fix(fabric.Canvas): ISSUE-6314 rerender in case of single drag selection

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -441,8 +441,14 @@
         shouldRender = transform.actionPerformed;
       }
       if (!isClick) {
+        var targetWasActive = target === this._activeObject;
         this._maybeGroupObjects(e);
-        shouldRender || (shouldRender = this._shouldRender(target));
+        if (!shouldRender) {
+          shouldRender = (
+            this._shouldRender(target) ||
+            (!targetWasActive && target === this._activeObject)
+          );
+        }
       }
       if (target) {
         var corner = target._findTargetCorner(

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -239,6 +239,29 @@
     canvas.__onMouseUp(e4);
   });
 
+  QUnit.test('specific bug #6314 for partial intersection with drag', function(assert) {
+    var canvas = this.canvas = new fabric.Canvas(null, {enableRetinaScaling: false, width: 600, height: 600});
+    var renderRequested = false;
+    var greenRect = new fabric.Rect({
+      width: 300,
+      height: 300,
+      left: 50,
+      top: 0,
+      fill: 'green',
+      selectable: false
+    });
+    canvas.add(greenRect);
+    canvas.__onMouseDown({ clientX: 25, clientY: 25, which: 1, target: canvas.upperCanvasEl });
+    canvas.__onMouseMove({ clientX: 30, clientY: 30, which: 1, target: canvas.upperCanvasEl });
+    canvas.requestRenderAll = function() {
+      console.log(arguments);
+      renderRequested = true;
+    };
+    canvas.__onMouseUp({ clientX: 100, clientY: 50, which: 1, target: canvas.upperCanvasEl });
+    assert.equal(renderRequested, true, 'a render has been requested');
+  });
+
+
   QUnit.test('mouse:up isClick = true', function(assert) {
     var e = { clientX: 30, clientY: 30, which: 1, target: canvas.upperCanvasEl  };
     var isClick = false;

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -248,16 +248,15 @@
       left: 50,
       top: 0,
       fill: 'green',
-      selectable: false
     });
     canvas.add(greenRect);
-    canvas.__onMouseDown({ clientX: 25, clientY: 25, which: 1, target: canvas.upperCanvasEl });
-    canvas.__onMouseMove({ clientX: 30, clientY: 30, which: 1, target: canvas.upperCanvasEl });
+    canvas._onMouseDown({ clientX: 25, clientY: 25, which: 1, target: canvas.upperCanvasEl });
+    canvas._onMouseMove({ clientX: 30, clientY: 30, which: 1, target: canvas.upperCanvasEl });
+    canvas._onMouseMove({ clientX: 100, clientY: 50, which: 1, target: canvas.upperCanvasEl });
     canvas.requestRenderAll = function() {
-      console.log(arguments);
       renderRequested = true;
     };
-    canvas.__onMouseUp({ clientX: 100, clientY: 50, which: 1, target: canvas.upperCanvasEl });
+    canvas._onMouseUp({ clientX: 100, clientY: 50, which: 1, target: canvas.upperCanvasEl });
     assert.equal(renderRequested, true, 'a render has been requested');
   });
 


### PR DESCRIPTION
Force a re-render in case of a single selection caused from a drag action that ends on top of the object.
close #6314