### PR TITLE
Fix decimate deleting end of a freedrawing line

### DIFF
--- a/src/brushes/pencil_brush.class.js
+++ b/src/brushes/pencil_brush.class.js
@@ -253,9 +253,11 @@
           newPoints.push(lastPoint);
         }
       }
-      if (newPoints.length === 1) {
-        newPoints.push(new fabric.Point(newPoints[0].x, newPoints[0].y));
-      }
+      /**
+       * Add the last point from the original line to the end of the array.
+       * This ensures decimate doesn't delete the last point on the line, and ensures the line is > 1 point.
+       */
+      newPoints.push(points[l]);
       return newPoints;
     },
 

--- a/src/brushes/pencil_brush.class.js
+++ b/src/brushes/pencil_brush.class.js
@@ -246,7 +246,7 @@
       var zoom = this.canvas.getZoom(), adjustedDistance = Math.pow(distance / zoom, 2),
           i, l = points.length - 1, lastPoint = points[0], newPoints = [lastPoint],
           cDistance;
-      for (i = 1; i < l; i++) {
+      for (i = 1; i < l - 1; i++) {
         cDistance = Math.pow(lastPoint.x - points[i].x, 2) + Math.pow(lastPoint.y - points[i].y, 2);
         if (cDistance >= adjustedDistance) {
           lastPoint = points[i];

--- a/test/unit/brushes.js
+++ b/test/unit/brushes.js
@@ -21,6 +21,16 @@
       assert.deepEqual(brush._points, [], 'points is an empty array');
     });
 
+	  QUnit.test('decimate points', function(assert) {
+	    var brush = new fabric.PencilBrush(canvas);
+	    var points = [{ x: 1, y: 0 }, { x: 2, y: 0 }, { x: 3, y: 0 }, { x: 4, y: 0 }, { x: 5, y: 0 }];
+	    var distance = 6;
+	    var newPoints = brush.decimatePoints(points, distance);
+	    assert.equal(newPoints[0], points[0], 'first point is always present');
+	    assert.equal(newPoints[1], points[points.length-1], 'last point is always present');
+	    assert.equal(newPoints.length, 2, 'All points removed except first and last');
+	  });
+    
     [true, false].forEach(function(val) {
       QUnit.module('fabric.BaseBrush with canvas.enableRetinaScaling = ' + val, function(hooks) {
         hooks.beforeEach(function() {


### PR DESCRIPTION
Stop decimate from deleting the last point on the line, whilst ensuring the line is always > 1 point in length (so that it actually displays)

Fixes this ticket: https://github.com/fabricjs/fabric.js/issues/6951