### PR TITLE
feat: Customize line width for controls

### DIFF
--- a/src/control.class.js
+++ b/src/control.class.js
@@ -127,6 +127,13 @@
     cursorStyle: 'crosshair',
 
     /**
+     * Defines the line width the Context2D will use to draw a stroke around the control.
+     * @type {Number}
+     * @default 1
+     */
+    lineWidth: 1,
+
+    /**
      * If controls has an offsetY or offsetX, draw a line that connects
      * the control to the bounding box
      * @type {Boolean}

--- a/src/controls.render.js
+++ b/src/controls.render.js
@@ -26,7 +26,8 @@
         methodName = transparentCorners ? 'stroke' : 'fill',
         stroke = !transparentCorners && (styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor),
         myLeft = left,
-        myTop = top, size;
+        myTop = top, size,
+        lineWidth = this.lineWidth || 1;
     ctx.save();
     ctx.fillStyle = styleOverride.cornerColor || fabricObject.cornerColor;
     ctx.strokeStyle = styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor;
@@ -44,8 +45,8 @@
     else {
       size = xSize;
     }
-    // this is still wrong
-    ctx.lineWidth = 1;
+    // this is still wrong (what is still wrong? original [ctx.lineWidth = 1])
+    ctx.lineWidth = lineWidth;
     ctx.beginPath();
     ctx.arc(myLeft, myTop, size / 2, 0, 2 * Math.PI, false);
     ctx[methodName]();
@@ -75,12 +76,13 @@
         methodName = transparentCorners ? 'stroke' : 'fill',
         stroke = !transparentCorners && (
           styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor
-        ), xSizeBy2 = xSize / 2, ySizeBy2 = ySize / 2;
+        ), xSizeBy2 = xSize / 2, ySizeBy2 = ySize / 2,
+        lineWidth = this.lineWidth || 1;
     ctx.save();
     ctx.fillStyle = styleOverride.cornerColor || fabricObject.cornerColor;
     ctx.strokeStyle = styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor;
-    // this is still wrong
-    ctx.lineWidth = 1;
+    // this is still wrong (what is still wrong? original [ctx.lineWidth = 1])
+    ctx.lineWidth = lineWidth;
     ctx.translate(left, top);
     ctx.rotate(degreesToRadians(fabricObject.angle));
     // this does not work, and fixed with ( && ) does not make sense.


### PR DESCRIPTION
![2021-11-29_14-22](https://user-images.githubusercontent.com/15027/143929585-1f3fc902-1c08-4fc0-9bfb-c0b6beadc9d2.png)

Allows for custom controls to define the line width that goes around the control.

https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineWidth