### PR TITLE
#6936: call remove on every object on canvas.clear

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -813,7 +813,9 @@
      * @chainable
      */
     clear: function () {
-      this._objects.length = 0;
+      this.forEachObject((function (obj) {
+        this.remove(obj);
+      }).bind(this));
       this.backgroundImage = null;
       this.overlayImage = null;
       this.backgroundColor = '';

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -813,9 +813,7 @@
      * @chainable
      */
     clear: function () {
-      this.forEachObject((function (obj) {
-        this.remove(obj);
-      }).bind(this));
+      this.remove.apply(this, this.getObjects());
       this.backgroundImage = null;
       this.overlayImage = null;
       this.backgroundColor = '';

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -430,10 +430,13 @@
 
     canvas.remove(rect);
     assert.strictEqual(objectsRemoved[0], rect);
+    assert.strictEqual(rect.canvas, undefined);
 
     canvas.remove(circle1, circle2);
     assert.strictEqual(objectsRemoved[1], circle1);
+    assert.strictEqual(circle1.canvas, undefined);
     assert.strictEqual(objectsRemoved[2], circle2);
+    assert.strictEqual(circle2.canvas, undefined);
 
     assert.equal(canvas.isEmpty(), true, 'canvas should be empty');
   });
@@ -450,8 +453,21 @@
     canvas.overlayColor = '#FF0000';
     canvas.backgroundImage = bg;
     canvas.overlayImage = bg;
+
+    var objectsRemoved = [];
+    canvas.on('object:removed', function(e) {
+      objectsRemoved.push(e.target);
+    });
+    var rect1 = makeRect(),
+        rect2 = makeRect(),
+        rect3 = makeRect();
+    canvas.add(rect1, rect2, rect3);
+
     assert.equal(canvas.clear(), canvas, 'should be chainable');
     assert.equal(canvas.getObjects().length, 0, 'clear remove all objects');
+    assert.strictEqual(objectsRemoved[0], rect1, 'clear should fire remove on previously added object');
+    assert.strictEqual(objectsRemoved[1], rect2, 'clear should fire remove on previously added object');
+    assert.strictEqual(objectsRemoved[2], rect3, 'clear should fire remove on previously added object');
     assert.equal(canvas.backgroundColor, '', 'clear remove background color');
     assert.equal(canvas.overlayColor, '', 'clear remove overlay color');
     assert.equal(canvas.backgroundImage, null, 'clear remove bg image');


### PR DESCRIPTION
Suggested fix for #6936: calls canvas.remove on every canvas object, instead of only clearing the canvas._objects array (this would result in firing additional removal events and removing the canvas property of the objects previously added to the canvas).

I understand we should be careful if the initial implementation may have skipped this removal on purpose. In terms of performance, I don't think removal itself is particularly costly in any way. Calling canvas.remove will fire 'object:removed' on canvas and 'removed' on each object for every object, the listeners may be costly or unwanted in some way.

If this is a cause of concern, either because it may be a performance issue or because it may be considered a breaking change: we could maybe implement an option parameter to canvas.remove, maybe called "suppressObjectRemoveEvents", that would default to true - so that this new behavior would be opt-in (at least temporarily).