### PR TITLE
fix(EraserBrush): check intersection taking in account canvas vpt

### DIFF
--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -694,7 +694,7 @@
         var _this = this;
         var targets = [];
         canvas.forEachObject(function (obj) {
-          if (obj.erasable && obj.intersectsWithObject(path)) {
+          if (obj.erasable && obj.intersectsWithObject(path, true)) {
             _this._addPathToObjectEraser(obj, path);
             targets.push(obj);
           }


### PR DESCRIPTION
The check used by Eraser Brush to determine if to add a path to an object needs to account for canvas viewport transform.
This fixes the issue.