### PR TITLE
fix(fabric.Pattern): Dynamic Patterns Demo

### DIFF
--- a/src/pattern.class.js
+++ b/src/pattern.class.js
@@ -168,7 +168,7 @@
      * @return {CanvasPattern}
      */
     toLive: function(ctx) {
-      var source = this.source;
+      var source = typeof this.source === 'function' ? this.source() : this.source;
       // if the image failed to load, return, and allow rest to continue loading
       if (!source) {
         return '';


### PR DESCRIPTION
Fix [Dynamic Patterns demo](http://fabricjs.com/dynamic-patterns):

`fabric.Pattern` accepts `options: { source: CanvasImageSource, ...options }` as its first argument. If `CanvasImageSource` is dynamic (see [demo](http://fabricjs.com/dynamic-patterns)), we might need `options.source` to be a function. If that's the case, we need to call `source` in `fabric.Patterns'`s `toLive` method.

![dynamic-patterns](https://user-images.githubusercontent.com/28757259/99886596-9b267180-2bf2-11eb-9f49-2598f2cb620a.gif)

Issue at https://github.com/fabricjs/fabric.js/issues/6698.