### PR TITLE
feat(text.class.js) add path rendering to textpaths

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -498,6 +498,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     _render: function(ctx) {
+      this.path && this.path._render(ctx);
       this._setTextStyles(ctx);
       this._renderTextLinesBackground(ctx);
       this._renderTextDecoration(ctx, 'underline');


### PR DESCRIPTION
This adds path rendering for text objects that contain a path.

![image](https://user-images.githubusercontent.com/9057412/130670027-45925b14-7c88-4a1c-98b2-7a39115db006.png)

@asturur - let me know if you're okay with this implementation and I'll add a visual test.
