### PR TITLE
fix(Group): fire added/removed events

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -164,7 +164,7 @@
           // if this group is inside another group, we need to pre transform the object
           fabric.util.removeTransformFromObject(object, this.group.calcTransformMatrix());
         }
-        this._objects.push(object);
+        this.add(object);
         object.group = this;
         object._set('canvas', this.canvas);
       }
@@ -205,12 +205,16 @@
       this.dirty = true;
       object.group = this;
       object._set('canvas', this.canvas);
+      this.fire('object:added', { target: object });
+      object.fire('added', { target: this });
     },
 
     /**
      * @private
      */
-    _onObjectRemoved: function(object) {
+    _onObjectRemoved: function (object) {
+      this.fire('object:removed', { target: object });
+      object.fire('removed', { target: this });
       this.dirty = true;
       delete object.group;
     },

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -167,8 +167,6 @@
         this.supressAddedEvent = true;
         this.add(object);
         this.supressAddedEvent = false;
-        object.group = this;
-        object._set('canvas', this.canvas);
       }
       this._calcBounds();
       this._updateObjectsCoords();

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -179,7 +179,7 @@
       else {
         this.setCoords();
       }
-      this._fireGroupEvent('added', object);
+      object && this._fireGroupEvent('added', object);
       return this;
     },
 
@@ -199,7 +199,7 @@
       this._updateObjectsCoords();
       this.setCoords();
       this.dirty = true;
-      this._fireGroupEvent('removed', object);
+      object && this._fireGroupEvent('removed', object);
       return this;
     },
 
@@ -228,7 +228,7 @@
      * @param {fabric.Object} object 
      */
     _fireGroupEvent: function (prefix, object) {
-      this.fire(`object:${prefix}`, { target: object });
+      this.fire('object:' + prefix, { target: object });
       object.fire(prefix, { target: this });
     },
 

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -87,9 +87,22 @@
     assert.strictEqual(group.item(group.size() - 1), rect1, 'last object should be newly added one');
     assert.equal(group.getObjects().length, 3, 'there should be 3 objects');
 
+    var fullMatrix = rect2.calcOwnMatrix();
+    var firedGroup = 0, firedObject = 0;
+    group.on('object:added', function (ev) {
+      firedGroup++;
+      assert.ok(ev.target === rect2 || ev.target === rect3);
+    });
+    rect2.on('added', function (ev) {
+      firedObject++;
+      assert.equal(ev.target, group);
+      assert.deepEqual(fullMatrix, rect2.calcOwnMatrix());
+    });
     group.add(rect2, rect3);
     assert.strictEqual(group.item(group.size() - 1), rect3, 'last object should be last added one');
     assert.equal(group.size(), 5, 'there should be 5 objects');
+    assert.equal(firedGroup, 2);
+    assert.equal(firedObject, 1);
   });
 
   QUnit.test('remove', function(assert) {
@@ -688,9 +701,22 @@
         group = new fabric.Group([rect1]);
 
     var coords = group.oCoords;
+    var fullMatrix = rect2.calcOwnMatrix();
+    var firedGroup = 0, firedObject = 0;
+    group.on('object:added', function (ev) {
+      firedGroup++;
+      assert.equal(ev.target, rect2);
+    });
+    rect2.on('added', function (ev) {
+      firedObject++;
+      assert.equal(ev.target, group);
+      assert.deepEqual(fullMatrix, fabric.util.multiplyTransformMatrices(group.calcOwnMatrix(), rect2.calcOwnMatrix()));
+    });
     group.addWithUpdate(rect2);
     var newCoords = group.oCoords;
     assert.notEqual(coords, newCoords, 'object coords have been recalculated - add');
+    assert.equal(firedGroup, 1);
+    assert.equal(firedObject, 1);
   });
 
   QUnit.test('group removeWithUpdate', function(assert) {
@@ -699,6 +725,17 @@
         group = new fabric.Group([rect1, rect2]);
 
     var coords = group.oCoords;
+    var fullMatrix = fabric.util.multiplyTransformMatrices(group.calcOwnMatrix(), rect2.calcOwnMatrix());
+    var firedGroup = 0, firedObject = 0;
+    group.on('object:removed', function (ev) {
+      firedGroup++;
+      assert.equal(ev.target, rect2);
+    });
+    rect2.on('removed', function (ev) {
+      firedObject++;
+      assert.equal(ev.target, group);
+      assert.deepEqual(rect2.calcOwnMatrix(), fullMatrix);
+    });
     group.removeWithUpdate(rect2);
     var newCoords = group.oCoords;
     assert.notEqual(coords, newCoords, 'object coords have been recalculated - remove');


### PR DESCRIPTION
### Motivation
#7037 #6619 #6130
I looked for the PR you mentioned @asturur, found something that looked off #6199

### Test it LIVE:
https://codesandbox.io/s/dev-sandbox-forked-ifg6i?file=/src/App.tsx

### Logic
I followed `StaticCanvas` impl of these events.

### Considerations:
1. Is this breaking? This fix fires an `added` `removed` event on object. While until now this was fired on objects that were added to/removed from canvas. This might break stuff for devs... I added a target property (the group) to the event to differentiate.
2. What about initialization? Should events fire on objects added within the initialization block? **Currently** they don't.