### PR TITLE
feat(Observable): prepend

### DIFF
--- a/src/mixins/observable.mixin.js
+++ b/src/mixins/observable.mixin.js
@@ -24,10 +24,11 @@
    * @alias on
    * @param {String|Object} eventName Event name (eg. 'after:render') or object with key/value pairs (eg. {'after:render': handler, 'selection:cleared': handler})
    * @param {Function} handler Function that receives a notification when an event of the specified type occurs
+   * @param {boolean} [prepend] whether to prepend the handler so it will be fired before the rest of the handlers
    * @return {Self} thisArg
    * @chainable
    */
-  function on(eventName, handler) {
+  function on(eventName, handler, prepend) {
     if (!this.__eventListeners) {
       this.__eventListeners = { };
     }
@@ -41,28 +42,33 @@
       if (!this.__eventListeners[eventName]) {
         this.__eventListeners[eventName] = [];
       }
-      this.__eventListeners[eventName].push(handler);
+      if (prepend) {
+        this.__eventListeners[eventName].unshift(handler);
+      }
+      else {
+        this.__eventListeners[eventName].push(handler);
+      }
     }
     return this;
   }
 
-  function _once(eventName, handler) {
+  function _once(eventName, handler, prepend) {
     var _handler = function () {
       handler.apply(this, arguments);
       this.off(eventName, _handler);
     }.bind(this);
-    this.on(eventName, _handler);
+    this.on(eventName, _handler, prepend);
   }
 
-  function once(eventName, handler) {
+  function once(eventName, handler, prepend) {
     // one object with key/value pairs was passed
     if (arguments.length === 1) {
       for (var prop in eventName) {
-        _once.call(this, prop, eventName[prop]);
+        _once.call(this, prop, eventName[prop], prepend);
       }
     }
     else {
-      _once.call(this, eventName, handler);
+      _once.call(this, eventName, handler, prepend);
     }
     return this;
   }

--- a/test/unit/observable.js
+++ b/test/unit/observable.js
@@ -353,3 +353,35 @@ QUnit.test('chaining', function(assert) {
   assert.equal(event1Fired, false);
   assert.equal(event2Fired, false);
 });
+
+QUnit.test('prepending events', function (assert) {
+  var foo = {},
+    firingOrder = [],
+    handler1 = function () {
+      firingOrder.push(1);
+    },
+    handler2 = function () {
+      firingOrder.push(2);
+    },
+    handler3 = function () {
+      firingOrder.push(3);
+    },
+    handler4 = function () {
+      firingOrder.push(4);
+    },
+    handler5 = function () {
+      firingOrder.push(5);
+    };
+
+  fabric.util.object.extend(foo, fabric.Observable);
+  foo.on('bar:baz', handler1);
+  foo.on('bar:baz', handler2);
+  foo.on('bar:baz', handler3, true);
+  foo.fire('bar:baz');
+  assert.deepEqual(firingOrder, [3, 1, 2], 'Firing order is wrong');
+  foo.on('bar:baz', handler4, true);
+  foo.on('bar:baz', handler5);
+  firingOrder = [];
+  foo.fire('bar:baz');
+  assert.deepEqual(firingOrder, [4, 3, 1, 2, 5], 'Firing order is wrong');
+});


### PR DESCRIPTION
Added the ability to prepend event handlers in order to control an event's firing sequence.
```js
const handler = () => {};
canvas.on('foo', handler, true)
canvas.once('foo', handler, true)
```