### PR TITLE
feat(itext): Add hiddenTextareaAppendTo to attach textarea to.

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -17,7 +17,12 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     this.hiddenTextarea.style.cssText = 'position: absolute; top: ' + style.top +
     '; left: ' + style.left + '; z-index: -999; opacity: 0; width: 1px; height: 1px; font-size: 1px;' +
     ' paddingｰtop: ' + style.fontSize + ';';
-    fabric.document.body.appendChild(this.hiddenTextarea);
+
+    if (this.hiddenTextareaAppendTo) {
+      this.hiddenTextareaAppendTo.appendChild(this.hiddenTextarea);
+    } else {
+      fabric.document.body.appendChild(this.hiddenTextarea);
+    }
 
     fabric.util.addListener(this.hiddenTextarea, 'keydown', this.onKeyDown.bind(this));
     fabric.util.addListener(this.hiddenTextarea, 'keyup', this.onKeyUp.bind(this));


### PR DESCRIPTION
This is to prevent laggy conditions where the entire body needs to be redrawn. We can attach somewhere else off of the main body tag.

[Some details into the scenario](https://atfzl.com/don-t-attach-tooltips-to-document-body) but this is a little different due to not making a lot of new elements. But in large pages it can cause additional lag to attach.

```js
const textbox = new Textbox('yo', { hiddenTextareaAppendTo: document.getElementById('hiddenTextarea') })
```

Not 100% into the long variable name but felt appropriate.

