### PR TITLE
added pathSide property to text on path

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -793,7 +793,7 @@
             break;
           //todo - add support for justify
         }
-        positionInPath += this.pathStartOffset * reverse ? -1 : 1;
+        positionInPath += this.pathStartOffset * (reverse ? -1 : 1);
       }
       if (path) {
         for (i = reverse ? line.length - 1 : 0;

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -210,7 +210,7 @@
      * @type Number
      * @default
      */
-    startOffset:               0,
+    pathStartOffset:               0,
 
     /**
      * Which side of the path the text should be drawn on.
@@ -218,7 +218,7 @@
      * @type {String} 'left|right'
      * @default
      */
-    side:               'left',
+     pathSide:               'left',
 
     /**
      * @private
@@ -758,7 +758,7 @@
       var width = 0, i, grapheme, line = this._textLines[lineIndex], prevGrapheme,
           graphemeInfo, numOfSpaces = 0, lineBounds = new Array(line.length),
           positionInPath = 0, startingPoint, totalPathLength, path = this.path,
-          reverse = this.side === 'right';
+          reverse = this.pathSide === 'right';
 
       this.__charBounds[lineIndex] = lineBounds;
       for (i = 0; i < line.length; i++) {
@@ -793,7 +793,7 @@
             break;
           //todo - add support for justify
         }
-        positionInPath += reverse ? -this.startOffset : this.startOffset;
+        positionInPath += this.pathStartOffset * reverse ? -1 : 1;
       }
       if (path) {
         for (i = reverse ? line.length - 1 : 0;
@@ -831,15 +831,7 @@
       var info = fabric.util.getPointOnPath(path.path, centerPosition, path.segmentsInfo);
       graphemeInfo.renderLeft = info.x - startingPoint.x;
       graphemeInfo.renderTop = info.y - startingPoint.y;
-      graphemeInfo.angle = info.angle;
-      switch (this.side) {
-        case 'left':
-          graphemeInfo.angle = info.angle;
-          break;
-        case 'right':
-          graphemeInfo.angle = info.angle + Math.PI;
-          break;
-      }
+      graphemeInfo.angle = info.angle + (this.pathSide ===  'right' ? Math.PI : 0);
     },
 
     /**

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -218,7 +218,7 @@
      * @type {String} 'left|right'
      * @default
      */
-     side:               'left',
+    side:               'left',
 
     /**
      * @private
@@ -758,7 +758,7 @@
       var width = 0, i, grapheme, line = this._textLines[lineIndex], prevGrapheme,
           graphemeInfo, numOfSpaces = 0, lineBounds = new Array(line.length),
           positionInPath = 0, startingPoint, totalPathLength, path = this.path,
-          reverse = this.side === "right";
+          reverse = this.side === 'right';
 
       this.__charBounds[lineIndex] = lineBounds;
       for (i = 0; i < line.length; i++) {
@@ -797,8 +797,8 @@
       }
       if (path) {
         for (i = reverse ? line.length - 1 : 0;
-            reverse ? i >= 0 : i < line.length;
-            reverse ? i-- : i++) {
+          reverse ? i >= 0 : i < line.length;
+          reverse ? i-- : i++) {
           graphemeInfo = lineBounds[i];
           if (positionInPath > totalPathLength) {
             positionInPath %= totalPathLength;
@@ -833,10 +833,10 @@
       graphemeInfo.renderTop = info.y - startingPoint.y;
       graphemeInfo.angle = info.angle;
       switch (this.side) {
-        case "left":
+        case 'left':
           graphemeInfo.angle = info.angle;
           break;
-        case "right":
+        case 'right':
           graphemeInfo.angle = info.angle + Math.PI;
           break;
       }

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -218,7 +218,7 @@
      * @type {String} 'left|right'
      * @default
      */
-     pathSide:               'left',
+    pathSide:               'left',
 
     /**
      * @private

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -213,6 +213,14 @@
     startOffset:               0,
 
     /**
+     * Which side of the path the text should be drawn on.
+     * Only used when text has a path
+     * @type {String} 'left|right'
+     * @default
+     */
+     side:               'left',
+
+    /**
      * @private
      */
     _fontSizeFraction: 0.222,
@@ -749,7 +757,8 @@
     _measureLine: function(lineIndex) {
       var width = 0, i, grapheme, line = this._textLines[lineIndex], prevGrapheme,
           graphemeInfo, numOfSpaces = 0, lineBounds = new Array(line.length),
-          positionInPath = 0, startingPoint, totalPathLength, path = this.path;
+          positionInPath = 0, startingPoint, totalPathLength, path = this.path,
+          reverse = this.side === "right";
 
       this.__charBounds[lineIndex] = lineBounds;
       for (i = 0; i < line.length; i++) {
@@ -773,18 +782,23 @@
         startingPoint.x += path.pathOffset.x;
         startingPoint.y += path.pathOffset.y;
         switch (this.textAlign) {
+          case 'left':
+            positionInPath = reverse ? (totalPathLength - width) : 0;
+            break;
           case 'center':
             positionInPath = (totalPathLength - width) / 2;
             break;
           case 'right':
-            positionInPath = (totalPathLength - width);
+            positionInPath = reverse ? 0 : (totalPathLength - width);
             break;
           //todo - add support for justify
         }
-        positionInPath += this.startOffset;
+        positionInPath += reverse ? -this.startOffset : this.startOffset;
       }
       if (path) {
-        for (i = 0; i < line.length; i++) {
+        for (i = reverse ? line.length - 1 : 0;
+            reverse ? i >= 0 : i < line.length;
+            reverse ? i-- : i++) {
           graphemeInfo = lineBounds[i];
           if (positionInPath > totalPathLength) {
             positionInPath %= totalPathLength;
@@ -818,6 +832,14 @@
       graphemeInfo.renderLeft = info.x - startingPoint.x;
       graphemeInfo.renderTop = info.y - startingPoint.y;
       graphemeInfo.angle = info.angle;
+      switch (this.side) {
+        case "left":
+          graphemeInfo.angle = info.angle;
+          break;
+        case "right":
+          graphemeInfo.angle = info.angle + Math.PI;
+          break;
+      }
     },
 
     /**


### PR DESCRIPTION
Here's my newest implementation of the `side` property for text on a path. Note that I've used the name `side` to be consistent with the related [SVG property](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/side), although SVG `side` is currently supported only in Firefox.

Feel free to test:
https://jsfiddle.net/melchiar/oLq91r2t/