### PR TITLE
Record group selection in transformed coordinates to support panning/zooming while group selecting

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -714,21 +714,8 @@
       maxX -= strokeOffset;
       maxY -= strokeOffset;
       // selection border
-      if (this.selectionDashArray.length > 1 && !supportLineDash) {
-        ctx.beginPath();
-
-        fabric.util.drawDashedLine(ctx, minX, minY, maxX, minY, this.selectionDashArray);
-        fabric.util.drawDashedLine(ctx, minX, maxY, maxX, maxY, this.selectionDashArray);
-        fabric.util.drawDashedLine(ctx, minX, minY, minX, maxY, this.selectionDashArray);
-        fabric.util.drawDashedLine(ctx, maxX, minY, maxX, maxY, this.selectionDashArray);
-
-        ctx.closePath();
-        ctx.stroke();
-      }
-      else {
-        fabric.Object.prototype._setLineDash.call(this, ctx, this.selectionDashArray);
-        ctx.strokeRect(minX, minY, maxX - minX, maxY - minY);
-      }
+      fabric.Object.prototype._setLineDash.call(this, ctx, this.selectionDashArray);
+      ctx.strokeRect(minX, minY, maxX - minX, maxY - minY);
     },
 
     /**

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -2,10 +2,8 @@
 
   var getPointer = fabric.util.getPointer,
       degreesToRadians = fabric.util.degreesToRadians,
-      abs = Math.abs,
       supportLineDash = fabric.StaticCanvas.supports('setLineDash'),
-      isTouchEvent = fabric.util.isTouchEvent,
-      STROKE_OFFSET = 0.5;
+      isTouchEvent = fabric.util.isTouchEvent;
 
   /**
    * Canvas class
@@ -689,21 +687,20 @@
      * @param {CanvasRenderingContext2D} ctx to draw the selection on
      */
     _drawSelection: function (ctx) {
-      var groupSelector = this._groupSelector,
-          left = groupSelector.left,
-          top = groupSelector.top,
-          aleft = abs(left),
-          atop = abs(top);
+      var selector = this._groupSelector,
+          viewportStart = new fabric.Point(selector.ex, selector.ey),
+          start = fabric.util.transformPoint(viewportStart, this.viewportTransform),
+          viewportExtent = new fabric.Point(selector.ex + selector.left, selector.ey + selector.top),
+          extent = fabric.util.transformPoint(viewportExtent, this.viewportTransform),
+          minX = Math.min(start.x, extent.x),
+          minY = Math.min(start.y, extent.y),
+          maxX = Math.max(start.x, extent.x),
+          maxY = Math.max(start.y, extent.y),
+          strokeOffset = this.selectionLineWidth / 2;
 
       if (this.selectionColor) {
         ctx.fillStyle = this.selectionColor;
-
-        ctx.fillRect(
-          groupSelector.ex - ((left > 0) ? 0 : -left),
-          groupSelector.ey - ((top > 0) ? 0 : -top),
-          aleft,
-          atop
-        );
+        ctx.fillRect(minX, minY, maxX - minX, maxY - minY);
       }
 
       if (!this.selectionLineWidth || !this.selectionBorderColor) {
@@ -712,30 +709,25 @@
       ctx.lineWidth = this.selectionLineWidth;
       ctx.strokeStyle = this.selectionBorderColor;
 
+      minX += strokeOffset;
+      minY += strokeOffset;
+      maxX -= strokeOffset;
+      maxY -= strokeOffset;
       // selection border
       if (this.selectionDashArray.length > 1 && !supportLineDash) {
-
-        var px = groupSelector.ex + STROKE_OFFSET - ((left > 0) ? 0 : aleft),
-            py = groupSelector.ey + STROKE_OFFSET - ((top > 0) ? 0 : atop);
-
         ctx.beginPath();
 
-        fabric.util.drawDashedLine(ctx, px, py, px + aleft, py, this.selectionDashArray);
-        fabric.util.drawDashedLine(ctx, px, py + atop - 1, px + aleft, py + atop - 1, this.selectionDashArray);
-        fabric.util.drawDashedLine(ctx, px, py, px, py + atop, this.selectionDashArray);
-        fabric.util.drawDashedLine(ctx, px + aleft - 1, py, px + aleft - 1, py + atop, this.selectionDashArray);
+        fabric.util.drawDashedLine(ctx, minX, minY, maxX, minY, this.selectionDashArray);
+        fabric.util.drawDashedLine(ctx, minX, maxY, maxX, maxY, this.selectionDashArray);
+        fabric.util.drawDashedLine(ctx, minX, minY, minX, maxY, this.selectionDashArray);
+        fabric.util.drawDashedLine(ctx, maxX, minY, maxX, maxY, this.selectionDashArray);
 
         ctx.closePath();
         ctx.stroke();
       }
       else {
         fabric.Object.prototype._setLineDash.call(this, ctx, this.selectionDashArray);
-        ctx.strokeRect(
-          groupSelector.ex + STROKE_OFFSET - ((left > 0) ? 0 : aleft),
-          groupSelector.ey + STROKE_OFFSET - ((top > 0) ? 0 : atop),
-          aleft,
-          atop
-        );
+        ctx.strokeRect(minX, minY, maxX - minX, maxY - minY);
       }
     },
 

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -2,7 +2,6 @@
 
   var getPointer = fabric.util.getPointer,
       degreesToRadians = fabric.util.degreesToRadians,
-      supportLineDash = fabric.StaticCanvas.supports('setLineDash'),
       isTouchEvent = fabric.util.isTouchEvent;
 
   /**

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -712,8 +712,8 @@
       if (this.selection && (!target ||
         (!target.selectable && !target.isEditing && target !== this._activeObject))) {
         this._groupSelector = {
-          ex: pointer.x,
-          ey: pointer.y,
+          ex: this._absolutePointer.x,
+          ey: this._absolutePointer.y,
           top: 0,
           left: 0
         };
@@ -806,7 +806,7 @@
 
       // We initially clicked in an empty area, so we draw a box for multiple selection
       if (groupSelector) {
-        pointer = this._pointer;
+        pointer = this._absolutePointer;
 
         groupSelector.left = pointer.x - groupSelector.ex;
         groupSelector.top = pointer.y - groupSelector.ey;

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -139,10 +139,10 @@
           continue;
         }
 
-        if ((allowIntersect && currentObject.intersectsWithRect(selectionX1Y1, selectionX2Y2)) ||
-            currentObject.isContainedWithinRect(selectionX1Y1, selectionX2Y2) ||
-            (allowIntersect && currentObject.containsPoint(selectionX1Y1)) ||
-            (allowIntersect && currentObject.containsPoint(selectionX2Y2))
+        if ((allowIntersect && currentObject.intersectsWithRect(selectionX1Y1, selectionX2Y2, true)) ||
+            currentObject.isContainedWithinRect(selectionX1Y1, selectionX2Y2, true) ||
+            (allowIntersect && currentObject.containsPoint(selectionX1Y1, null, true)) ||
+            (allowIntersect && currentObject.containsPoint(selectionX2Y2, null, true))
         ) {
           group.push(currentObject);
           // only add one object if it's a click

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -153,9 +153,10 @@
   });
 
   QUnit.test('mouse:down and group selector', function(assert) {
-    var e = { clientX: 30, clientY: 30, which: 1, target: canvas.upperCanvasEl };
-    var rect = new fabric.Rect({ width: 60, height: 60 });
-    var expectedGroupSelector = { ex: 30, ey: 30, top: 0, left: 0 };
+    var e = { clientX: 30, clientY: 40, which: 1, target: canvas.upperCanvasEl };
+    var rect = new fabric.Rect({ width: 150, height: 150 });
+    var expectedGroupSelector = { ex: 80, ey: 120, top: 0, left: 0 };
+    canvas.absolutePan(new fabric.Point(50, 80));
     canvas.__onMouseDown(e);
     assert.deepEqual(canvas._groupSelector, expectedGroupSelector, 'a new groupSelector is created');
     canvas.add(rect);
@@ -653,6 +654,15 @@
 
   // TODO: QUnit.test('mousemove: subTargetCheck: setCursorFromEvent considers subTargets')
   // TODO: QUnit.test('mousemove: subTargetCheck: setCursorFromEvent considers subTargets in reverse order, so the top-most subTarget's .hoverCursor takes precedence')
+
+  QUnit.test('mouse move and group selector', function(assert){
+    var e = { clientX: 30, clientY: 40, which: 1, target: canvas.upperCanvasEl };
+    var expectedGroupSelector = { ex: 15, ey: 30, left: 65, top: 90};
+    canvas.absolutePan(new fabric.Point(50, 80));
+    canvas._groupSelector = {ex: 15, ey: 30, top: 0, left: 0};
+    canvas.__onMouseMove(e);
+    assert.deepEqual(canvas._groupSelector, expectedGroupSelector, 'groupSelector is updated');
+  });
 
   ['MouseDown', 'MouseMove', 'MouseOut', 'MouseEnter', 'MouseWheel', 'DoubleClick'].forEach(function(eventType) {
     QUnit.test('avoid multiple registration - ' + eventType, function(assert) {


### PR DESCRIPTION
Fixes this issue: https://github.com/fabricjs/fabric.js/issues/7086

There is still a slight issue because the group select controls don't get immediately rerendered when transforming, but I didn't want to shove too much into a single PR. I thought about making a feature toggle on fabric.Canvas, but I couldn't think of any use cases for the way it behaved before. I didn't see any existing methods of testing the contents of _drawSelection(). I'm glad to make changes as needed.

I changed _drawSelection to accommodate varying selectionLineWidth, since the previous implementation was essentially hardcoded to 1, and would draw outside the box for values > 1, now it should always draw within the box.

Thank you!