### PR TITLE
fix(shapes): fabric.Object._fromObject never should return

### DIFF
--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -198,10 +198,10 @@
    * @memberOf fabric.Circle
    * @param {Object} object Object to create an instance from
    * @param {function} [callback] invoked with new instance as first argument
-   * @return {Object} Instance of fabric.Circle
+   * @return {void}
    */
   fabric.Circle.fromObject = function(object, callback) {
-    return fabric.Object._fromObject('Circle', object, callback);
+    fabric.Object._fromObject('Circle', object, callback);
   };
 
 })(typeof exports !== 'undefined' ? exports : this);

--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -172,10 +172,10 @@
    * @memberOf fabric.Ellipse
    * @param {Object} object Object to create an instance from
    * @param {function} [callback] invoked with new instance as first argument
-   * @return {fabric.Ellipse}
+   * @return {void}
    */
   fabric.Ellipse.fromObject = function(object, callback) {
-    return fabric.Object._fromObject('Ellipse', object, callback);
+    fabric.Object._fromObject('Ellipse', object, callback);
   };
 
 })(typeof exports !== 'undefined' ? exports : this);

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -74,7 +74,7 @@
    * @param {Function} [callback] Callback to invoke when an fabric.Path instance is created
    */
   fabric.Polygon.fromObject = function(object, callback) {
-    return fabric.Object._fromObject('Polygon', object, callback, 'points');
+    fabric.Object._fromObject('Polygon', object, callback, 'points');
   };
 
 })(typeof exports !== 'undefined' ? exports : this);

--- a/src/shapes/polygon.class.js
+++ b/src/shapes/polygon.class.js
@@ -72,6 +72,7 @@
    * @memberOf fabric.Polygon
    * @param {Object} object Object to create an instance from
    * @param {Function} [callback] Callback to invoke when an fabric.Path instance is created
+   * @return {void}
    */
   fabric.Polygon.fromObject = function(object, callback) {
     fabric.Object._fromObject('Polygon', object, callback, 'points');


### PR DESCRIPTION
`fabric.Object._fromObject` doesn't return anything, and is processed through the callback.

This removes the return and fixes the documentation. This is mostly to upstream this fix to Typescript types as it incorrectly thinks Polygon, Circle, Ellipse return an object.

Thank you!