### PR TITLE
Docs: Added clearer NPM import examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,23 @@ Fabric.js started as a foundation for design editor on [printio.ru](http://print
 
 <h3 id="npm-install">Install with npm</h3>
 
-To install Fabric.js using npm, you must first manually [install Cairo](http://cairographics.org/download/) on your system. Cairo is a system library which powers node-canvas, which Fabric.js relies on. When the installation is complete, you may need to restart your terminal or command prompt before installing fabric.
+Note: If you are using Fabric.js in a Node.js script, you must first manually [install Cairo](http://cairographics.org/download/) on your system. Cairo is a system library which powers node-canvas, which Fabric.js relies on. When the installation is complete, you may need to restart your terminal or command prompt before installing fabric.
+
 
     $ npm install fabric --save
+    
+
+After this, you can import fabric like so:
+
+```
+const fabric = require("fabric").fabric;
+```
+
+Or you can use this instead if your environment supports ES6 imports:
+
+```
+import { fabric } from "fabric";
+```
 
 <h3 id="fabric-building">Building</h3>
 
@@ -194,27 +208,6 @@ For example:
     node build.js modules=ALL exclude=json no-strict no-svg-export
 
 ### Examples of use
-
-#### Using NPM
-
-To use fabric with npm, run
-
-```bash
-npm i fabric
-```
-
-After this, you can import fabric like so:
-
-```
-const fabric = require("fabric").fabric;
-```
-
-If you are using ES6 imports (such as in React), you can use this instead:
-
-```
-import { fabric } from "fabric";
-```
-
 
 #### Adding red rectangle to canvas
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Fabric.js started as a foundation for design editor on [printio.ru](http://print
 
 <h3 id="npm-install">Install with npm</h3>
 
-Note: If you are using Fabric.js in a Node.js script, you must first manually [install Cairo](http://cairographics.org/download/) on your system. Cairo is a system library which powers node-canvas, which Fabric.js relies on. When the installation is complete, you may need to restart your terminal or command prompt before installing fabric.
+Note: If you are using Fabric.js in a Node.js script, you will depend from [node-canvas](https://github.com/Automattic/node-canvas).`node-canvas` is an html canvas replacement that works on top of native libraries.
+Please follow the instructions located [here](https://github.com/Automattic/node-canvas#compiling) in order to get it up and running.
 
 
     $ npm install fabric --save

--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ For example:
 
 ### Examples of use
 
+#### Using NPM
+
+To use fabric with npm, run
+
+```bash
+npm i fabric
+```
+
+After this, you can import fabric like so:
+
+```
+const fabric = require("fabric").fabric;
+```
+
+If you are using ES6 imports (such as in React), you can use this instead:
+
+```
+import { fabric } from "fabric";
+```
+
+
 #### Adding red rectangle to canvas
 
 ```html

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ You can [run automated unit tests](http://fabricjs.com/test/unit/) right in the 
 
 Fabric.js started as a foundation for design editor on [printio.ru](http://printio.ru) — interactive online store with ability to create your own designs. The idea was to create [Javascript-based editor](http://printio.ru/ringer_man_tees/new), which would make it easy to manipulate vector shapes and images on T-Shirts. Since performance was one of the most critical requirements, we chose canvas over SVG. While SVG is excellent with static shapes, it's not as performant as canvas when it comes to dynamic manipulation of objects (movement, scaling, rotation, etc.). Fabric.js was heavily inspired by [Ernest Delgado's canvas experiment](http://www.ernestdelgado.com/public-tests/canvasphoto/demo/canvas.html). In fact, code from Ernest's experiment was the foundation of an entire framework. Later, Fabric.js grew into a collection of distinct object types and got an SVG-to-canvas parser.
 
+### Installation Instructions
+
 <h3 id="bower-install">Install with bower</h3>
 
     $ bower install fabric

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-### Fabric
+## Fabric.js
+
 <!-- build/coverage status, climate -->
 
 [![Build Status](https://secure.travis-ci.org/fabricjs/fabric.js.svg?branch=master)](http://travis-ci.org/#!/kangax/fabric.js)
@@ -87,6 +88,8 @@ Or you can use this instead if your environment supports ES6 imports:
 ```
 import { fabric } from "fabric";
 ```
+
+See [the example section](#examples-of-use) for usage examples.
 
 <h3 id="fabric-building">Building</h3>
 


### PR DESCRIPTION
See Issue #6466

This PR updates the examples for using Fabric.js in NPM environments. Specifically, it provides an import example for a NPM app or script.