### PR TITLE
Fix bug - onMouseUp

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -456,10 +456,7 @@
           shouldRender = true;
         }
         else {
-          var corner = target._findTargetCorner(
-            this.getPointer(e, true),
-            fabric.util.isTouchEvent(e)
-          );
+          var corner = target.__corner;
           var control = target.controls[corner],
               mouseUpHandler = control && control.getMouseUpHandler(e, target, control);
           if (mouseUpHandler) {


### PR DESCRIPTION
If the mouse is held down and dragged off the "corner", then `__onMouseUp` **can not find the corner** because the pointer is no longer positioned over the corner. As a result, the `mouseUpHandler` is not invoked when the mouse is released.

This fixes that bug, by using the `__corner` assigned during `__onMouseDown`.