### PR TITLE
docs(filters): Fix parameter in example

### DIFF
--- a/src/filters/gamma_filter.class.js
+++ b/src/filters/gamma_filter.class.js
@@ -15,7 +15,7 @@
    * @see {@link http://fabricjs.com/image-filters|ImageFilters demo}
    * @example
    * var filter = new fabric.Image.filters.Gamma({
-   *   brightness: 200
+   *   gamma: [1, 0.5, 2.1]
    * });
    * object.filters.push(filter);
    * object.applyFilters();


### PR DESCRIPTION
There is an error in the example sentence of `fabric.Image.filters.Gamma`. The parameter name was `brightness` and was a numeric.