### PR TITLE
fix(fabric.Object) unnecessary cache invalidation, ISSUE-7157

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -930,6 +930,17 @@
      * @return {Object} object with scaleX and scaleY properties
      */
     getObjectScaling: function() {
+      // if the object is a top level one, on the canvas, we go for simple aritmetic
+      // otherwise the complex method with angles will return approximations and decimals
+      // and will likely kill the cache when not needed
+      // https://github.com/fabricjs/fabric.js/issues/7157
+      if (!this.group) {
+        return {
+          scaleX: this.scaleX,
+          scaleY: this.scaleY,
+        };
+      }
+      // if we are inside a group total zoom calculation is complex, we defer to generic matrices
       var options = fabric.util.qrDecompose(this.calcTransformMatrix());
       return { scaleX: Math.abs(options.scaleX), scaleY: Math.abs(options.scaleY) };
     },


### PR DESCRIPTION
Using a generic method to find out the object scaling is necessary for groups and nested groups, but for alone objects is not needed and will also give sligtly different results depending on the object angle.

On the example of ISSUE-7157, the object would move from a zoom of 1 to 0.999999999999 back and forth depending on the angle and was invalidating cache every a couple of frames

close #7157