### PR TITLE
Version 4.0.0-rc1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## [latest]
+## [4.0.0-rc.1]
+- fix(fabric.Canvas): ISSUE-6314 rerender in case of drag selection that select a single oobject. [#6421](https://github.com/fabricjs/fabric.js/pull/6421);
+- feat(text): allow correct cursor/selection position if text is edited inside a group. [#6256](https://github.com/fabricjs/fabric.js/pull/6256);
+- feat(fabric.Control): remove position option in favor of x and y [#6415](https://github.com/fabricjs/fabric.js/pull/6415);
+- fix(fabric.Object) ISSUE-6340 infinite recursion on groups [#6416](https://github.com/fabricjs/fabric.js/pull/6416);
 - fix(fabric.Object): geometry mixin fix partiallyOnscreen [#6402](https://github.com/fabricjs/fabric.js/pull/6402);
 - fix(fabric.Image): ISSUE-6397 modify crossOrigin behaviour for setSrc [#6414](https://github.com/fabricjs/fabric.js/pull/6414);
 - Breaking: fabric.Image.setCrossOrigin is gone. Having the property on the fabric.Image is misleading and brings to errors. crossOrigin is for loading/reloading only, and is mandatory to specify it each load.
+- Breaking: fabric.Control constructor does not accept anymore a position object, but 2 properties, x and y.
 
 ## [4.0.0-beta.12]
 - fix(fabric.IText): respect value of `cursorColor` [#6300](https://github.com/fabricjs/fabric.js/pull/6300);

--- a/HEADER.js
+++ b/HEADER.js
@@ -1,6 +1,6 @@
 /*! Fabric.js Copyright 2008-2015, Printio (Juriy Zaytsev, Maxim Chernyak) */
 
-var fabric = fabric || { version: '4.0.0-beta.12' };
+var fabric = fabric || { version: '4.0.0-rc.1' };
 if (typeof exports !== 'undefined') {
   exports.fabric = fabric;
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fabric",
   "description": "Object model for HTML5 canvas, and SVG-to-canvas parser. Backed by jsdom and node-canvas.",
   "homepage": "http://fabricjs.com/",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-rc.1",
   "author": "Juriy Zaytsev <kangax@gmail.com>",
   "contributors": [
     {
@@ -62,7 +62,7 @@
   },
   "optionalDependencies": {
     "canvas": "^2.6.1",
-    "jsdom": "^15.1.0"
+    "jsdom": "^15.2.1"
   },
   "devDependencies": {
     "eslint": "4.18.x",

--- a/src/control.class.js
+++ b/src/control.class.js
@@ -39,7 +39,8 @@
 
     /**
      * Drawing angle of the control.
-     * Used to reuse the same drawing function for different rotated controls
+     * NOT used for now, but name marked as needed for internal logic
+     * example: to reuse the same drawing function for different rotated controls
      * @type {Number}
      * @default 0
      */
@@ -100,6 +101,33 @@
      * @default false
      */
     withConnection: false,
+
+    /**
+     * The control actionHandler, provide one to handle action ( control being moved )
+     * @param {Event} eventData the native mouse event
+     * @param {Object} transformData properties of the current transform
+     * @param {fabric.Object} object on which the control is displayed
+     * @return {Function}
+     */
+    actionHandler: function(/* eventData, transformData, fabricObject */) { },
+
+    /**
+     * The control handler for mouse down, provide one to handle mouse down on control
+     * @param {Event} eventData the native mouse event
+     * @param {Object} transformData properties of the current transform
+     * @param {fabric.Object} object on which the control is displayed
+     * @return {Function}
+     */
+    mouseDownHandler: function(/* eventData, transformData, fabricObject */) { },
+
+    /**
+     * The control mouseUpHandler, provide one to handle an effect on mouse up.
+     * @param {Event} eventData the native mouse event
+     * @param {Object} transformData properties of the current transform
+     * @param {fabric.Object} object on which the control is displayed
+     * @return {Function}
+     */
+    mouseUpHandler: function(/* eventData, transformData, fabricObject */) { },
 
     /**
      * Returns control actionHandler

--- a/src/control.class.js
+++ b/src/control.class.js
@@ -46,13 +46,6 @@
     angle: 0,
 
     /**
-     * Maybe useless, maybe will get removed before releaseing
-     * @type {String}
-     * @default ''
-     */
-    name: '',
-
-    /**
      * Relative position of the control. X
      * 0,0 is the center of the Object, while -0.5 (left) or 0.5 (right) are the extremities
      * of the bounding box.

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -930,6 +930,7 @@
           y = pointer.y,
           action = transform.action,
           actionPerformed = false,
+          actionHandler = transform.actionHandler,
           // this object could be created from the function in the control handlers
           options = {
             target: transform.target,
@@ -945,8 +946,8 @@
           this.setCursor(options.target.moveCursor || this.moveCursor);
         }
       }
-      else {
-        (actionPerformed = transform.actionHandler(e, transform, x, y)) && this._fire(action, options);
+      else if (actionHandler) {
+        (actionPerformed = actionHandler(e, transform, x, y)) && this._fire(action, options);
       }
       transform.actionPerformed = transform.actionPerformed || actionPerformed;
     },

--- a/src/mixins/default_controls.js
+++ b/src/mixins/default_controls.js
@@ -10,7 +10,6 @@
       objectControls = fabric.Object.prototype.controls;
 
   objectControls.ml = new fabric.Control({
-    name: 'ml',
     x: -0.5,
     y: 0,
     cursorStyleHandler: scaleSkewStyleHandler,
@@ -19,7 +18,6 @@
   });
 
   objectControls.mr = new fabric.Control({
-    name: 'mr',
     x: 0.5,
     y: 0,
     cursorStyleHandler: scaleSkewStyleHandler,
@@ -28,7 +26,6 @@
   });
 
   objectControls.mb = new fabric.Control({
-    name: 'mb',
     x: 0,
     y: 0.5,
     cursorStyleHandler: scaleSkewStyleHandler,
@@ -37,7 +34,6 @@
   });
 
   objectControls.mt = new fabric.Control({
-    name: 'mt',
     x: 0,
     y: -0.5,
     cursorStyleHandler: scaleSkewStyleHandler,
@@ -46,7 +42,6 @@
   });
 
   objectControls.tl = new fabric.Control({
-    name: 'tl',
     x: -0.5,
     y: -0.5,
     cursorStyleHandler: scaleStyleHandler,
@@ -54,7 +49,6 @@
   });
 
   objectControls.tr = new fabric.Control({
-    name: 'tr',
     x: 0.5,
     y: -0.5,
     cursorStyleHandler: scaleStyleHandler,
@@ -62,7 +56,6 @@
   });
 
   objectControls.bl = new fabric.Control({
-    name: 'bl',
     x: -0.5,
     y: 0.5,
     cursorStyleHandler: scaleStyleHandler,
@@ -70,7 +63,6 @@
   });
 
   objectControls.br = new fabric.Control({
-    name: 'br',
     x: 0.5,
     y: 0.5,
     cursorStyleHandler: scaleStyleHandler,
@@ -78,7 +70,6 @@
   });
 
   objectControls.mtr = new fabric.Control({
-    name: 'mtr',
     x: 0,
     y: -0.5,
     actionHandler: controlHandlers.rotationWithSnapping,
@@ -105,7 +96,6 @@
     textBoxControls.mb = objectControls.mb;
 
     textBoxControls.mr = new fabric.Control({
-      name: 'mr',
       x: 0.5,
       y: 0,
       actionHandler: controlHandlers.changeWidth,
@@ -114,7 +104,6 @@
     });
 
     textBoxControls.ml = new fabric.Control({
-      name: 'ml',
       x: -0.5,
       y: 0,
       actionHandler: controlHandlers.changeWidth,

--- a/src/parser.js
+++ b/src/parser.js
@@ -1045,12 +1045,6 @@
       function onComplete(r) {
 
         var xml = r.responseXML;
-        if (xml && !xml.documentElement && fabric.window.ActiveXObject && r.responseText) {
-          xml = new ActiveXObject('Microsoft.XMLDOM');
-          xml.async = 'false';
-          //IE chokes on DOCTYPE
-          xml.loadXML(r.responseText.replace(/<!DOCTYPE[\s\S]*?(\[[\s\S]*\])*?>/i, ''));
-        }
         if (!xml || !xml.documentElement) {
           callback && callback(null);
           return false;
@@ -1072,21 +1066,8 @@
      * @param {String} [options.crossOrigin] crossOrigin crossOrigin setting to use for external resources
      */
     loadSVGFromString: function(string, callback, reviver, options) {
-      string = string.trim();
-      var doc;
-      if (typeof fabric.window.DOMParser !== 'undefined') {
-        var parser = new fabric.window.DOMParser();
-        if (parser && parser.parseFromString) {
-          doc = parser.parseFromString(string, 'text/xml');
-        }
-      }
-      else if (fabric.window.ActiveXObject) {
-        doc = new ActiveXObject('Microsoft.XMLDOM');
-        doc.async = 'false';
-        // IE chokes on DOCTYPE
-        doc.loadXML(string.replace(/<!DOCTYPE[\s\S]*?(\[[\s\S]*\])*?>/i, ''));
-      }
-
+      var parser = new fabric.window.DOMParser(),
+          doc = parser.parseFromString(string.trim(), 'text/xml');
       fabric.parseSVGDocument(doc.documentElement, function (results, _options, elements, allElements) {
         callback(results, _options, elements, allElements);
       }, reviver, options);

--- a/src/util/dom_event.js
+++ b/src/util/dom_event.js
@@ -1,5 +1,5 @@
 (function () {
-  // since ie10 can use addEventListener but they do not support options, i need to check
+  // since ie11 can use addEventListener but they do not support options, i need to check
   var couldUseAttachEvent = !!fabric.document.createElement('div').attachEvent,
       touchEvents = ['touchstart', 'touchmove', 'touchend'];
   /**


### PR DESCRIPTION
Since last beta:

- fix(fabric.Canvas): ISSUE-6314 rerender in case of drag selection that select a single oobject. [#6421](https://github.com/fabricjs/fabric.js/pull/6421);
- feat(text): allow correct cursor/selection position if text is edited inside a group. [#6256](https://github.com/fabricjs/fabric.js/pull/6256);
- feat(fabric.Control): remove position option in favor of x and y [#6415](https://github.com/fabricjs/fabric.js/pull/6415);
- fix(fabric.Object) ISSUE-6340 infinite recursion on groups [#6416](https://github.com/fabricjs/fabric.js/pull/6416);
- fix(fabric.Object): geometry mixin fix partiallyOnscreen [#6402](https://github.com/fabricjs/fabric.js/pull/6402);
- fix(fabric.Image): ISSUE-6397 modify crossOrigin behaviour for setSrc [#6414](https://github.com/fabricjs/fabric.js/pull/6414);
- Breaking: fabric.Image.setCrossOrigin is gone. Having the property on the fabric.Image is misleading and brings to errors. crossOrigin is for loading/reloading only, and is mandatory to specify it each load.
- Breaking: fabric.Control constructor does not accept anymore a position object, but 2 properties, x and y.
