### PR TITLE
Fix(fabric.Text): Avoid reiterating measurements when width is 0 and measure also empty lines for consistency.

### DIFF
--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1347,15 +1347,8 @@
         return this.__lineWidths[lineIndex];
       }
 
-      var width, line = this._textLines[lineIndex], lineInfo;
-
-      if (!line || line.join('') === '') {
-        width = 0;
-      }
-      else {
-        lineInfo = this.measureLine(lineIndex);
-        width = lineInfo.width;
-      }
+      var lineInfo = this.measureLine(lineIndex);
+      var width = lineInfo.width;
       this.__lineWidths[lineIndex] = width;
       return width;
     },

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1343,13 +1343,13 @@
      * @return {Number} Line width
      */
     getLineWidth: function(lineIndex) {
-      if (this.__lineWidths[lineIndex]) {
+      if (this.__lineWidths[lineIndex] !== undefined) {
         return this.__lineWidths[lineIndex];
       }
 
       var width, line = this._textLines[lineIndex], lineInfo;
 
-      if (line === '') {
+      if (!line || line.join('') === '') {
         width = 0;
       }
       else {


### PR DESCRIPTION
Very small PR, I noticed we were hitting measure text more than expected and found this to be the cause.

Happy for this to be declined If I've misunderstood these checks :) 