### PR TITLE
Added activeOn 'up/down' property

### DIFF
--- a/HEADER.js
+++ b/HEADER.js
@@ -128,16 +128,6 @@ fabric.textureSize = 2048;
 fabric.disableStyleCopyPaste = false;
 
 /**
- * When 'true', objects on touch devices will be selected on the first touch,
- * with subsequent touches required to transform/move the object.
- * Defaults to 'false'.
- * @since 4.4.0
- * @type Boolean
- * @default
- */
-fabric.touchSelectBeforeTransform = false;
-
-/**
  * Enable webgl for filtering picture is available
  * A filtering backend will be initialized, this will both take memory and
  * time since a default 2048x2048 canvas will be created for the gl context

--- a/HEADER.js
+++ b/HEADER.js
@@ -128,6 +128,16 @@ fabric.textureSize = 2048;
 fabric.disableStyleCopyPaste = false;
 
 /**
+ * When 'true', objects on touch devices will be selected on the first touch,
+ * with subsequent touches required to transform/move the object.
+ * Defaults to 'false'.
+ * @since 4.4.0
+ * @type Boolean
+ * @default
+ */
+fabric.touchSelectBeforeTransform = false;
+
+/**
  * Enable webgl for filtering picture is available
  * A filtering backend will be initialized, this will both take memory and
  * time since a default 2048x2048 canvas will be created for the gl context

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -717,6 +717,10 @@
         var alreadySelected = target === this._activeObject;
         if (target.selectable) {
           this.setActiveObject(target, e);
+          if (fabric.touchSelectBeforeTransform &&
+            !alreadySelected && fabric.util.isTouchEvent(e)) {
+            return;
+          }
         }
         var corner = target._findTargetCorner(
           this.getPointer(e, true),

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -721,7 +721,7 @@
 
       if (target) {
         var alreadySelected = target === this._activeObject;
-        if (target.selectable && target.activeOn !== 'up') {
+        if (target.selectable && target.activeOn === 'down') {
           this.setActiveObject(target, e);
         }
         var corner = target._findTargetCorner(

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -451,6 +451,22 @@
         }
       }
       if (target) {
+        if (target.selectable && target !== this._activeObject) {
+          if (fabric.util.isTouchEvent(e)) {
+            var activeOnDown = (target.setActiveOn === 'mouseuptouchdown' ||
+            target.setActiveOn === 'mousetouchdown');
+          }
+          else {
+            var activeOnDown = (target.setActiveOn === 'mousetouchdown' ||
+            target.setActiveOn === 'mousedowntouchup');
+          }
+          if (!activeOnDown) {
+            this.setActiveObject(target, e);
+            this._handleEvent(e, 'up', LEFT_CLICK, isClick);
+            this.requestRenderAll();
+            return;
+          }
+        }
         var corner = target._findTargetCorner(
           this.getPointer(e, true),
           fabric.util.isTouchEvent(e)

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -451,31 +451,21 @@
         }
       }
       if (target) {
-        if (target.selectable && target !== this._activeObject) {
-          if (fabric.util.isTouchEvent(e)) {
-            var activeOnDown = (target.setActiveOn === 'mouseuptouchdown' ||
-            target.setActiveOn === 'mousetouchdown');
-          }
-          else {
-            var activeOnDown = (target.setActiveOn === 'mousetouchdown' ||
-            target.setActiveOn === 'mousedowntouchup');
-          }
-          if (!activeOnDown) {
-            this.setActiveObject(target, e);
-            this._handleEvent(e, 'up', LEFT_CLICK, isClick);
-            this.requestRenderAll();
-            return;
-          }
+        if (target.selectable && target !== this._activeObject && target.activeOn === 'up') {
+          this.setActiveObject(target, e);
+          shouldRender = true;
         }
-        var corner = target._findTargetCorner(
-          this.getPointer(e, true),
-          fabric.util.isTouchEvent(e)
-        );
-        var control = target.controls[corner],
-            mouseUpHandler = control && control.getMouseUpHandler(e, target, control);
-        if (mouseUpHandler) {
-          var pointer = this.getPointer(e);
-          mouseUpHandler(e, transform, pointer.x, pointer.y);
+        else {
+          var corner = target._findTargetCorner(
+            this.getPointer(e, true),
+            fabric.util.isTouchEvent(e)
+          );
+          var control = target.controls[corner],
+              mouseUpHandler = control && control.getMouseUpHandler(e, target, control);
+          if (mouseUpHandler) {
+            var pointer = this.getPointer(e);
+            mouseUpHandler(e, transform, pointer.x, pointer.y);
+          }
         }
         target.isMoving = false;
       }
@@ -731,21 +721,7 @@
 
       if (target) {
         var alreadySelected = target === this._activeObject;
-        if (!alreadySelected) {
-          if (fabric.util.isTouchEvent(e)) {
-            var activeOnDown = (target.setActiveOn === 'mouseuptouchdown' ||
-            target.setActiveOn === 'mousetouchdown');
-          }
-          else {
-            var activeOnDown = (target.setActiveOn === 'mousetouchdown' ||
-            target.setActiveOn === 'mousedowntouchup');
-          }
-          if (!activeOnDown) {
-            this._handleEvent(e, 'down');
-            return;
-          }
-        }
-        if (target.selectable) {
+        if (target.selectable && target.activeOn !== 'up') {
           this.setActiveObject(target, e);
         }
         var corner = target._findTargetCorner(

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -715,12 +715,22 @@
 
       if (target) {
         var alreadySelected = target === this._activeObject;
-        if (target.selectable) {
-          this.setActiveObject(target, e);
-          if (fabric.touchSelectBeforeTransform &&
-            !alreadySelected && fabric.util.isTouchEvent(e)) {
+        if (!alreadySelected) {
+          if(fabric.util.isTouchEvent(e)) {
+            var activeOnDown = (target.setActiveOn === 'mouseuptouchdown' ||
+            target.setActiveOn === 'mousetouchdown');
+          }
+          else {
+            var activeOnDown = (target.setActiveOn === 'mousetouchdown' ||
+            target.setActiveOn === 'mousedowntouchup');
+          }
+          if(!activeOnDown) {
+            this._handleEvent(e, 'down');
             return;
           }
+        }
+        if (target.selectable) {
+          this.setActiveObject(target, e);
         }
         var corner = target._findTargetCorner(
           this.getPointer(e, true),

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -716,7 +716,7 @@
       if (target) {
         var alreadySelected = target === this._activeObject;
         if (!alreadySelected) {
-          if(fabric.util.isTouchEvent(e)) {
+          if (fabric.util.isTouchEvent(e)) {
             var activeOnDown = (target.setActiveOn === 'mouseuptouchdown' ||
             target.setActiveOn === 'mousetouchdown');
           }
@@ -724,7 +724,7 @@
             var activeOnDown = (target.setActiveOn === 'mousetouchdown' ||
             target.setActiveOn === 'mousedowntouchup');
           }
-          if(!activeOnDown) {
+          if (!activeOnDown) {
             this._handleEvent(e, 'down');
             return;
           }

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -570,7 +570,7 @@
      * @default
      */
     paintFirst:           'fill',
-    
+
     /**
      * When 'mousetouchdown', object is set to active on mousedown/touchdown
      * When 'mousedowntouchup', object is set to active on mousedown/touchup

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -578,7 +578,7 @@
      * When 'mousetouchup', object is set to active on mouseup/touchup
      * since 4.4.0
      * @type String
-     * @default
+     * @default 'mousetouchdown'
      */
     setActiveOn:           'mousetouchdown',
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -572,15 +572,15 @@
     paintFirst:           'fill',
 
     /**
-     * When 'mousetouchdown', object is set to active on mousedown/touchdown
-     * When 'mousedowntouchup', object is set to active on mousedown/touchup
-     * When 'mouseuptouchdown', object is set to active on mouseup/touchdown
-     * When 'mousetouchup', object is set to active on mouseup/touchup
+     * When 'down', object is set to active on mousedown/touchstart
+     * When 'up', object is set to active on mouseup/touchend
+     * Experimental. Let's see if this breaks anything before supporting officially
+     * @private
      * since 4.4.0
      * @type String
-     * @default 'mousetouchdown'
+     * @default 'down'
      */
-    setActiveOn:           'mousetouchdown',
+    activeOn:           'down',
 
     /**
      * List of properties to consider when checking if state

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -570,6 +570,17 @@
      * @default
      */
     paintFirst:           'fill',
+    
+    /**
+     * When 'mousetouchdown', object is set to active on mousedown/touchdown
+     * When 'mousedowntouchup', object is set to active on mousedown/touchup
+     * When 'mouseuptouchdown', object is set to active on mouseup/touchdown
+     * When 'mousetouchup', object is set to active on mouseup/touchup
+     * since 4.4.0
+     * @type String
+     * @default
+     */
+    setActiveOn:           'mousetouchdown',
 
     /**
      * List of properties to consider when checking if state

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -179,6 +179,21 @@
     canvas.__onMouseUp(e);
   });
 
+  QUnit.test('activeOn object selection', function(assert) {
+    var rect = new fabric.Rect({ width: 200, height: 200, activeOn: 'down' });
+    canvas.add(rect);
+    var e = { clientX: 30, clientY: 15, which: 1, target: canvas.upperCanvasEl };
+    canvas.__onMouseDown(e);
+    assert.equal(canvas._activeObject, rect, 'with activeOn of down object is selected on mouse down');
+    canvas.__onMouseUp(e);
+    canvas.discardActiveObject();
+    rect.activeOn = 'up';
+    canvas.__onMouseDown(e);
+    assert.equal(canvas._activeObject, null, 'with activeOn of up object is not selected on mouse down');
+    canvas.__onMouseUp(e);
+    assert.equal(canvas._activeObject, rect, 'with activeOn of up object is selected on mouse up');
+  });
+
   QUnit.test('specific bug #5317 for shift+click and active selection', function(assert) {
     var greenRect = new fabric.Rect({
       width: 300,


### PR DESCRIPTION
Let me know if this is a feature you think this is worth merging. I've had comments from users who find the touch controls difficult since it's easy to accidentally drag/move an object while trying to select it. This property lets you change the touch behavior to select an object on the first touch, and only drag it on subsequent touches.

Not certain on the property name so let me know if you think of a better one.