### PR TITLE
fix(fabric.Text) fix typo in cacheProperties preventing cache clear to work

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -991,7 +991,6 @@
           this.group.set('dirty', true);
         }
       }
-
       return this;
     },
 

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -10,9 +10,9 @@
     return;
   }
 
-  var styleProps =
-    'fontFamily fontWeight fontSize text underline overline linethrough' +
-    ' textAlign fontStyle lineHeight textBackgroundColor charSpacing styles path'.split(' ');
+  var additionalProps =
+    ('fontFamily fontWeight fontSize text underline overline linethrough' +
+    ' textAlign fontStyle lineHeight textBackgroundColor charSpacing styles path').split(' ');
 
   /**
    * Text class
@@ -172,13 +172,13 @@
      * as well as for history (undo/redo) purposes
      * @type Array
      */
-    stateProperties: fabric.Object.prototype.stateProperties.concat(styleProps),
+    stateProperties: fabric.Object.prototype.stateProperties.concat(additionalProps),
 
     /**
      * List of properties to consider when checking if cache needs refresh
      * @type Array
      */
-    cacheProperties: fabric.Object.prototype.cacheProperties.concat(styleProps),
+    cacheProperties: fabric.Object.prototype.cacheProperties.concat(additionalProps),
 
     /**
      * When defined, an object is rendered via stroke and this property specifies its color.

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -841,5 +841,9 @@
     assert.equal(text.height, 100, 'text is big as the path height');
   });
 
+  QUnit.test('cacheProperties for text', function(assert) {
+    var text = new fabric.Text('a');
+    assert.equal(text.cacheProperties.join('-'), 'fill-stroke-strokeWidth-strokeDashArray-width-height-paintFirst-strokeUniform-strokeLineCap-strokeDashOffset-strokeLineJoin-strokeMiterLimit-backgroundColor-clipPath-fontFamily-fontWeight-fontSize-text-underline-overline-linethrough-textAlign-fontStyle-lineHeight-textBackgroundColor-charSpacing-styles-path');
+  });
 
 })();


### PR DESCRIPTION
refactoring some code i missed a couple of brakets around a multiline string.
This wasn't caught by any test, now we have a test to catch it.

close #6767
