### PR TITLE
Fix null pointer error of guidelines

### DIFF
--- a/lib/aligning_guidelines.js
+++ b/lib/aligning_guidelines.js
@@ -190,7 +190,9 @@ function initAligningGuidelines(canvas) {
   });
 
   canvas.on('before:render', function() {
-    canvas.clearContext(canvas.contextTop);
+    if (canvas.contextTop) {
+      canvas.clearContext(canvas.contextTop);
+    }
   });
 
   canvas.on('after:render', function() {

--- a/lib/centering_guidelines.js
+++ b/lib/centering_guidelines.js
@@ -68,7 +68,9 @@ function initCenteringGuidelines(canvas) {
   });
 
   canvas.on('before:render', function() {
-    canvas.clearContext(canvas.contextTop);
+    if (canvas.contextTop) {
+      canvas.clearContext(canvas.contextTop);
+    }
   });
 
   canvas.on('after:render', function() {


### PR DESCRIPTION
1. Bugfix：When calling canvas.toDataURL after initCenteringGuidelines(canvas) or initAligningGuidelines(canvas) it will cause a “Reference clearRect of null” error.