### PR TITLE
Doc: Clarify viewport transformations take Canvas 2D API transform matrix

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -133,8 +133,12 @@
     imageSmoothingEnabled: true,
 
     /**
-     * The transformation (in the format of Canvas transform) which focuses the viewport
+     * The transformation (a Canvas 2D API transform matrix) which focuses the viewport
      * @type Array
+     * @example <caption>Default transform</caption>
+     * canvas.viewportTransform = [1, 0, 0, 1, 0, 0]; 
+     * @example <caption>Scale by 70% and translate toward bottom-right by 50, without skewing</caption>
+     * canvas.viewportTransform = [0.7, 0, 0, 0.7, 50, 50]; 
      * @default
      */
     viewportTransform: fabric.iMatrix.concat(),
@@ -670,8 +674,8 @@
     },
 
     /**
-     * Sets viewport transform of this canvas instance
-     * @param {Array} vpt the transform in the form of context.transform
+     * Sets viewport transformation of this canvas instance
+     * @param {Array} vpt a Canvas 2D API transform matrix
      * @return {fabric.Canvas} instance
      * @chainable true
      */


### PR DESCRIPTION
Clarify in src/static_canvas.class.js that viewport transformations take a Canvas 2D API transform matrix.
Give example.

Closes #7400 