### PR TITLE
Remove Erroneous Comment and Fix for Parsing CSS Rules

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -983,8 +983,7 @@
 
       // very crude parsing of style contents
       for (i = 0, len = styles.length; i < len; i++) {
-        // <style/> could produce `undefined`, covering this case with ''
-        var styleContents = styles[i].textContent || '';
+        var styleContents = styles[i].textContent;
 
         // remove comments
         styleContents = styleContents.replace(/\/\*[\s\S]*?\*\//g, '');


### PR DESCRIPTION
Hi guys,

I stumbled across a bug which existed in version 3.0.0 which was caused by empty style tags within an SVG document. In PR #6169, this was fixed but an erroneous comment and fix.

The original code:
```
// IE9 doesn't support textContent, but provides text instead.
var styleContents = styles[i].textContent || styles[i].text;
```
After PR #6169:
```
// <style/> could produce `undefined`, covering this case with ''
var styleContents = styles[i].textContent || '';
```

As stated in the docs, the `textContent` property will always be a string. So it's not necessary to add a logic OR. The actual issue back then was that an empty string is interpreted as falsy in JS, so it would take the value of the second parameter which isn't defined. In my case on Chrome, I had an empty style tag that would evaluate to an empty string and so I ended up with `styleContents` being undefined.
```
var styleContents = "" || undefined; // evaluates to undefined
```

After removing the deprecated IE9 fix, it's just fine to take the value of `textContent` without the logical OR:
```
var styleContents = styles[i].textContent;
```

This won't change any functionality and the added test in the former PR still applies. I wanted to add this just for the sake of correctness.

Greetings,
Thomas
