### PR TITLE
Add fix for doc not genearting for clone

### DIFF
--- a/src/util/lang_object.js
+++ b/src/util/lang_object.js
@@ -8,6 +8,7 @@
    * @memberOf fabric.util.object
    * @param {Object} destination Where to copy to
    * @param {Object} source Where to copy from
+   * @param {Boolean} deep Whether to extend nested objects
    * @return {Object}
    */
 
@@ -53,9 +54,11 @@
 
   /**
    * Creates an empty object and copies all enumerable properties of another object to it
+   * This method is mostly for internal use, and not intended for duplicating shapes in canvas. 
    * @memberOf fabric.util.object
    * TODO: this function return an empty object if you try to clone null
    * @param {Object} object Object to clone
+   * @param {Boolean} deep Whether to clone nested objects
    * @return {Object}
    */
   function clone(object, deep) {

--- a/src/util/lang_object.js
+++ b/src/util/lang_object.js
@@ -56,11 +56,12 @@
    * Creates an empty object and copies all enumerable properties of another object to it
    * This method is mostly for internal use, and not intended for duplicating shapes in canvas. 
    * @memberOf fabric.util.object
-   * TODO: this function return an empty object if you try to clone null
    * @param {Object} object Object to clone
    * @param {Boolean} deep Whether to clone nested objects
    * @return {Object}
    */
+
+  //TODO: this function return an empty object if you try to clone null
   function clone(object, deep) {
     return extend({ }, object, deep);
   }

--- a/src/util/lang_object.js
+++ b/src/util/lang_object.js
@@ -8,7 +8,7 @@
    * @memberOf fabric.util.object
    * @param {Object} destination Where to copy to
    * @param {Object} source Where to copy from
-   * @param {Boolean} deep Whether to extend nested objects
+   * @param {Boolean} [deep] Whether to extend nested objects
    * @return {Object}
    */
 
@@ -57,7 +57,7 @@
    * This method is mostly for internal use, and not intended for duplicating shapes in canvas. 
    * @memberOf fabric.util.object
    * @param {Object} object Object to clone
-   * @param {Boolean} deep Whether to clone nested objects
+   * @param {Boolean} [deep] Whether to clone nested objects
    * @return {Object}
    */
 


### PR DESCRIPTION
I have found the problem why **JSDoc** does not generate doc for the `clone` method 
It's because there is a 'TODO' comment line just below the `@memberOf` annotation.

Also marked the `deep` parameter for `extend` and `clone` method to optional ( for **JSDoc** )