### PR TITLE
fix(Canvas): fire `removed` events on Canvas dispose

### DIFF
--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1763,7 +1763,7 @@
       this.forEachObject(function(object) {
         object.dispose && object.dispose();
         this._onObjectRemoved(object);
-      });
+      }.bind(this));
       this._objects = [];
       if (this.backgroundImage && this.backgroundImage.dispose) {
         this.backgroundImage.dispose();

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1762,6 +1762,7 @@
       }
       this.forEachObject(function(object) {
         object.dispose && object.dispose();
+        this._onObjectRemoved(object);
       });
       this._objects = [];
       if (this.backgroundImage && this.backgroundImage.dispose) {

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1541,7 +1541,8 @@
     var canvas2 = new fabric.StaticCanvas(null, { renderOnAddRemove: false });
     assert.ok(typeof canvas2.dispose === 'function');
     var called = [];
-    canvas2.add(makeRect(), makeRect(), makeRect());
+    var objects = [makeRect(), makeRect(), makeRect()];
+    canvas2.add.apply(canvas2, objects);
     canvas2.forEachObject(function (obj) {
       obj.on('removed', function () {
         called.push(obj);
@@ -1549,7 +1550,7 @@
     });
     canvas2.dispose();
     assert.equal(canvas2.getObjects().length, 0, 'dispose should clear canvas');
-    assert.deepEqual(called, canvas2.getObjects(), 'dispose should fire removed events');
+    assert.deepEqual(called, objects, 'dispose should fire removed events');
     assert.equal(canvas2.lowerCanvasEl, null, 'dispose should clear lowerCanvasEl');
     assert.equal(canvas2.contextContainer, null, 'dispose should clear contextContainer');
   });


### PR DESCRIPTION
#7447 
This makes it easier to dispose objects without needing to extend classes and to handle disposing side effects.