### PR TITLE
ci(): Avoid running coverage check on master merge

### DIFF
--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -3,8 +3,6 @@
 name: Pr quality check
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
This will avoid the error we get every time since there isn't a PR to push a comment to when we merge to master.