### PR TITLE
fix(fabric.Object): when in groups or active groups, fix the ability to shift deselect

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -450,29 +450,6 @@
     },
 
     /**
-     * Checks if point is contained within an area of given object
-     * @param {Event} e Event object
-     * @param {fabric.Object} target Object to test against
-     * @param {Object} [point] x,y object of point coordinates we want to check.
-     * @return {Boolean} true if point is contained within an area of given object
-     */
-    containsPoint: function (e, target, point) {
-      var ignoreZoom = true,
-          pointer = point || this.getPointer(e, ignoreZoom),
-          xy, isTouch = e ? isTouchEvent(e) : false;
-
-      if (target.group && target.group === this._activeObject && target.group.type === 'activeSelection') {
-        xy = this._normalizePointer(target.group, pointer);
-      }
-      else {
-        xy = { x: pointer.x, y: pointer.y };
-      }
-      // http://www.geog.ubc.ca/courses/klink/gis.notes/ncgia/u32.html
-      // http://idav.ucdavis.edu/~okreylos/TAship/Spring2000/PointInPolygon.html
-      return (target.containsPoint(xy) || !!target._findTargetCorner(pointer, isTouch));
-    },
-
-    /**
      * @private
      */
     _normalizePointer: function (object, pointer) {
@@ -850,7 +827,10 @@
       if (obj &&
           obj.visible &&
           obj.evented &&
-          this.containsPoint(null, obj, pointer)) {
+          // http://www.geog.ubc.ca/courses/klink/gis.notes/ncgia/u32.html
+          // http://idav.ucdavis.edu/~okreylos/TAship/Spring2000/PointInPolygon.html
+          (obj.containsPoint(pointer) || !!obj._findTargetCorner(pointer))
+      ) {
         if ((this.perPixelTargetFind || obj.perPixelTargetFind) && !obj.isEditing) {
           var isTransparent = this.isTargetTransparent(obj, globalPointer.x, globalPointer.y);
           if (!isTransparent) {
@@ -877,7 +857,7 @@
       // until we call this function specifically to search inside the activeGroup
       while (i--) {
         var objToCheck = objects[i];
-        var pointerToUse = objToCheck.group && objToCheck.group.type !== 'activeSelection' ?
+        var pointerToUse = objToCheck.group ?
           this._normalizePointer(objToCheck.group, pointer) : pointer;
         if (this._checkTarget(pointerToUse, objToCheck, pointer)) {
           target = objects[i];

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -525,7 +525,9 @@
      */
     setCoords: function(skipCorners) {
       this.aCoords = this.calcACoords();
-      this.lineCoords = this.calcLineCoords();
+      // in case we are in a group, for how the inner group target check works,
+      // lineCoords are exactly aCoords. Since the vpt gets absorbed by the normalized pointer.
+      this.lineCoords = this.group ? this.aCoords : this.calcLineCoords();
       if (skipCorners) {
         return this;
       }

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -104,7 +104,6 @@
 
     /**
      * @private
-     * @param {Boolean} [skipCoordsChange] if true, coordinates of objects enclosed in a group do not change
      */
     _updateObjectsACoords: function() {
       var skipControls = true;
@@ -398,8 +397,8 @@
      */
     _restoreObjectState: function(object) {
       this.realizeTransform(object);
-      object.setCoords();
       delete object.group;
+      object.setCoords();
       return this;
     },
 

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -2207,34 +2207,6 @@
     assert.equal(canvas.getHeight(), 500, 'Should be as the backstore only value');
   });
 
-  QUnit.test('containsPoint', function(assert) {
-    assert.ok(typeof canvas.containsPoint === 'function');
-
-    var rect = new fabric.Rect({ left: 75, top: 75, width: 50, height: 50 });
-    canvas.add(rect);
-
-    var canvasEl = canvas.getElement(),
-        canvasOffset = fabric.util.getElementOffset(canvasEl);
-
-    var eventStub = {
-      clientX: canvasOffset.left + 100,
-      clientY: canvasOffset.top + 100,
-      target: rect
-    };
-
-    assert.ok(canvas.containsPoint(eventStub, rect), 'point at (100, 100) should be within area (75, 75, 125, 125)');
-
-    eventStub = {
-      clientX: canvasOffset.left + 200,
-      clientY: canvasOffset.top + 200,
-      target: rect
-    };
-    assert.ok(!canvas.containsPoint(eventStub, rect), 'point at (200, 200) should NOT be within area (75, 75, 125, 125)');
-
-    rect.set('left', 175).set('top', 175).setCoords();
-    assert.ok(canvas.containsPoint(eventStub, rect), 'on rect at (200, 200) should be within area (175, 175, 225, 225)');
-  });
-
   QUnit.test('setupCurrentTransform', function(assert) {
     assert.ok(typeof canvas._setupCurrentTransform === 'function');
 
@@ -2353,24 +2325,6 @@
   //   assert.equal(rect.originX, 'right');
   //   assert.equal(rect.originY, 'bottom');
   // });
-
-  QUnit.test('containsPoint in viewport transform', function(assert) {
-    canvas.viewportTransform = [2, 0, 0, 2, 50, 50];
-    var rect = new fabric.Rect({ left: 75, top: 75, width: 50, height: 50 });
-    canvas.add(rect);
-
-    var canvasEl = canvas.getElement(),
-        canvasOffset = fabric.util.getElementOffset(canvasEl);
-
-    var eventStub = {
-      clientX: canvasOffset.left + 250,
-      clientY: canvasOffset.top + 250,
-      target: rect
-    };
-
-    assert.ok(canvas.containsPoint(eventStub, rect), 'point at (250, 250) should be within area (75, 75, 125, 125)');
-    canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
-  });
 
   QUnit.test('fxRemove', function(assert) {
     var done = assert.async();


### PR DESCRIPTION
close #6493 
close #6530 

When checking sub targets in active selection the viewport handling is done in normalize pointer, and this was in contrast with how lineCoords are built.
To avoid this, we know that lineCoords equal to aCoords when objects are in a container. We can fix setCoords to do not calculate those extra coords when using setCoords in grouped objects.