### PR TITLE
fix: add caveats for ES6 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Or you can use this instead if your build pipeline supports ES6 imports:
 import { fabric } from "fabric";
 ```
 
-NOTE: es6 imports won't work in browser or wth bundlers which expect es6 module like vite. Use commonjs syntax instead.
+NOTE: es6 imports won't work in browser or with bundlers which expect es6 module like vite. Use commonjs syntax instead.
 
 See [the example section](#examples-of-use) for usage examples.
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ After this, you can import fabric like so:
 const fabric = require("fabric").fabric;
 ```
 
-Or you can use this instead if your environment supports ES6 imports:
+Or you can use this instead if your build pipeline supports ES6 imports:
 
 ```
 import { fabric } from "fabric";
 ```
+
+NOTE: es6 imports won't work in browser or wth bundlers which expect es6 module like vite. Use commonjs syntax instead.
 
 See [the example section](#examples-of-use) for usage examples.
 


### PR DESCRIPTION
fabric does not support es6 modules. and requires bundlers to transpile import statements to commonjs imports at compile time. 

However, as browsers have started supporting ES6 modules. The readme gives the impression that fabric is supported via browser's es module which leads to confusion and errors[1]

[1] https://stackoverflow.com/questions/57715326/fabric-js-as-es6-import-in-chrome-doesnt-work