### PR TITLE
feat(text.class.js) added pathAlign property for text on path

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -244,6 +244,7 @@
      * How text is aligned to the path. This property determines
      * the perpendicular position of each character relative to the path.
      * (one of "baseline", "center", "ascender", "descender")
+     * This feature is in BETA, and its behavior may change
      * @type String
      * @default
      */
@@ -563,7 +564,20 @@
      * @param {String} [charStyle.fontStyle] Font style (italic|normal)
      */
     _setTextStyles: function(ctx, charStyle, forMeasuring) {
-      ctx.textBaseline = 'alphabetic';
+      ctx.textBaseline = 'alphabetical';
+      if (this.path) {
+        switch (this.pathAlign) {
+          case 'center':
+            ctx.textBaseline = 'middle';
+            break;
+          case 'ascender':
+            ctx.textBaseline = 'top';
+            break;
+          case 'descender':
+            ctx.textBaseline = 'bottom';
+            break;
+        }
+      }
       ctx.font = this._getFontDeclaration(charStyle, forMeasuring);
     },
 
@@ -854,31 +868,13 @@
      */
     _setGraphemeOnPath: function(positionInPath, graphemeInfo, startingPoint) {
       var centerPosition = positionInPath + graphemeInfo.kernedWidth / 2,
-          path = this.path, offsetDist = 0;
+          path = this.path;
 
       // we are at currentPositionOnPath. we want to know what point on the path is.
       var info = fabric.util.getPointOnPath(path.path, centerPosition, path.segmentsInfo);
       graphemeInfo.renderLeft = info.x - startingPoint.x;
       graphemeInfo.renderTop = info.y - startingPoint.y;
       graphemeInfo.angle = info.angle + (this.pathSide ===  'right' ? Math.PI : 0);
-
-      switch (this.pathAlign) {
-        case 'center':
-          offsetDist = graphemeInfo.height / 4;
-          break;
-        case 'ascender':
-          offsetDist = graphemeInfo.height / 1.5;
-          break;
-        case 'descender':
-          offsetDist = graphemeInfo.height / -3.75;
-          break;
-      }
-
-      if (offsetDist) {
-        // offsets the grapheme in the direction perpenticular to the path's tangent
-        graphemeInfo.renderLeft -= fabric.util.sin(graphemeInfo.angle) * offsetDist;
-        graphemeInfo.renderTop += fabric.util.cos(graphemeInfo.angle) * offsetDist;
-      }
     },
 
     /**

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -247,7 +247,7 @@
      * @type String
      * @default
      */
-     pathAlign:               'baseline',
+    pathAlign:               'baseline',
 
     /**
      * @private

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -862,18 +862,16 @@
       graphemeInfo.renderTop = info.y - startingPoint.y;
       graphemeInfo.angle = info.angle + (this.pathSide ===  'right' ? Math.PI : 0);
 
-      if (this.type === 'text' && this.path) {
-        switch (this.pathAlign) {
-          case 'center':
-            offsetDist = graphemeInfo.height / 4;
-            break;
-          case 'ascender':
-            offsetDist = graphemeInfo.height / 1.5;
-            break;
-          case 'descender':
-            offsetDist = graphemeInfo.height / -3.75;
-            break;
-        }
+      switch (this.pathAlign) {
+        case 'center':
+          offsetDist = graphemeInfo.height / 4;
+          break;
+        case 'ascender':
+          offsetDist = graphemeInfo.height / 1.5;
+          break;
+        case 'descender':
+          offsetDist = graphemeInfo.height / -3.75;
+          break;
       }
 
       if (offsetDist) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -875,10 +875,9 @@
       }
 
       if (offsetDist) {
-        var angle = graphemeInfo.angle - Math.PI / 2;
-        var vec = fabric.util.calcVectorPoint(angle, offsetDist);
-        graphemeInfo.renderLeft -= vec.x;
-        graphemeInfo.renderTop -= vec.y;
+        // offsets the grapheme in the direction perpenticular to the path's tangent
+        graphemeInfo.renderLeft -= fabric.util.sin(graphemeInfo.angle) * offsetDist;
+        graphemeInfo.renderTop += fabric.util.cos(graphemeInfo.angle) * offsetDist;
       }
     },
 

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -13,7 +13,7 @@
   var additionalProps =
     ('fontFamily fontWeight fontSize text underline overline linethrough' +
     ' textAlign fontStyle lineHeight textBackgroundColor charSpacing styles' +
-    ' direction path pathStartOffset pathSide').split(' ');
+    ' direction path pathStartOffset pathSide pathAlign').split(' ');
 
   /**
    * Text class
@@ -42,7 +42,8 @@
       'styles',
       'path',
       'pathStartOffset',
-      'pathSide'
+      'pathSide',
+      'pathAlign'
     ],
 
     /**
@@ -238,6 +239,15 @@
      * @default
      */
     pathSide:               'left',
+
+    /**
+     * How text is aligned to the path. This property determines
+     * the perpendicular position of each character relative to the path.
+     * (one of "baseline", "center", "ascender", "descender")
+     * @type String
+     * @default
+     */
+     pathAlign:               'baseline',
 
     /**
      * @private
@@ -844,13 +854,34 @@
      */
     _setGraphemeOnPath: function(positionInPath, graphemeInfo, startingPoint) {
       var centerPosition = positionInPath + graphemeInfo.kernedWidth / 2,
-          path = this.path;
+          path = this.path, offsetDist = 0;
 
       // we are at currentPositionOnPath. we want to know what point on the path is.
       var info = fabric.util.getPointOnPath(path.path, centerPosition, path.segmentsInfo);
       graphemeInfo.renderLeft = info.x - startingPoint.x;
       graphemeInfo.renderTop = info.y - startingPoint.y;
       graphemeInfo.angle = info.angle + (this.pathSide ===  'right' ? Math.PI : 0);
+
+      if (this.type === 'text' && this.path) {
+        switch (this.pathAlign) {
+          case 'center':
+            offsetDist = graphemeInfo.height / 4;
+            break;
+          case 'ascender':
+            offsetDist = graphemeInfo.height / 1.5;
+            break;
+          case 'descender':
+            offsetDist = graphemeInfo.height / -3.75;
+            break;
+        }
+      }
+
+      if (offsetDist) {
+        var angle = graphemeInfo.angle - Math.PI / 2;
+        var vec = fabric.util.calcVectorPoint(angle, offsetDist);
+        graphemeInfo.renderLeft -= vec.x;
+        graphemeInfo.renderTop -= vec.y;
+      }
     },
 
     /**

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -870,7 +870,6 @@
   fabric.util.getBoundsOfCurve = getBoundsOfCurve;
   fabric.util.getPointOnPath = getPointOnPath;
   fabric.util.transformPath = transformPath;
-  fabric.util.calcVectorPoint = calcVectorPoint;
   /**
    * Typo of `fromArcToBeziers` kept for not breaking the api once corrected.
    * Will be removed in fabric 5.0

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -108,20 +108,6 @@
   }
 
   /**
-   * Calculates the coordinates of a vector from angle and distance
-   * @param {Number} angle the angle of the vector in radians
-   * @param {Number} distance the distance/length of the vector
-   * @return {Object.x} x coordinate of point
-   * @return {Object.y} y coordinate of point
-   */
-  function calcVectorPoint(angle, distance) {
-    var coords = {};
-    coords.x = fabric.util.cos(angle) * distance;
-    coords.y = fabric.util.sin(angle) * distance;
-    return coords;
-  }
-
-  /**
    * Calculate bounding box of a beziercurve
    * @param {Number} x0 starting point
    * @param {Number} y0

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -108,6 +108,20 @@
   }
 
   /**
+   * Calculates the coordinates of a vector from angle and distance
+   * @param {Number} angle the angle of the vector in radians
+   * @param {Number} distance the distance/length of the vector
+   * @return {Object.x} x coordinate of point
+   * @return {Object.y} y coordinate of point
+   */
+  function calcVectorPoint(angle, distance) {
+    var coords = {};
+    coords.x = fabric.util.cos(angle) * distance;
+    coords.y = fabric.util.sin(angle) * distance;
+    return coords;
+  }
+
+  /**
    * Calculate bounding box of a beziercurve
    * @param {Number} x0 starting point
    * @param {Number} y0
@@ -870,6 +884,7 @@
   fabric.util.getBoundsOfCurve = getBoundsOfCurve;
   fabric.util.getPointOnPath = getPointOnPath;
   fabric.util.transformPath = transformPath;
+  fabric.util.calcVectorPoint = calcVectorPoint;
   /**
    * Typo of `fromArcToBeziers` kept for not breaking the api once corrected.
    * Will be removed in fabric 5.0

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -44,12 +44,13 @@
     skewX:                    0,
     skewY:                    0,
     charSpacing:              0,
-    styles:                     { },
+    styles:                   { },
     strokeUniform:            false,
     path:                     null,
     direction:                'ltr',
-    pathStartOffset:            0,
-    pathSide:                   'left',
+    pathStartOffset:          0,
+    pathSide:                 'left',
+    pathAlign:                'baseline'
   };
 
 

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -57,6 +57,7 @@
     direction:                  'ltr',
     pathStartOffset:            0,
     pathSide:                   'left',
+    pathAlign:                  'baseline'
   };
 
   QUnit.test('constructor', function(assert) {
@@ -869,7 +870,7 @@
 
   QUnit.test('cacheProperties for text', function(assert) {
     var text = new fabric.Text('a');
-    assert.equal(text.cacheProperties.join('-'), 'fill-stroke-strokeWidth-strokeDashArray-width-height-paintFirst-strokeUniform-strokeLineCap-strokeDashOffset-strokeLineJoin-strokeMiterLimit-backgroundColor-clipPath-fontFamily-fontWeight-fontSize-text-underline-overline-linethrough-textAlign-fontStyle-lineHeight-textBackgroundColor-charSpacing-styles-direction-path-pathStartOffset-pathSide');
+    assert.equal(text.cacheProperties.join('-'), 'fill-stroke-strokeWidth-strokeDashArray-width-height-paintFirst-strokeUniform-strokeLineCap-strokeDashOffset-strokeLineJoin-strokeMiterLimit-backgroundColor-clipPath-fontFamily-fontWeight-fontSize-text-underline-overline-linethrough-textAlign-fontStyle-lineHeight-textBackgroundColor-charSpacing-styles-direction-path-pathStartOffset-pathSide-pathAlign');
   });
 
   QUnit.test('_getLineLeftOffset', function(assert) {

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -55,8 +55,9 @@
     strokeUniform: false,
     path: null,
     direction: 'ltr',
-    pathStartOffset:            0,
-    pathSide:                   'left',
+    pathStartOffset: 0,
+    pathSide: 'left',
+    pathAlign: 'baseline'
   };
 
   QUnit.test('constructor', function(assert) {


### PR DESCRIPTION
(note - this replaces #7358 which had branch conflicts)

This adds an additional property pathAlign to the text class for setting the perpendicular alignment of each character on a path. It's basically the equivalent to the text path alignment settings in InDesign/Illustrator. Not sure how useful the ascender and descender options will be, but I expect center will see a lot of use.

I've taken the approach of offsetting each grapheme's position based on the path's tangent rather than just modifying the canvas's `textbaseline` since the `textbaseline` prop gives inconsistent results across different browsers.

![image](https://user-images.githubusercontent.com/9057412/132559448-7eedc5dc-5d93-42b6-922b-f9f0190c1139.png)

![image](https://user-images.githubusercontent.com/9057412/132559464-46b2d2f9-e234-490d-a148-6f9f748cb868.png)

![image](https://user-images.githubusercontent.com/9057412/132559482-dfe649e1-2588-453b-a3ef-e61376ec21c3.png)

![image](https://user-images.githubusercontent.com/9057412/132559565-f39008cf-b858-4d7f-aeb7-543097aef34f.png)