### PR TITLE
fix(fabric.Path): setting `path` during runtime

### DIFF
--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -70,9 +70,6 @@
           fabric.util.parsePath(path)
         );
 
-      if (!this.path) {
-        return;
-      }
       fabric.Polyline.prototype._setPositionDimensions.call(this, options || {});
     },
 

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -6,6 +6,7 @@
       min = fabric.util.array.min,
       max = fabric.util.array.max,
       extend = fabric.util.object.extend,
+      clone = fabric.util.object.clone,
       _toString = Object.prototype.toString,
       toFixed = fabric.util.toFixed;
 
@@ -47,13 +48,19 @@
      * @param {Object} [options] Options object
      * @return {fabric.Path} thisArg
      */
-    initialize: function(path, options) {
-      options = options || { };
+    initialize: function (path, options) {
+      options = clone(options || {});
+      delete options.path;
       this.callSuper('initialize', options);
-      if (!path) {
-        path = [];
-      }
+      this._setPath(path || [], options);
+    },
 
+    /**
+    * @private
+    * @param {Array|String} path Path data (sequence of coordinates and corresponding "command" tokens)
+    * @param {Object} [options] Options object
+    */
+    _setPath: function (path, options) {
       var fromArray = _toString.call(path) === '[object Array]';
 
       this.path = fromArray
@@ -66,7 +73,19 @@
       if (!this.path) {
         return;
       }
-      fabric.Polyline.prototype._setPositionDimensions.call(this, options);
+      fabric.Polyline.prototype._setPositionDimensions.call(this, options || {});
+    },
+
+    /**
+     * @private
+     */
+    _set: function (key, value) {
+      if (key === 'path') {
+        this._setPath(value);
+      }
+      else {
+        this.callSuper('_set', key, value);
+      }
     },
 
     /**

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -75,18 +75,6 @@
 
     /**
      * @private
-     */
-    _set: function (key, value) {
-      if (key === 'path') {
-        this._setPath(value);
-      }
-      else {
-        this.callSuper('_set', key, value);
-      }
-    },
-
-    /**
-     * @private
      * @param {CanvasRenderingContext2D} ctx context to render path on
      */
     _renderPathCommands: function(ctx) {

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -56,6 +56,12 @@
     getPathObject('M 100 100 L 300 100 L 200 300 z', callback);
   }
 
+  function updatePath(pathObject, value, preservePosition) {
+    const { left, top } = pathObject;
+    pathObject.set("path", value);
+    preservePosition && pathObject.set({ left, top });
+  }
+
   QUnit.module('fabric.Path', {
     beforeEach: function() {
       fabric.Object.__uid = 0;
@@ -113,6 +119,27 @@
     assert.equal(path.left, 150);
     assert.equal(path.top, 150);
     done();
+  });
+
+  QUnit.test('set path after initialization', function (assert) {
+    var done = assert.async();
+    var path = new fabric.Path('M 100 100 L 200 100 L 170 200 z', REFERENCE_PATH_OBJECT);
+    updatePath(path, REFERENCE_PATH_OBJECT.path, true);
+    assert.deepEqual(path.toObject(), REFERENCE_PATH_OBJECT);
+    updatePath(path, REFERENCE_PATH_OBJECT.path, false);
+    var left = path.left;
+    var top = path.top;
+    path.center();
+    assert.equal(left, path.left);
+    assert.equal(top, path.top);
+    var opts = fabric.util.object.clone(REFERENCE_PATH_OBJECT);
+    delete opts.path;
+    path.set(opts);
+    updatePath(path, 'M 100 100 L 300 100 L 200 300 z', true);
+    makePathObject(function (cleanPath) {
+      assert.deepEqual(path.toObject(), cleanPath.toObject());
+      done();
+    });
   });
 
   QUnit.test('toString', function(assert) {

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -58,7 +58,7 @@
 
   function updatePath(pathObject, value, preservePosition) {
     const { left, top } = pathObject;
-    pathObject.set("path", value);
+    pathObject._setPath(value);
     preservePosition && pathObject.set({ left, top });
   }
 


### PR DESCRIPTION
This PR with #7140 finalizes the replacement of #7082 

Apparently calling `setCoords` was redundant.
Everything looks good