### PR TITLE
fix Path._calcDimensions (account for strokeWidth)

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -322,11 +322,12 @@
           deltaX = maxX - minX,
           deltaY = maxY - minY;
 
+      //  account for strokeWidth
       return {
-        left: minX,
-        top: minY,
-        width: deltaX,
-        height: deltaY
+        left: minX - this.strokeWidth / 2,
+        top: minY - this.strokeWidth / 2,
+        width: deltaX + this.strokeWidth,
+        height: deltaY + this.strokeWidth
       };
     }
   });


### PR DESCRIPTION
Motivation #7042 

It seems that the dimensions do not account for `strokeWidth` though it is expected.

Test: https://codesandbox.io/s/fervent-sunset-5d2x8?file=/src/patchPath.ts:100-440

The test reveals another bug that seems to originate from `PencilBrush`, try changing the brush `strokeWidth`