### PR TITLE
fix(fabric.util): unwanted mutation in fabric.util.rotatePoint

### DIFF
--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -115,8 +115,8 @@
      * @return {fabric.Point} The new rotated point
      */
     rotatePoint: function(point, origin, radians) {
-      point.subtractEquals(origin);
-      var v = fabric.util.rotateVector(point, radians);
+      var newPoint = new fabric.Point(point.x - origin.x, point.y - origin.y),
+          v = fabric.util.rotateVector(newPoint, radians);
       return new fabric.Point(v.x, v.y).addEquals(origin);
     },
 

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -30,7 +30,7 @@
       assert.equal(fabric.util.toFixed(what, 5), 166.66667, 'should leave 5 fractional digits');
       assert.equal(fabric.util.toFixed(what, 0), 167, 'should leave 0 fractional digits');
 
-      var fractionless = (typeof what == 'number')
+      var fractionless = (typeof what === 'number')
         ? parseInt(what)
         : what.substring(0, what.indexOf('.'));
 
@@ -834,7 +834,7 @@
     assert.equal(Math.round(rotated.y), 0);
     var rotated = fabric.util.rotatePoint(point, origin, Math.PI / 2);
     assert.equal(Math.round(rotated.x), 3);
-    assert.equal(Math.round(rotated.y), -2);
+    assert.equal(Math.round(rotated.y), 1);
   });
 
   QUnit.test('transformPoint', function(assert) {


### PR DESCRIPTION
The function subctratEquals is mutating the original point, this is an issue of the point class where half method mutate, half don't.

This fixes the bug for the rotate point method, since returning a new point and mutating the input does not make sense.

close #7055