### PR TITLE
Fix svg parsing in case it uses empty use tag or use with image href

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -471,12 +471,23 @@
     var nodelist = _getMultipleNodes(doc, ['use', 'svg:use']), i = 0;
     while (nodelist.length && i < nodelist.length) {
       var el = nodelist[i],
-          xlink = (el.getAttribute('xlink:href') || el.getAttribute('href')).substr(1),
+          xlinkAttribute = el.getAttribute('xlink:href') || el.getAttribute('href');
+
+      if (xlinkAttribute === null) {
+        return;
+      }
+
+      var xlink = xlinkAttribute.substr(1),
           x = el.getAttribute('x') || 0,
           y = el.getAttribute('y') || 0,
           el2 = elementById(doc, xlink).cloneNode(true),
           currentTrans = (el2.getAttribute('transform') || '') + ' translate(' + x + ', ' + y + ')',
-          parentNode, oldLength = nodelist.length, attr, j, attrs, len, namespace = fabric.svgNS;
+          parentNode,
+          oldLength = nodelist.length, attr,
+          j,
+          attrs,
+          len,
+          namespace = fabric.svgNS;
 
       applyViewboxTransform(el2);
       if (/^svg$/i.test(el2.nodeName)) {
@@ -558,7 +569,7 @@
     parsedDim.toBeParsed = toBeParsed;
 
     if (missingViewBox) {
-      if (((x || y) && element.parentNode.nodeName !== '#document')) {
+      if (((x || y) && element.parentNode && element.parentNode.nodeName !== '#document')) {
         translateMatrix = ' translate(' + parseUnit(x) + ' ' + parseUnit(y) + ') ';
         matrix = (element.getAttribute('transform') || '') + translateMatrix;
         element.setAttribute('transform', matrix);

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -802,4 +802,35 @@
     });
   });
 
+  QUnit.test('parseSVGFromString with empty <use/>', function(assert) {
+    var done = assert.async();
+    var string =
+      '<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">' +
+        '<use/>' +
+        '<rect width="10" height="10" />' +
+      '</svg>';
+
+    fabric.loadSVGFromString(string, function(objects) {
+      assert.equal(objects[0].type, 'rect');
+      done();
+    });
+  });
+
+  QUnit.test('parseSVGFromString with <use/> having base64 image href', function(assert) {
+    var done = assert.async();
+    var string =
+      '<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">' +
+        '<defs>' +
+          '<image id="image" x="0" y="0" width="4346.7" height="4346.7" xlink:href="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"/>' +
+        '</defs>' +
+        '<use xlink:href="#image"/>' +
+        '<rect width="10" height="10" />' +
+      '</svg>';
+
+    fabric.loadSVGFromString(string, function(objects) {
+      assert.equal(objects[0].type, 'image');
+      done();
+    });
+  });
+
 })();


### PR DESCRIPTION
Fix cases where parsing string to svg was crashing.

Added the two test cases where this occurs.
1st case (empty <use>) occurs because xLinkAttribute is null (line 476)
2nd case (image href) occurs because element.parentNode is null

Didn't bump dist files as i'm not aware if this should be done in scope of PRs or not
