### PR TITLE
ci(): Update npmpublish-next to trigger on merged PR.

### DIFF
--- a/.github/workflows/npmpublish-next.yml
+++ b/.github/workflows/npmpublish-next.yml
@@ -1,11 +1,13 @@
 name: Node.js Package @next
-
 on:
-  push:
-    branches: [ master ]
+  pull_request:
+    branches:
+      - master
+    types: [closed]
 
 jobs:
   publish-npm:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
@ShaMan123 That yml file isn't working, probably because a master push is not a merge PR, and in general we want to avoid direct push to master.

Let's try if this works