### PR TITLE
Fix mouse up target while performing drag operation

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -524,6 +524,10 @@
             absolutePointer: this._absolutePointer,
             transform: this._currentTransform
           };
+      if (eventType === 'up') {
+        options.currentTarget = this.findTarget(e);
+        options.currentSubTargets = this.targets;
+      }
       this.fire('mouse:' + eventType, options);
       target && target.fire('mouse' + eventType, options);
       for (var i = 0; i < targets.length; i++) {

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -301,6 +301,21 @@
     assert.equal(isClick, false, 'moving the pointer, the click is false');
   });
 
+  QUnit.test('mouse:up should return currentTarget', function(assert) {
+    var e = { clientX: 30, clientY: 30, which: 1 };
+    var e2 = { clientX: 31, clientY: 31, which: 1 };
+    var rect = new fabric.Rect({ left: 0, top: 0, width: 50, height: 50 });
+    canvas.add(rect);
+    var opt;
+    canvas.on('mouse:up', function(_opt) {
+      opt = _opt;
+    });
+    canvas.__onMouseDown(e);
+    canvas.__onMouseMove(e2);
+    canvas.__onMouseUp(e2);
+    assert.equal(opt.currentTarget, rect, 'options match model - currentTarget');
+  });
+
   QUnit.test('fires object:modified and object:moved', function(assert) {
     var e = { clientX: 30, clientY: 30, which: 1 };
     var e2 = { clientX: 31, clientY: 31, which: 1 };

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -301,19 +301,22 @@
     assert.equal(isClick, false, 'moving the pointer, the click is false');
   });
 
-  QUnit.test('mouse:up should return currentTarget', function(assert) {
-    var e = { clientX: 30, clientY: 30, which: 1 };
-    var e2 = { clientX: 31, clientY: 31, which: 1 };
-    var rect = new fabric.Rect({ left: 0, top: 0, width: 50, height: 50 });
-    canvas.add(rect);
+  QUnit.test('mouse:up should return target and currentTarget', function(assert) {
+    var e1 = { clientX: 30, clientY: 30, which: 1 };
+    var e2 = { clientX: 100, clientY: 100, which: 1 };
+    var rect1 = new fabric.Rect({ left: 0, top: 0, width: 50, height: 50, lockMovementX: true, lockMovementY: true });
+    var rect2 = new fabric.Rect({ left: 75, top: 75, width: 50, height: 50 });
+    canvas.add(rect1);
+    canvas.add(rect2);
     var opt;
     canvas.on('mouse:up', function(_opt) {
       opt = _opt;
     });
-    canvas.__onMouseDown(e);
+    canvas.__onMouseDown(e1);
     canvas.__onMouseMove(e2);
     canvas.__onMouseUp(e2);
-    assert.equal(opt.currentTarget, rect, 'options match model - currentTarget');
+    assert.equal(opt.target, rect1, 'options match model - target');
+    assert.equal(opt.currentTarget, rect2, 'options match model - currentTarget');
   });
 
   QUnit.test('fires object:modified and object:moved', function(assert) {


### PR DESCRIPTION
Hi @asturur 

I'm trying to fix the bug describer here in #6117. Based on my limited understanding of the code, I feel the bug is triggered because a transform event of "Drag" is fired. The problem here is that the node's x and y positions are locked. If they were unlocked then surely the mouse up target will be the same as mouse down. But here since the positions are locked, the mouse up target should be wherever the mouse currently is. That I found was coming out as incorrect because of the drag transform being fired.

Can you review this draft and provide your suggestions ?

Thanks,
Kartik