### PR TITLE
feat(EraserBrush): better `erasing:end` event

### DIFF
--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -867,6 +867,9 @@
           obj.fire('erasing:end', {
             path: path
           });
+          if (obj.group && Array.isArray(_this.__subTargets)) {
+            _this.__subTargets.push(obj);
+          }
         });
       },
 
@@ -930,6 +933,7 @@
         // finalize erasing
         var drawables = this.applyEraserToCanvas(path);
         var _this = this;
+        this.__subTargets = [];
         var targets = [];
         canvas.forEachObject(function (obj) {
           if (obj.erasable && obj.intersectsWithObject(path, true)) {
@@ -937,10 +941,13 @@
             targets.push(obj);
           }
         });
-
-        // `targets` are the direct `_objects` of canvas
-        // use object's `erasing:end` event if you need to monitor nested objects
-        canvas.fire('erasing:end', { path: path, targets: targets, drawables: drawables });
+        canvas.fire('erasing:end', {
+          path: path,
+          targets: targets,
+          subTargets: this.__subTargets,
+          drawables: drawables
+        });
+        delete this.__subTargets;
 
         canvas.requestRenderAll();
         path.setCoords();

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -360,7 +360,7 @@
   var __onResize = fabric.Canvas.prototype._onResize;
   /**
    * @fires erasing:start
-   * @fires erasing:end use object's `erasing:end` event if you need to monitor nested objects
+   * @fires erasing:end
    */
   fabric.util.object.extend(fabric.Canvas.prototype, {
     /**

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -360,7 +360,7 @@
   var __onResize = fabric.Canvas.prototype._onResize;
   /**
    * @fires erasing:start
-   * @fires erasing:end
+   * @fires erasing:end use object's `erasing:end` event if you need to monitor nested objects
    */
   fabric.util.object.extend(fabric.Canvas.prototype, {
     /**

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -123,6 +123,9 @@
   var _render = fabric.Object.prototype.render;
   var _toObject = fabric.Object.prototype.toObject;
   var __createBaseSVGMarkup = fabric.Object.prototype._createBaseSVGMarkup;
+  /**
+   * @fires erasing:end
+   */
   fabric.util.object.extend(fabric.Object.prototype, {
     /**
      * Indicates whether this object can be erased by {@link fabric.EraserBrush}
@@ -355,6 +358,10 @@
   });
 
   var __onResize = fabric.Canvas.prototype._onResize;
+  /**
+   * @fires erasing:start
+   * @fires erasing:end
+   */
   fabric.util.object.extend(fabric.Canvas.prototype, {
     /**
      * Used by {@link #renderAll}
@@ -857,6 +864,9 @@
             clipPath: clipObject,
             dirty: true
           });
+          obj.fire('erasing:end', {
+            path: path
+          });
         });
       },
 
@@ -928,6 +938,8 @@
           }
         });
 
+        // `targets` are the direct `_objects` of canvas
+        // use object's `erasing:end` event if you need to monitor nested objects
         canvas.fire('erasing:end', { path: path, targets: targets, drawables: drawables });
 
         canvas.requestRenderAll();


### PR DESCRIPTION
1. Fire `erasing:end` event on object.
This is important since #7100 because erasable targets may be nested deep in the object tree and there is no way of knowing if a nested object was erased.
2. Add `subTargets` property to canvas `erasing:end` event.

### Context
Canvas fires `erasing:end` event with a `targets` property. Since #7100 `targets` is not adequate because erasable targets may be nested deep in the object tree.
I am thinking of a way to add a `subTargets` property to canvas `erasing:end` event that will contain all erased nested objects. To achieve this I need some advice.
Can I assume that cloning a path is a sync and not an async process?