### PR TITLE
fix(fabric.StaticCanvas): restore canvas size when disposing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - fix(fabric.Group): support `excludeFromExport` set on objects [#7148](https://github.com/fabricjs/fabric.js/pull/7148).
 - fix(fabric.StaticCanvas): support `excludeFromExport` set on `backgroundColor`, `overlayColor`, `clipPath` [#7148](https://github.com/fabricjs/fabric.js/pull/7148).
 - feat(fabric.Collection): the `contains` method now accepts a second boolean parameter `deep`, checking all descendants, `collection.contains(obj, true)` [#7139](https://github.com/fabricjs/fabric.js/pull/7139).
+- fix(fabric.StaticCanvas): disposing canvas now restores canvas size and style to original state.
 
 ## [4.5.1]
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -523,7 +523,7 @@
       }
 
       fabric.util.addClass(this.lowerCanvasEl, 'lower-canvas');
-
+      this._originalCanvasStyle = this.lowerCanvasEl.style;
       if (this.interactive) {
         this._applyCanvasStyle(this.lowerCanvasEl);
       }
@@ -1770,13 +1770,13 @@
       this.overlayImage = null;
       this._iTextInstances = null;
       this.contextContainer = null;
+      // restore canvas style
+      this.lowerCanvasEl.classList.remove('lower-canvas');
+      this.lowerCanvasEl.style = this._originalCanvasStyle;
+      delete this._originalCanvasStyle;
       // restore canvas size to original size in case retina scaling was applied
       this.lowerCanvasEl.setAttribute('width', this.width);
       this.lowerCanvasEl.setAttribute('height', this.height);
-      if (this.upperCanvasEl) {
-        this.upperCanvasEl.setAttribute('width', this.width);
-        this.upperCanvasEl.setAttribute('height', this.height);
-      }
       fabric.util.cleanUpJsdomNode(this.lowerCanvasEl);
       this.lowerCanvasEl = undefined;
       return this;

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1770,6 +1770,13 @@
       this.overlayImage = null;
       this._iTextInstances = null;
       this.contextContainer = null;
+      // restore canvas size to original size in case retina scaling was applied
+      this.lowerCanvasEl.setAttribute('width', this.width);
+      this.lowerCanvasEl.setAttribute('height', this.height);
+      if (this.upperCanvasEl) {
+        this.upperCanvasEl.setAttribute('width', this.width);
+        this.upperCanvasEl.setAttribute('height', this.height);
+      }
       fabric.util.cleanUpJsdomNode(this.lowerCanvasEl);
       this.lowerCanvasEl = undefined;
       return this;


### PR DESCRIPTION
When `enableRetinaScaling=true` the canvas element is resized.
When disposing canvas it is important to restore it's size in case the app will be reusing the canvas element.
With react, for example, `hot reload/fast refresh` disposes the fabric canvas instance but reuses the canvas element. 
This means that `_initRetinaScaling` is run again on the same canvas element, causing unwanted size changes.

### Sandbox!!
https://codesandbox.io/s/react-sandbox-forked-kh2vb?file=/src/App.tsx
I love the sandbox script !