### PR TITLE
fix(fabric.Canvas): rotation handle should take origin into account

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -608,10 +608,6 @@
       else if (corner === 'bl' || corner === 'mb' || corner === 'br') {
         origin.y = 'top';
       }
-      else if (corner === 'mtr') {
-        origin.x = 'center';
-        origin.y = 'center';
-      }
       return origin;
     },
 


### PR DESCRIPTION
Remove the fixed center origin from the code.
Default origin should depend from `_shouldCenterTransform` function in the `_setupCurrentTransform`;

close #6679