### PR TITLE
fix(fabric.IText): copy style in non full mode when typing text

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -189,6 +189,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         // we want to copy the style before the cursor OR the style at the cursor if selection
         // is bigger than 0.
         copiedStyle = this.getSelectionStyles(selectionStart, selectionStart + 1, false);
+        console.log(copiedStyle)
         // now duplicate the style one for each inserted text.
         copiedStyle = insertedText.map(function() {
           // this return an array of references, but that is fine since we are

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -188,7 +188,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         // let's copy some style before deleting.
         // we want to copy the style before the cursor OR the style at the cursor if selection
         // is bigger than 0.
-        copiedStyle = this.getSelectionStyles(selectionStart, selectionStart + 1, true);
+        copiedStyle = this.getSelectionStyles(selectionStart, selectionStart + 1, false);
         // now duplicate the style one for each inserted text.
         copiedStyle = insertedText.map(function() {
           // this return an array of references, but that is fine since we are

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -189,7 +189,6 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         // we want to copy the style before the cursor OR the style at the cursor if selection
         // is bigger than 0.
         copiedStyle = this.getSelectionStyles(selectionStart, selectionStart + 1, false);
-        console.log(copiedStyle)
         // now duplicate the style one for each inserted text.
         copiedStyle = insertedText.map(function() {
           // this return an array of references, but that is fine since we are


### PR DESCRIPTION
Copying style without using the full properties available, will avoid creating extra props that make the text completely styled and not reacting anymore to the generic properties of the text object.

close #6436 
close #6426 
