### PR TITLE
feat(Control) Add control fill/stroke options

### DIFF
--- a/src/control.class.js
+++ b/src/control.class.js
@@ -127,6 +127,20 @@
     cursorStyle: 'crosshair',
 
     /**
+     * Sets the fill color of the control. If null, defaults to object's cornerColor
+     * @type {?String}
+     * @default null
+     */
+    fill: null,
+
+    /**
+     * Sets the stroke color of the control. If null, defaults to object's cornerStrokeColor
+     * @type {?String}
+     * @default null
+     */
+    stroke: null,
+
+    /**
      * If controls has an offsetY or offsetX, draw a line that connects
      * the control to the bounding box
      * @type {Boolean}

--- a/src/controls.render.js
+++ b/src/controls.render.js
@@ -24,7 +24,9 @@
         transparentCorners = typeof styleOverride.transparentCorners !== 'undefined' ?
           styleOverride.transparentCorners : fabricObject.transparentCorners,
         methodName = transparentCorners ? 'stroke' : 'fill',
-        stroke = !transparentCorners && (styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor || this.stroke),
+        stroke = !transparentCorners && (
+          styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor || this.stroke
+        ),
         myLeft = left,
         myTop = top, size;
     ctx.save();
@@ -74,8 +76,9 @@
           styleOverride.transparentCorners : fabricObject.transparentCorners,
         methodName = transparentCorners ? 'stroke' : 'fill',
         stroke = !transparentCorners && (
-          styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor
-        ), xSizeBy2 = xSize / 2, ySizeBy2 = ySize / 2;
+          styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor || this.stroke
+        ),
+        xSizeBy2 = xSize / 2, ySizeBy2 = ySize / 2;
     ctx.save();
     ctx.fillStyle = this.fill || styleOverride.cornerColor || fabricObject.cornerColor;
     ctx.strokeStyle = this.stroke || styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor;

--- a/src/controls.render.js
+++ b/src/controls.render.js
@@ -24,12 +24,12 @@
         transparentCorners = typeof styleOverride.transparentCorners !== 'undefined' ?
           styleOverride.transparentCorners : fabricObject.transparentCorners,
         methodName = transparentCorners ? 'stroke' : 'fill',
-        stroke = !transparentCorners && (styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor),
+        stroke = !transparentCorners && (styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor || this.stroke),
         myLeft = left,
         myTop = top, size;
     ctx.save();
-    ctx.fillStyle = styleOverride.cornerColor || fabricObject.cornerColor;
-    ctx.strokeStyle = styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor;
+    ctx.fillStyle = this.fill || styleOverride.cornerColor || fabricObject.cornerColor;
+    ctx.strokeStyle = this.stroke || styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor;
     // as soon as fabric react v5, remove ie11, use proper ellipse code.
     if (xSize > ySize) {
       size = xSize;
@@ -77,8 +77,8 @@
           styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor
         ), xSizeBy2 = xSize / 2, ySizeBy2 = ySize / 2;
     ctx.save();
-    ctx.fillStyle = styleOverride.cornerColor || fabricObject.cornerColor;
-    ctx.strokeStyle = styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor;
+    ctx.fillStyle = this.fill || styleOverride.cornerColor || fabricObject.cornerColor;
+    ctx.strokeStyle = this.stroke || styleOverride.cornerStrokeColor || fabricObject.cornerStrokeColor;
     // this is still wrong
     ctx.lineWidth = 1;
     ctx.translate(left, top);


### PR DESCRIPTION
This allows custom controls to have specific fill/stroke outside specific
object options (fabric.Object.cornerStrokeStyle).

```javascript
const object = new fabric.Rect({ width: 5, height: 10 })
object.set('controls', {
 mtr: new fabric.Control({ fill: 'red', stroke: 'blue' })
})
```
