### PR TITLE
fix(IText): copypaste linebreaks

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -866,7 +866,13 @@
           this.insertCharStyleObject(cursorLoc.lineIndex + i, 0, addedLines[i], copiedStyle);
         }
         else if (copiedStyle) {
-          this.styles[cursorLoc.lineIndex + i][0] = copiedStyle[0];
+          // this test is required in order to close #6841
+          // when a pasted buffer begins with a newline then
+          // this.styles[cursorLoc.lineIndex + i] and copiedStyle[0]
+          // may be undefined for some reason
+          if (this.styles[cursorLoc.lineIndex + i] && copiedStyle[0]) {
+            this.styles[cursorLoc.lineIndex + i][0] = copiedStyle[0];
+          }
         }
         copiedStyle = copiedStyle && copiedStyle.slice(addedLines[i] + 1);
       }


### PR DESCRIPTION
This is a fix for a copy and paste bug in the textfield object. Text that contains just newlines will though an exception when pasted. The fix tests ``this.styles[cursorLoc.lineIndex + i] && copiedStyle[0])`` are both defined.

```

////////////////////// example ////////////////////// 

for() {
}

////////////////////// end example ////////////////////// 

```
close #6841