### PR TITLE
fix(Fabric.text): account for fontSize in textpath dimensions

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -795,8 +795,6 @@
           //todo - add support for justify
         }
         positionInPath += this.pathStartOffset * (reverse ? -1 : 1);
-      }
-      if (path) {
         for (i = reverse ? line.length - 1 : 0;
           reverse ? i >= 0 : i < line.length;
           reverse ? i-- : i++) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -400,13 +400,14 @@
       }
       this._splitText();
       this._clearCache();
+      var textHeight = this.calcTextHeight();
       if (this.path) {
-        this.width = this.path.width;
-        this.height = this.path.height;
+        this.width = this.path.width + textHeight;
+        this.height = this.path.height + textHeight;
       }
       else {
         this.width = this.calcTextWidth() || this.cursorWidth || this.MIN_TEXT_WIDTH;
-        this.height = this.calcTextHeight();
+        this.height = textHeight;
       }
       if (this.textAlign.indexOf('justify') !== -1) {
         // once text is measured we need to make space fatter to make justified text.


### PR DESCRIPTION
Text on a path is currently using the dimensions of the assigned path which can cause the cache size to be too small.

![image](https://user-images.githubusercontent.com/9057412/129426766-2e721d9b-993d-49f3-b6ad-e71dceb8c174.png)

This fix adds the calculated text height to the object's dimensions to ensure that nothing is clipped in the cache canvas. 
![image](https://user-images.githubusercontent.com/9057412/129426978-ef239af2-2ee9-4b37-9cb5-a42ab6bbee93.png)

Honestly though I'm not crazy about this solution since depending on the path's shape and direction this means the bounding box will sometimes be unnecessarily large. Let me know if you can think of a better idea.

![image](https://user-images.githubusercontent.com/9057412/129427228-bb17f195-b92f-47cb-a034-41fcf5f5b4e3.png)
