### PR TITLE
feat(Observable): once event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [next]
+- feat(Observable.once): Add once event handler (#7317)
 - feat(fabric.Object): Improve drawing of controls in group. (#7119)
 - fix(EraserBrush): intersectsWithObject edge cases (#7290)
 - fix(EraserBrush): dump canvas bg/overlay color support (#7289)

--- a/src/mixins/observable.mixin.js
+++ b/src/mixins/observable.mixin.js
@@ -46,6 +46,27 @@
     return this;
   }
 
+  function _once(eventName, handler) {
+    var _handler = function () {
+      handler();
+      this.off(eventName, _handler);
+    }.bind(this);
+    this.on(eventName, _handler);
+  }
+
+  function once(eventName, handler) {
+    // one object with key/value pairs was passed
+    if (arguments.length === 1) {
+      for (var prop in eventName) {
+        _once.call(this, prop, eventName[prop]);
+      }
+    }
+    else {
+      _once.call(this, eventName, handler);
+    }
+    return this;
+  }
+
   /**
    * Stops event observing for a particular event handler. Calling this method
    * without arguments removes all handlers for all events
@@ -114,6 +135,7 @@
   fabric.Observable = {
     fire: fire,
     on: on,
+    once: once,
     off: off,
   };
 })();

--- a/src/mixins/observable.mixin.js
+++ b/src/mixins/observable.mixin.js
@@ -48,7 +48,7 @@
 
   function _once(eventName, handler) {
     var _handler = function () {
-      handler();
+      handler.apply(this, arguments)
       this.off(eventName, _handler);
     }.bind(this);
     this.on(eventName, _handler);

--- a/src/mixins/observable.mixin.js
+++ b/src/mixins/observable.mixin.js
@@ -48,7 +48,7 @@
 
   function _once(eventName, handler) {
     var _handler = function () {
-      handler.apply(this, arguments)
+      handler.apply(this, arguments);
       this.off(eventName, _handler);
     }.bind(this);
     this.on(eventName, _handler);

--- a/test/unit/observable.js
+++ b/test/unit/observable.js
@@ -4,6 +4,7 @@ QUnit.test('fabric.Observable exists', function(assert) {
   assert.ok(fabric.Observable);
   assert.ok(fabric.Observable.fire);
   assert.ok(fabric.Observable.on);
+  assert.ok(fabric.Observable.once);
   assert.ok(fabric.Observable.off);
 });
 
@@ -18,6 +19,51 @@ QUnit.test('fire + on', function(assert) {
 
   foo.fire('bar:baz');
   assert.equal(eventFired, true);
+});
+
+QUnit.test('fire once', function (assert) {
+  var foo = {};
+  fabric.util.object.extend(foo, fabric.Observable);
+
+  var eventFired = 0;
+  foo.once('bar:baz', function () {
+    eventFired++;
+  });
+
+  foo.fire('bar:baz');
+  assert.equal(eventFired, 1);
+  foo.fire('bar:baz');
+  assert.equal(eventFired, 1);
+});
+
+QUnit.test('fire once multiple handlers', function (assert) {
+  var foo = {};
+  fabric.util.object.extend(foo, fabric.Observable);
+  var eventFired = 0;
+  var eventFired2 = 0;
+  var eventFired3 = 0;
+  foo.once({
+    'bar:baz': function () {
+      eventFired++;
+    },
+    'blah:blah': function () {
+      eventFired2++;
+    },
+    'blah:blah:bloo': function () {
+      eventFired3++;
+    }
+  });
+  foo.fire('bar:baz');
+  assert.equal(eventFired, 1);
+  assert.equal(eventFired2, 0);
+  foo.fire('blah:blah');
+  assert.equal(eventFired, 1);
+  assert.equal(eventFired2, 1);
+  foo.fire('bar:baz');
+  foo.fire('blah:blah');
+  assert.equal(eventFired, 1);
+  assert.equal(eventFired2, 1);
+  assert.equal(eventFired3, 0);
 });
 
 QUnit.test('off', function(assert) {

--- a/test/unit/observable.js
+++ b/test/unit/observable.js
@@ -27,6 +27,7 @@ QUnit.test('fire once', function (assert) {
 
   var eventFired = 0;
   foo.once('bar:baz', function () {
+    assert.equal(this, foo);
     eventFired++;
   });
 
@@ -42,15 +43,21 @@ QUnit.test('fire once multiple handlers', function (assert) {
   var eventFired = 0;
   var eventFired2 = 0;
   var eventFired3 = 0;
+  var eventData = { a: 'b', c: 'd' };
   foo.once({
     'bar:baz': function () {
       eventFired++;
+      assert.equal(this, foo);
     },
     'blah:blah': function () {
       eventFired2++;
+      assert.equal(this, foo);
     },
-    'blah:blah:bloo': function () {
+    'blah:blah:bloo': function (e) {
       eventFired3++;
+      assert.equal(this, foo);
+      assert.deepEqual(arguments[0], eventData);
+      assert.equal(e, eventData);
     }
   });
   foo.fire('bar:baz');
@@ -64,6 +71,7 @@ QUnit.test('fire once multiple handlers', function (assert) {
   assert.equal(eventFired, 1);
   assert.equal(eventFired2, 1);
   assert.equal(eventFired3, 0);
+  foo.fire('blah:blah:bloo', eventData);
 });
 
 QUnit.test('off', function(assert) {


### PR DESCRIPTION
This is very useful and saves repetitive `on` `off` logic for calling an event once and it aligns `Observable` with node's `EventEmitter`