### PR TITLE
fix(EraserBrush): safeguard eraser from `prototype.fill` changes

### DIFF
--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -835,6 +835,7 @@
         if (!obj.getEraser()) {
           var size = obj._getNonTransformedDimensions();
           var rect = new fabric.Rect({
+            fill: 'rgb(0,0,0)',
             width: size.x,
             height: size.y,
             clipPath: obj.clipPath,


### PR DESCRIPTION
### Motivation
I came across an edge case.
I was changing `Object.prototype.fill` to `null`.
It made erasing break.

The eraser logic uses a `Rect` and draw paths over it so clipping can be done. 
If fill is `null` the eraser erases everything.

This PR safeguards the eraser from such a case.