### PR TITLE
fix: iText.hiddenTextarea can be undefined.

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -155,7 +155,7 @@
 
       if (this._iTextInstances) {
         this._iTextInstances.forEach(function(obj) {
-          if (obj.isEditing) {
+          if (obj.isEditing && obj.hiddenTextarea) {
             obj.hiddenTextarea.focus();
           }
         });


### PR DESCRIPTION
It is possible for obj.hiddenArea to be undefined. This causes `obj.hiddenTextarea.focus();` to error. This checks for truthy before trying to focus. 

I am probably incorrectly using this tool but wanted to fix this to prevent errors everytime I move my mouse from the canvas.

Thank you!