### PR TITLE
Update documentation for clone and extend methods

### DIFF
--- a/src/util/lang_object.js
+++ b/src/util/lang_object.js
@@ -8,6 +8,7 @@
    * @memberOf fabric.util.object
    * @param {Object} destination Where to copy to
    * @param {Object} source Where to copy from
+   * @param {Boolean} deep Whether to extend nested objects
    * @return {Object}
    */
 
@@ -53,9 +54,11 @@
 
   /**
    * Creates an empty object and copies all enumerable properties of another object to it
+   * This method is mostly for internal use, and not intended for duplicating shapes in canvas. 
    * @memberOf fabric.util.object
    * TODO: this function return an empty object if you try to clone null
    * @param {Object} object Object to clone
+   * @param {Boolean} deep Whether to clone nested objects
    * @return {Object}
    */
   function clone(object, deep) {


### PR DESCRIPTION
Add more information in the documentation for `clone` and `extend` methods.