### PR TITLE
feat(EraserBrush): inverted brush

### DIFF
--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -696,6 +696,7 @@
       _saveAndTransform: function (ctx) {
         this.callSuper('_saveAndTransform', ctx);
         ctx.globalCompositeOperation = this.inverted ? 'source-over' : 'destination-out';
+        this.inverted && (ctx.strokeStyle = 'rgba(255,255,255,0)');
       },
 
       /**

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -436,6 +436,11 @@
       type: 'eraser',
 
       /**
+       * When set to `true` the brush will create a visual effect of undoing erasing
+       */
+      inverted: false,
+
+      /**
        * Indicates that the ctx is ready and rendering can begin.
        * Used to prevent a race condition caused by {@link fabric.EraserBrush#onMouseMove} firing before {@link fabric.EraserBrush#onMouseDown} has completed
        *
@@ -690,7 +695,7 @@
        */
       _saveAndTransform: function (ctx) {
         this.callSuper('_saveAndTransform', ctx);
-        ctx.globalCompositeOperation = 'destination-out';
+        ctx.globalCompositeOperation = this.inverted ? 'source-over' : 'destination-out';
       },
 
       /**
@@ -756,6 +761,12 @@
           return true;
         }
         return false;
+      },
+
+      createPath: function (pathData) {
+        var path = this.callSuper('createPath', pathData);
+        path.globalCompositeOperation = this.inverted ? 'source-over' : 'destination-out';
+        return path;
       },
 
       /**
@@ -850,7 +861,6 @@
         }
 
         path.clone(function (path) {
-          path.globalCompositeOperation = 'destination-out';
           // http://fabricjs.com/using-transformations
           var desiredTransform = fabric.util.multiplyTransformMatrices(
             fabric.util.invertTransform(


### PR DESCRIPTION
### Motivation 
#5187 

### POC
https://codesandbox.io/s/blissful-sutherland-yk05j?file=/src/EraserBrush.js:25469-25473
Try finddling with `inverted erasing`
It simply changes the `globalCompositeOperation `
```js
(path | ctx).globalCompositeOperation = this.inverted
          ? "source-over"
          : "destination-out";

```
With existing erasing logic this approach simply adds a path that draws over erasing paths in the object's clip path.

---

### The Challenge
The problem is the rendering of the brush in such a case.
It will draw color and I would expect it won't and only recover erased paths.
This might be possible but will require some work.

#### Context
https://github.com/fabricjs/fabric.js/blob/master/src/mixins/eraser_brush.mixin.js#L420
>When erasing occurs, the path (generated by mouse move) clips the top ctx and reveals the bottom ctx.
 >  * This achieves the desired effect of seeming to erase only erasable objects.
 >  * After erasing is done the created path is added to all intersected objects' `clipPath` property.

#### Drawing Logic
https://github.com/fabricjs/fabric.js/blob/master/src/mixins/eraser_brush.mixin.js#L646
##### Botton ctx
>Render all non-erasable objects on bottom layer with the exception of overlays to avoid being clipped by the brush.
>Groups are rendered for nested selective erasing, non-erasable objects are visible while erasable objects are not.

##### Top ctx
>Render all objects on top layer, erasable and non-erasable
>This is important for cases such as overlapping objects, the background object erasable and the foreground object not erasable.
>Render the brush

### Thoughts
To achieve an inverted/recovery effect the canvas should be prepared differently:
1. Render everything on bottom ctx Render all objects on bottom ctx 
2. Render top ctx in a way that when erasing it will reveal a rendered canvas with objects rendered **without** their eraser:
    - using a filter/[pattern](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createPattern) of canvas?
    - **render canvas on top ctx, clip entire ctx, set brush `globalCompositionOpertion =  "source-over"` to reveal top canvas**
3. On mouse up add the path as any eraser path (with existing logic), set path `globalCompositionOpertion =  "source-over"`

### Workaround
The effect of inverted erasing on a specific object can be achieved by setting the brush `globalCompositionOpertion =  "source-over"` and applying a color/filter with conjunction with #7175 

_Originally posted by @ShaMan123 in https://github.com/fabricjs/fabric.js/issues/5187#issuecomment-892493315_