### PR TITLE
fix(fabric.Path): setting `path` property after initialization

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -374,7 +374,7 @@
   fabric.Path.convertPointsToPath = function (points) {
     var start = points[0].x;
     var minMax = points.reduce(
-      (prev, curr) => {
+      function (prev, curr) {
         return {
           min: Math.min(curr.x, prev.min),
           max: Math.max(curr.x, prev.max)
@@ -384,7 +384,7 @@
     );
     var width = minMax.max - minMax.min;
     return fabric.PencilBrush.prototype.convertPointsToSVGPath
-      .call({ width }, points)
+      .call({ width: width }, points)
       .join(' ');
   };
 

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -50,10 +50,15 @@
     initialize: function (path, options) {
       options = options || {};
       this.callSuper('initialize', options);
-      this.setPath(path || [], options);
+      this._setPath(path || [], options);
     },
 
-    setPath: function (path, options) {
+    /**
+    * @private
+    * @param {Array|String} path Path data (sequence of coordinates and corresponding "command" tokens)
+    * @param {Object} [options] Options object
+    */
+    _setPath: function (path, options) {
       var fromArray = _toString.call(path) === '[object Array]';
 
       this.path = fromArray
@@ -69,11 +74,14 @@
       fabric.Polyline.prototype._setPositionDimensions.call(this, options || {});
     },
 
+    /**
+     * @private
+     */
     _set: function (key, value) {
       if (key === 'path') {
         var left = this.left,
             top = this.top;
-        this.setPath(value);
+        this._setPath(value);
         this.left = left;
         this.top = top;
         this.setCoords();

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -53,7 +53,7 @@
       this.setPath(path || [], options);
     },
 
-    setPath: function (path, options = {}) {
+    setPath: function (path, options) {
       var fromArray = _toString.call(path) === '[object Array]';
 
       this.path = fromArray
@@ -66,7 +66,7 @@
       if (!this.path) {
         return;
       }
-      fabric.Polyline.prototype._setPositionDimensions.call(this, options);
+      fabric.Polyline.prototype._setPositionDimensions.call(this, options || {})
     },
 
     _set: function (key, value) {

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -66,18 +66,19 @@
       if (!this.path) {
         return;
       }
-      fabric.Polyline.prototype._setPositionDimensions.call(this, options || {})
+      fabric.Polyline.prototype._setPositionDimensions.call(this, options || {});
     },
 
     _set: function (key, value) {
       if (key === 'path') {
         var left = this.left,
-          top = this.top;
+            top = this.top;
         this.setPath(value);
         this.left = left;
         this.top = top;
         this.setCoords();
-      } else {
+      }
+      else {
         this.callSuper('_set', key, value);
       }
     },
@@ -368,7 +369,7 @@
   /**
    * @static
    * @memberOf fabric.Path
-   * @param {fabric.Point[]} points 
+   * @param {fabric.Point[]} points
    * @returns {string} svg path
    */
   fabric.Path.convertPointsToPath = function (points) {

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -79,7 +79,11 @@
      */
     _set: function (key, value) {
       if (key === 'path') {
+        var left = this.left,
+            top = this.top;
         this._setPath(value);
+        this.left = left;
+        this.top = top;
         this.setCoords();
       }
       else {

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -6,6 +6,7 @@
       min = fabric.util.array.min,
       max = fabric.util.array.max,
       extend = fabric.util.object.extend,
+      clone = fabric.util.object.clone,
       _toString = Object.prototype.toString,
       toFixed = fabric.util.toFixed;
 
@@ -48,7 +49,8 @@
      * @return {fabric.Path} thisArg
      */
     initialize: function (path, options) {
-      options = options || {};
+      options = clone(options || {});
+      delete options.path;
       this.callSuper('initialize', options);
       this._setPath(path || [], options);
     },
@@ -72,6 +74,7 @@
         return;
       }
       fabric.Polyline.prototype._setPositionDimensions.call(this, options || {});
+      this.setCoords();
     },
 
     /**
@@ -79,12 +82,7 @@
      */
     _set: function (key, value) {
       if (key === 'path') {
-        var left = this.left,
-            top = this.top;
         this._setPath(value);
-        this.left = left;
-        this.top = top;
-        this.setCoords();
       }
       else {
         this.callSuper('_set', key, value);

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -47,13 +47,13 @@
      * @param {Object} [options] Options object
      * @return {fabric.Path} thisArg
      */
-    initialize: function(path, options) {
-      options = options || { };
+    initialize: function (path, options) {
+      options = options || {};
       this.callSuper('initialize', options);
-      if (!path) {
-        path = [];
-      }
+      this.setPath(path || [], options);
+    },
 
+    setPath: function (path, options = {}) {
       var fromArray = _toString.call(path) === '[object Array]';
 
       this.path = fromArray
@@ -67,6 +67,15 @@
         return;
       }
       fabric.Polyline.prototype._setPositionDimensions.call(this, options);
+    },
+
+    _set: function (key, value) {
+      if (key === 'path') {
+        this.setPath(value);
+        this.setCoords();
+      } else {
+        this.callSuper('_set', key, value);
+      }
     },
 
     /**

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -71,7 +71,11 @@
 
     _set: function (key, value) {
       if (key === 'path') {
+        var left = this.left,
+          top = this.top;
         this.setPath(value);
+        this.left = left;
+        this.top = top;
         this.setCoords();
       } else {
         this.callSuper('_set', key, value);

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -79,11 +79,7 @@
      */
     _set: function (key, value) {
       if (key === 'path') {
-        var left = this.left,
-            top = this.top;
         this._setPath(value);
-        this.left = left;
-        this.top = top;
         this.setCoords();
       }
       else {

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -365,6 +365,41 @@
     }
   };
 
+  /**
+   * @static
+   * @memberOf fabric.Path
+   * @param {fabric.Point[]} points 
+   * @returns {string} svg path
+   */
+  fabric.Path.convertPointsToPath = function (points) {
+    var start = points[0].x;
+    var minMax = points.reduce(
+      (prev, curr) => {
+        return {
+          min: Math.min(curr.x, prev.min),
+          max: Math.max(curr.x, prev.max)
+        };
+      },
+      { min: start, max: start }
+    );
+    var width = minMax.max - minMax.min;
+    return fabric.PencilBrush.prototype.convertPointsToSVGPath
+      .call({ width }, points)
+      .join(' ');
+  };
+
+  /**
+   * @static
+   * @memberOf fabric.Path
+   * @param {fabric.Point[]} points
+   * @param {Object} options path options
+   * @returns {fabric.Path} fabric.Path instance
+   */
+  fabric.Path.fromPoints = function (points, options) {
+    return new fabric.Path(fabric.Path.convertPointsToPath(points), options);
+  };
+
+
   /* _FROM_SVG_START_ */
   /**
    * List of attribute names to account for when parsing SVG element (used by `fabric.Path.fromElement`)

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -118,7 +118,6 @@
   QUnit.test('set path after initialization', function (assert) {
     var done = assert.async();
     fabric.Object.NUM_FRACTION_DIGITS = 12;
-    assert.ok(typeof fabric.Path.prototype.setPath === 'function');
     var path = new fabric.Path('M 100 100 L 200 100 L 170 200 z', REFERENCE_PATH_OBJECT);
     path.set('path', REFERENCE_PATH_OBJECT.path);
     assert.deepEqual(path.toObject(), REFERENCE_PATH_OBJECT);

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -115,6 +115,20 @@
     done();
   });
 
+  QUnit.test('set path after initialization', function (assert) {
+    var done = assert.async();
+    fabric.Object.NUM_FRACTION_DIGITS = 12;
+    assert.ok(typeof fabric.Path.prototype.setPath === 'function');
+    var path = new fabric.Path('M 100 100 L 200 100 L 170 200 z', REFERENCE_PATH_OBJECT);
+    path.set('path', REFERENCE_PATH_OBJECT.path);
+    assert.deepEqual(path.toObject(), REFERENCE_PATH_OBJECT);
+    path.set('path', 'M 100 100 L 300 100 L 200 300 z');
+    makePathObject(function (clone) {
+      assert.deepEqual(path.toObject(), clone.toObject());
+      done();
+    });
+  });
+
   QUnit.test('toString', function(assert) {
     var done = assert.async();
     makePathObject(function(path) {
@@ -238,6 +252,48 @@
       assert.deepEqual(path.toObject(), REFERENCE_PATH_OBJECT);
       done();
     });
+  });
+
+  QUnit.test('convertPointsToPath', function (assert) {
+    var done = assert.async();
+    assert.ok(typeof fabric.Path.convertPointsToPath === 'function');
+    var points = [];
+    var pathData = [
+      ["M", 100.2, 99.8],
+      ["Q", 100, 100, 200, 100],
+      ["Q", 300, 100, 250, 200],
+      ["L", 199.8, 300.2]
+    ];
+    REFERENCE_PATH_OBJECT.path.forEach(function (item) {
+      if (item.length > 2) {
+        points.push(new fabric.Point(item[1], item[2]));
+      }
+    });
+    assert.deepEqual(fabric.util.parsePath(fabric.Path.convertPointsToPath(points)), pathData);
+    done();
+  });
+
+  QUnit.test('fromPoints', function (assert) {
+    var done = assert.async();
+    var pathData = [
+      ["M", 100.2, 99.8],
+      ["Q", 100, 100, 200, 100],
+      ["Q", 300, 100, 250, 200],
+      ["L", 199.8, 300.2]
+    ];
+    assert.ok(typeof fabric.Path.fromPoints === 'function');
+    var points = [];
+    REFERENCE_PATH_OBJECT.path.forEach(function (item) {
+      if (item.length > 2) {
+        points.push(new fabric.Point(item[1], item[2]));
+      }
+    });
+    const options = Object.assign({}, REFERENCE_PATH_OBJECT);
+    delete options.path;
+    var path = fabric.Path.fromPoints(points, options);
+    assert.ok(path instanceof fabric.Path);
+    assert.deepEqual(path.path, pathData);
+    done();
   });
 
   QUnit.test('fromElement', function(assert) {

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -117,7 +117,6 @@
 
   QUnit.test('set path after initialization', function (assert) {
     var done = assert.async();
-    fabric.Object.NUM_FRACTION_DIGITS = 12;
     var path = new fabric.Path('M 100 100 L 200 100 L 170 200 z', REFERENCE_PATH_OBJECT);
     path.set('path', REFERENCE_PATH_OBJECT.path);
     assert.deepEqual(path.toObject(), REFERENCE_PATH_OBJECT);

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -56,6 +56,12 @@
     getPathObject('M 100 100 L 300 100 L 200 300 z', callback);
   }
 
+  function updatePath(pathObject, value, preservePosition) {
+    const { left, top } = pathObject;
+    pathObject.set("path", value);
+    preservePosition && pathObject.set({ left, top });
+  }
+
   QUnit.module('fabric.Path', {
     beforeEach: function() {
       fabric.Object.__uid = 0;
@@ -118,11 +124,20 @@
   QUnit.test('set path after initialization', function (assert) {
     var done = assert.async();
     var path = new fabric.Path('M 100 100 L 200 100 L 170 200 z', REFERENCE_PATH_OBJECT);
-    path.set('path', REFERENCE_PATH_OBJECT.path);
+    updatePath(path, REFERENCE_PATH_OBJECT.path, true);
     assert.deepEqual(path.toObject(), REFERENCE_PATH_OBJECT);
-    path.set('path', 'M 100 100 L 300 100 L 200 300 z');
-    makePathObject(function (clone) {
-      assert.deepEqual(path.toObject(), clone.toObject());
+    updatePath(path, REFERENCE_PATH_OBJECT.path, false);
+    var left = path.left;
+    var top = path.top;
+    path.center();
+    assert.equal(left, path.left);
+    assert.equal(top, path.top);
+    var opts = fabric.util.object.clone(REFERENCE_PATH_OBJECT);
+    delete opts.path;
+    path.set(opts);
+    updatePath(path, 'M 100 100 L 300 100 L 200 300 z', true);
+    makePathObject(function (cleanPath) {
+      assert.deepEqual(path.toObject(), cleanPath.toObject());
       done();
     });
   });


### PR DESCRIPTION
### Motivation
Setting `path` property after `fabric.Path` initialization doesn't work out of the box and needs too much handling and internal knowledge of this repository's logic to make it successful.
**This is bad for DEV UX.**

### Fix
The fix re-uses the same logic to reset the path correctly.

```js
const path = new fabric.Path(...);
// do stuff
path.set('path', .......);
```

### Test it
https://codesandbox.io/s/reverent-ives-464sc?file=/src/App.tsx