### PR TITLE
feat(animation): animations registry

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1200,6 +1200,7 @@
      */
     dispose: function () {
       var wrapper = this.wrapperEl;
+      fabric.runningAnimations.cancelAll();
       this.removeListeners();
       wrapper.removeChild(this.upperCanvasEl);
       wrapper.removeChild(this.lowerCanvasEl);

--- a/src/mixins/animation.mixin.js
+++ b/src/mixins/animation.mixin.js
@@ -25,6 +25,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         _this = this;
 
     fabric.util.animate({
+      target: this,
       startValue: object.left,
       endValue: this.getCenter().left,
       duration: this.FX_DURATION,
@@ -60,6 +61,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         _this = this;
 
     fabric.util.animate({
+      target: this,
       startValue: object.top,
       endValue: this.getCenter().top,
       duration: this.FX_DURATION,
@@ -95,6 +97,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         _this = this;
 
     fabric.util.animate({
+      target: this,
       startValue: object.opacity,
       endValue: 0,
       duration: this.FX_DURATION,
@@ -196,6 +199,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     }
 
     var _options = {
+      target: this,
       startValue: options.from,
       endValue: to,
       byValue: options.by,

--- a/src/mixins/animation.mixin.js
+++ b/src/mixins/animation.mixin.js
@@ -13,8 +13,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
    * @param {Object} [callbacks] Callbacks object with optional "onComplete" and/or "onChange" properties
    * @param {Function} [callbacks.onComplete] Invoked on completion
    * @param {Function} [callbacks.onChange] Invoked on every step of animation
-   * @return {fabric.Canvas} thisArg
-   * @chainable
+   * @return {fabric.AnimationContext} context
    */
   fxCenterObjectH: function (object, callbacks) {
     callbacks = callbacks || { };
@@ -24,7 +23,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         onChange = callbacks.onChange || empty,
         _this = this;
 
-    fabric.util.animate({
+    return fabric.util.animate({
       target: this,
       startValue: object.left,
       endValue: this.getCenter().left,
@@ -39,8 +38,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         onComplete();
       }
     });
-
-    return this;
   },
 
   /**
@@ -49,8 +46,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
    * @param {Object} [callbacks] Callbacks object with optional "onComplete" and/or "onChange" properties
    * @param {Function} [callbacks.onComplete] Invoked on completion
    * @param {Function} [callbacks.onChange] Invoked on every step of animation
-   * @return {fabric.Canvas} thisArg
-   * @chainable
+   * @return {fabric.AnimationContext} context
    */
   fxCenterObjectV: function (object, callbacks) {
     callbacks = callbacks || { };
@@ -60,7 +56,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         onChange = callbacks.onChange || empty,
         _this = this;
 
-    fabric.util.animate({
+    return fabric.util.animate({
       target: this,
       startValue: object.top,
       endValue: this.getCenter().top,
@@ -75,8 +71,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         onComplete();
       }
     });
-
-    return this;
   },
 
   /**
@@ -85,8 +79,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
    * @param {Object} [callbacks] Callbacks object with optional "onComplete" and/or "onChange" properties
    * @param {Function} [callbacks.onComplete] Invoked on completion
    * @param {Function} [callbacks.onChange] Invoked on every step of animation
-   * @return {fabric.Canvas} thisArg
-   * @chainable
+   * @return {fabric.AnimationContext} context
    */
   fxRemove: function (object, callbacks) {
     callbacks = callbacks || { };
@@ -96,7 +89,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         onChange = callbacks.onChange || empty,
         _this = this;
 
-    fabric.util.animate({
+    return fabric.util.animate({
       target: this,
       startValue: object.opacity,
       endValue: 0,
@@ -111,8 +104,6 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
         onComplete();
       }
     });
-
-    return this;
   }
 });
 
@@ -123,7 +114,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
    * @param {Number|Object} value Value to animate property to (if string was given first) or options object
    * @return {fabric.Object} thisArg
    * @tutorial {@link http://fabricjs.com/fabric-intro-part-2#animation}
-   * @chainable
+   * @return {fabric.AnimationContext | fabric.AnimationContext[]} animation context (or an array if passed multiple properties)
    *
    * As object — multiple properties
    *
@@ -136,22 +127,22 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
    * object.animate('left', { duration: ... });
    *
    */
-  animate: function() {
+  animate: function () {
     if (arguments[0] && typeof arguments[0] === 'object') {
-      var propsToAnimate = [], prop, skipCallbacks;
+      var propsToAnimate = [], prop, skipCallbacks, out = [];
       for (prop in arguments[0]) {
         propsToAnimate.push(prop);
       }
       for (var i = 0, len = propsToAnimate.length; i < len; i++) {
         prop = propsToAnimate[i];
         skipCallbacks = i !== len - 1;
-        this._animate(prop, arguments[0][prop], arguments[1], skipCallbacks);
+        out.push(this._animate(prop, arguments[0][prop], arguments[1], skipCallbacks));
       }
+      return out;
     }
     else {
-      this._animate.apply(this, arguments);
+      return this._animate.apply(this, arguments);
     }
-    return this;
   },
 
   /**

--- a/src/mixins/object_straightening.mixin.js
+++ b/src/mixins/object_straightening.mixin.js
@@ -15,11 +15,9 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
   /**
    * Straightens an object (rotating it from current angle to one of 0, 90, 180, 270, etc. depending on which is closer)
    * @return {fabric.Object} thisArg
-   * @chainable
    */
   straighten: function() {
     this.rotate(this._getAngleValueForStraighten());
-    return this;
   },
 
   /**
@@ -28,7 +26,6 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
    * @param {Function} [callbacks.onComplete] Invoked on completion
    * @param {Function} [callbacks.onChange] Invoked on every step of animation
    * @return {fabric.Object} thisArg
-   * @chainable
    */
   fxStraighten: function(callbacks) {
     callbacks = callbacks || { };
@@ -38,7 +35,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
         onChange = callbacks.onChange || empty,
         _this = this;
 
-    fabric.util.animate({
+    return fabric.util.animate({
       target: this,
       startValue: this.get('angle'),
       endValue: this._getAngleValueForStraighten(),
@@ -52,8 +49,6 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
         onComplete();
       },
     });
-
-    return this;
   }
 });
 
@@ -63,24 +58,20 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
    * Straightens object, then rerenders canvas
    * @param {fabric.Object} object Object to straighten
    * @return {fabric.Canvas} thisArg
-   * @chainable
    */
   straightenObject: function (object) {
     object.straighten();
     this.requestRenderAll();
-    return this;
   },
 
   /**
    * Same as {@link fabric.Canvas.prototype.straightenObject}, but animated
    * @param {fabric.Object} object Object to straighten
    * @return {fabric.Canvas} thisArg
-   * @chainable
    */
   fxStraightenObject: function (object) {
-    object.fxStraighten({
+    return object.fxStraighten({
       onChange: this.requestRenderAllBound
     });
-    return this;
   }
 });

--- a/src/mixins/object_straightening.mixin.js
+++ b/src/mixins/object_straightening.mixin.js
@@ -39,6 +39,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
         _this = this;
 
     fabric.util.animate({
+      target: this,
       startValue: this.get('angle'),
       endValue: this._getAngleValueForStraighten(),
       duration: this.FX_DURATION,

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -202,7 +202,8 @@
     /**
      * Delete textures, reference to elements and eventually JSDOM cleanup
      */
-    dispose: function() {
+    dispose: function () {
+      this.callSuper('dispose');
       this.removeTexture(this.cacheKey);
       this.removeTexture(this.cacheKey + '_filtered');
       this._cacheContext = undefined;

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1941,6 +1941,13 @@
       if (this.globalCompositeOperation) {
         ctx.globalCompositeOperation = this.globalCompositeOperation;
       }
+    },
+
+    /**
+     * cancel instance's running animations
+     */
+    dispose: function () {
+      fabric.runningAnimations.cancelByTarget(this);
     }
   });
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -1038,7 +1038,6 @@
     /**
      * Centers object horizontally in the canvas
      * @param {fabric.Object} object Object to center horizontally
-     * @return {fabric.Canvas} thisArg
      */
     centerObjectH: function (object) {
       return this._centerObject(object, new fabric.Point(this.getCenter().left, object.getCenterPoint().y));
@@ -1047,8 +1046,6 @@
     /**
      * Centers object vertically in the canvas
      * @param {fabric.Object} object Object to center vertically
-     * @return {fabric.Canvas} thisArg
-     * @chainable
      */
     centerObjectV: function (object) {
       return this._centerObject(object, new fabric.Point(object.getCenterPoint().x, this.getCenter().top));
@@ -1057,8 +1054,6 @@
     /**
      * Centers object vertically and horizontally in the canvas
      * @param {fabric.Object} object Object to center vertically and horizontally
-     * @return {fabric.Canvas} thisArg
-     * @chainable
      */
     centerObject: function(object) {
       var center = this.getCenter();
@@ -1069,8 +1064,6 @@
     /**
      * Centers object vertically and horizontally in the viewport
      * @param {fabric.Object} object Object to center vertically and horizontally
-     * @return {fabric.Canvas} thisArg
-     * @chainable
      */
     viewportCenterObject: function(object) {
       var vpCenter = this.getVpCenter();
@@ -1081,20 +1074,15 @@
     /**
      * Centers object horizontally in the viewport, object.top is unchanged
      * @param {fabric.Object} object Object to center vertically and horizontally
-     * @return {fabric.Canvas} thisArg
-     * @chainable
      */
     viewportCenterObjectH: function(object) {
       var vpCenter = this.getVpCenter();
-      this._centerObject(object, new fabric.Point(vpCenter.x, object.getCenterPoint().y));
-      return this;
+      return this._centerObject(object, new fabric.Point(vpCenter.x, object.getCenterPoint().y));
     },
 
     /**
      * Centers object Vertically in the viewport, object.top is unchanged
      * @param {fabric.Object} object Object to center vertically and horizontally
-     * @return {fabric.Canvas} thisArg
-     * @chainable
      */
     viewportCenterObjectV: function(object) {
       var vpCenter = this.getVpCenter();
@@ -1105,7 +1093,6 @@
     /**
      * Calculate the point in canvas that correspond to the center of actual viewport.
      * @return {fabric.Point} vpCenter, viewport center
-     * @chainable
      */
     getVpCenter: function() {
       var center = this.getCenter(),
@@ -1117,14 +1104,11 @@
      * @private
      * @param {fabric.Object} object Object to center
      * @param {fabric.Point} center Center point
-     * @return {fabric.Canvas} thisArg
-     * @chainable
      */
     _centerObject: function(object, center) {
       object.setPositionByOrigin(center, 'center', 'center');
       object.setCoords();
       this.renderOnAddRemove && this.requestRenderAll();
-      return this;
     },
 
     /**

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -31,7 +31,8 @@
      * cancel all running animations
      */
     cancelAll: function () {
-      this.forEach(function (animation) {
+      var animations = this.slice();
+      animations.forEach(function (animation) {
         animation.cancel();
       });
     },

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -44,6 +44,19 @@
     },
 
     /**
+     * cancel all running animations for target
+     * @param {*} target 
+     * @returns 
+     */
+    cancelByTarget: function (target) {
+      var cancelled = this.findAnimationsByTarget(target);
+      cancelled.forEach(function (animation) {
+        animation.cancel();
+      });
+      return cancelled;
+    },
+
+    /**
      *
      * @param {CancelFunction} cancelFunc the function returned by animate
      * @returns {number}
@@ -60,6 +73,20 @@
     findAnimation: function (cancelFunc) {
       return this.find(function (animation) {
         return animation.cancel === cancelFunc;
+      });
+    },
+
+    /**
+     *
+     * @param {*} target the object that is assigned to the target property of the animation context
+     * @returns {AnimationContext[]} array of animation options object associated with target
+     */
+    findAnimationsByTarget: function (target) {
+      if (!target) {
+        return [];
+      }
+      return this.filter(function (animation) {
+        return animation.target === target;
       });
     }
   });

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -71,7 +71,7 @@
    * Changes value from one to another within certain period of time, invoking callbacks as value is being changed.
    * @memberOf fabric.util
    * @param {AnimationOptions} [options] Animation options
-   * @returns {Function} abort function
+   * @returns {CancelFunction} abort function
    */
   function animate(options) {
     options || (options = {});

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -86,7 +86,10 @@
       cancel: function () {
         cancel = true;
         removeFromRegistry();
-      }
+      },
+      currentValue: 'startValue' in options ? options.startValue : 0,
+      completionRate: 0,
+      durationRate: 0
     });
     fabric.runningAnimations.push(context);
 
@@ -111,7 +114,11 @@
         var currentTime = time > finish ? duration : (time - start),
             timePerc = currentTime / duration,
             current = easing(currentTime, startValue, byValue, duration),
-            valuePerc = Math.abs((current - startValue) / byValue);
+          valuePerc = Math.abs((current - startValue) / byValue);
+        //  update context
+        context.currentValue = current;
+        context.completionRate = valuePerc;
+        context.durationRate = timePerc;
         if (cancel) {
           return;
         }
@@ -123,6 +130,10 @@
           return;
         }
         if (time > finish) {
+          //  update context
+          context.currentValue = endValue;
+          context.completionRate = 1;
+          context.durationRate = 1;
           onChange(endValue, 1, 1);
           onComplete(endValue, 1, 1);
           removeFromRegistry();

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -15,8 +15,13 @@
    * @property {Function} [options.abort] Additional function with logic. If returns true, animation aborts.
    *
    * @typedef {() => void} CancelFunction
+   * 
+   * @typedef {Object} AnimationCurrentState
+   * @property {number} currentValue value in range [`startValue`, `endValue`]
+   * @property {number} completionRate value in range [0, 1]
+   * @property {number} durationRate value in range [0, 1]
    *
-   * @typedef {(AnimationOptions & { cancel: CancelFunction }} AnimationContext
+   * @typedef {(AnimationOptions & AnimationCurrentState & { cancel: CancelFunction }} AnimationContext
    */
 
   /**

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -140,8 +140,6 @@
       options.onStart && options.onStart();
 
       (function tick(ticktime) {
-        // TODO: move abort call after calculation
-        // and pass (current,valuePerc, timePerc) as arguments
         time = ticktime || +new Date();
         var currentTime = time > finish ? duration : (time - start),
             timePerc = currentTime / duration,
@@ -163,6 +161,7 @@
           context.currentValue = endValue;
           context.completionRate = 1;
           context.durationRate = 1;
+          //  execute callbacks
           onChange(endValue, 1, 1);
           onComplete(endValue, 1, 1);
           removeFromRegistry();

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -106,6 +106,8 @@
       options.onStart && options.onStart();
 
       (function tick(ticktime) {
+        // TODO: move abort call after calculation
+        // and pass (current,valuePerc, timePerc) as arguments
         time = ticktime || +new Date();
         var currentTime = time > finish ? duration : (time - start),
             timePerc = currentTime / duration,
@@ -116,6 +118,9 @@
         }
         if (abort(current, valuePerc, timePerc)) {
           removeFromRegistry();
+          // remove this in 5.0
+          // does to even make sense to abort and run onComplete?
+          onComplete(endValue, 1, 1);
           return;
         }
         if (time > finish) {

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -155,9 +155,6 @@
           return;
         }
         if (abort(current, valuePerc, timePerc)) {
-          // remove this in 5.0
-          // does to even make sense to abort and run onComplete?
-          onComplete(endValue, 1, 1);
           removeFromRegistry();
           return;
         }

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -41,8 +41,6 @@
       options.onStart && options.onStart();
 
       (function tick(ticktime) {
-        // TODO: move abort call after calculation
-        // and pass (current,valuePerc, timePerc) as arguments
         time = ticktime || +new Date();
         var currentTime = time > finish ? duration : (time - start),
             timePerc = currentTime / duration,
@@ -52,9 +50,6 @@
           return;
         }
         if (abort(current, valuePerc, timePerc)) {
-          // remove this in 4.0
-          // does to even make sense to abort and run onComplete?
-          onComplete(endValue, 1, 1);
           return;
         }
         if (time > finish) {

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -1,4 +1,63 @@
-(function() {
+(function () {
+  
+  var extend = fabric.util.object.extend,
+    clone = fabric.util.object.clone;
+  
+  /**
+   * @typedef {Object} AnimationOptions
+   * @property {Function} [options.onChange] Callback; invoked on every value change
+   * @property {Function} [options.onComplete] Callback; invoked when value change is completed
+   * @property {Number} [options.startValue=0] Starting value
+   * @property {Number} [options.endValue=100] Ending value
+   * @property {Number} [options.byValue=100] Value to modify the property by
+   * @property {Function} [options.easing] Easing function
+   * @property {Number} [options.duration=500] Duration of change (in ms)
+   * @property {Function} [options.abort] Additional function with logic. If returns true, animation aborts.
+   * 
+   * @typedef {() => void} CancelFunction
+   * 
+   * @typedef {(AnimationOptions & { cancel: CancelFunction }} AnimationContext
+   */
+
+  /**
+   * Array holding all running animations
+   * @memberof fabric
+   * @type {AnimationContext[]}
+   */
+  var RUNNING_ANIMATIONS = [];
+  fabric.util.object.extend(RUNNING_ANIMATIONS, {
+
+    /**
+     * cancel all running animations
+     */
+    cancelAll: function () {
+      this.forEach(function (animation) {
+        animation.cancel();
+      });
+    },
+    
+    /**
+     * 
+     * @param {CancelFunction} cancelFunc the function returned by animate
+     * @returns {number}
+     */
+    findAnimationIndex: function (cancelFunc) {
+      return this.findIndex(function (animation) {
+        return animation.cancel === cancelFunc;
+      });
+    },
+
+    /**
+     *
+     * @param {CancelFunction} cancelFunc the function returned by animate
+     * @returns {AnimationContext | undefined} animation's options object
+     */
+    findAnimation: function (cancelFunc) {
+      return this.find(function (animation) {
+        return animation.cancel === cancelFunc;
+      });
+    }
+  });
 
   function noop() {
     return false;
@@ -11,22 +70,27 @@
   /**
    * Changes value from one to another within certain period of time, invoking callbacks as value is being changed.
    * @memberOf fabric.util
-   * @param {Object} [options] Animation options
-   * @param {Function} [options.onChange] Callback; invoked on every value change
-   * @param {Function} [options.onComplete] Callback; invoked when value change is completed
-   * @param {Number} [options.startValue=0] Starting value
-   * @param {Number} [options.endValue=100] Ending value
-   * @param {Number} [options.byValue=100] Value to modify the property by
-   * @param {Function} [options.easing] Easing function
-   * @param {Number} [options.duration=500] Duration of change (in ms)
-   * @param {Function} [options.abort] Additional function with logic. If returns true, onComplete is called.
+   * @param {AnimationOptions} [options] Animation options
    * @returns {Function} abort function
    */
   function animate(options) {
-    var cancel = false;
-    requestAnimFrame(function(timestamp) {
-      options || (options = { });
+    options || (options = {});
+    var cancel = false,
+      context,
+      removeFromRegistry = function () {
+        var index = fabric.runningAnimations.indexOf(context);
+        index > -1 && fabric.runningAnimations.splice(index, 1);
+      };
+    
+    context = extend(clone(options), {
+      cancel: function () {
+        cancel = true;
+        removeFromRegistry();
+      }
+    });
+    fabric.runningAnimations.push(context);
 
+    requestAnimFrame(function(timestamp) {
       var start = timestamp || +new Date(),
           duration = options.duration || 500,
           finish = start + duration, time,
@@ -50,11 +114,13 @@
           return;
         }
         if (abort(current, valuePerc, timePerc)) {
+          removeFromRegistry();
           return;
         }
         if (time > finish) {
           onChange(endValue, 1, 1);
           onComplete(endValue, 1, 1);
+          removeFromRegistry();
           return;
         }
         else {
@@ -63,9 +129,8 @@
         }
       })(start);
     });
-    return function() {
-      cancel = true;
-    };
+
+    return context.cancel;
   }
 
   var _requestAnimFrame = fabric.window.requestAnimationFrame       ||
@@ -97,4 +162,5 @@
   fabric.util.animate = animate;
   fabric.util.requestAnimFrame = requestAnimFrame;
   fabric.util.cancelAnimFrame = cancelAnimFrame;
+  fabric.runningAnimations = RUNNING_ANIMATIONS;
 })();

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -111,13 +111,13 @@
         context,
         removeFromRegistry = function () {
           var index = fabric.runningAnimations.indexOf(context);
-          index > -1 && fabric.runningAnimations.splice(index, 1);
+          return index > -1 && fabric.runningAnimations.splice(index, 1)[0];
         };
 
     context = extend(clone(options), {
       cancel: function () {
         cancel = true;
-        removeFromRegistry();
+        return removeFromRegistry();
       },
       currentValue: 'startValue' in options ? options.startValue : 0,
       completionRate: 0,

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -35,6 +35,7 @@
       animations.forEach(function (animation) {
         animation.cancel();
       });
+      return animations;
     },
 
     /**

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -116,10 +116,10 @@
           return;
         }
         if (abort(current, valuePerc, timePerc)) {
-          removeFromRegistry();
           // remove this in 5.0
           // does to even make sense to abort and run onComplete?
           onComplete(endValue, 1, 1);
+          removeFromRegistry();
           return;
         }
         if (time > finish) {

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -1,8 +1,8 @@
 (function () {
-  
+
   var extend = fabric.util.object.extend,
-    clone = fabric.util.object.clone;
-  
+      clone = fabric.util.object.clone;
+
   /**
    * @typedef {Object} AnimationOptions
    * @property {Function} [options.onChange] Callback; invoked on every value change
@@ -13,9 +13,9 @@
    * @property {Function} [options.easing] Easing function
    * @property {Number} [options.duration=500] Duration of change (in ms)
    * @property {Function} [options.abort] Additional function with logic. If returns true, animation aborts.
-   * 
+   *
    * @typedef {() => void} CancelFunction
-   * 
+   *
    * @typedef {(AnimationOptions & { cancel: CancelFunction }} AnimationContext
    */
 
@@ -35,9 +35,9 @@
         animation.cancel();
       });
     },
-    
+
     /**
-     * 
+     *
      * @param {CancelFunction} cancelFunc the function returned by animate
      * @returns {number}
      */
@@ -76,12 +76,12 @@
   function animate(options) {
     options || (options = {});
     var cancel = false,
-      context,
-      removeFromRegistry = function () {
-        var index = fabric.runningAnimations.indexOf(context);
-        index > -1 && fabric.runningAnimations.splice(index, 1);
-      };
-    
+        context,
+        removeFromRegistry = function () {
+          var index = fabric.runningAnimations.indexOf(context);
+          index > -1 && fabric.runningAnimations.splice(index, 1);
+        };
+
     context = extend(clone(options), {
       cancel: function () {
         cancel = true;

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -72,7 +72,7 @@
    * Changes value from one to another within certain period of time, invoking callbacks as value is being changed.
    * @memberOf fabric.util
    * @param {AnimationOptions} [options] Animation options
-   * @returns {CancelFunction} cencel function
+   * @returns {CancelFunction} cancel function
    */
   function animate(options) {
     options || (options = {});

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -71,7 +71,7 @@
    * Changes value from one to another within certain period of time, invoking callbacks as value is being changed.
    * @memberOf fabric.util
    * @param {AnimationOptions} [options] Animation options
-   * @returns {CancelFunction} abort function
+   * @returns {CancelFunction} cencel function
    */
   function animate(options) {
     options || (options = {});

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -31,7 +31,7 @@
      * cancel all running animations
      */
     cancelAll: function () {
-      var animations = this.splice(0, this.length);
+      var animations = this.splice(0);
       animations.forEach(function (animation) {
         animation.cancel();
       });
@@ -43,9 +43,7 @@
      * @returns {number}
      */
     findAnimationIndex: function (cancelFunc) {
-      return this.findIndex(function (animation) {
-        return animation.cancel === cancelFunc;
-      });
+      return this.indexOf(this.findAnimation(cancelFunc));
     },
 
     /**

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -15,7 +15,7 @@
    * @property {Function} [options.abort] Additional function with logic. If returns true, animation aborts.
    *
    * @typedef {() => void} CancelFunction
-   * 
+   *
    * @typedef {Object} AnimationCurrentState
    * @property {number} currentValue value in range [`startValue`, `endValue`]
    * @property {number} completionRate value in range [0, 1]
@@ -119,7 +119,7 @@
         var currentTime = time > finish ? duration : (time - start),
             timePerc = currentTime / duration,
             current = easing(currentTime, startValue, byValue, duration),
-          valuePerc = Math.abs((current - startValue) / byValue);
+            valuePerc = Math.abs((current - startValue) / byValue);
         //  update context
         context.currentValue = current;
         context.completionRate = valuePerc;

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -31,7 +31,7 @@
      * cancel all running animations
      */
     cancelAll: function () {
-      var animations = this.slice();
+      var animations = this.splice(0, this.length);
       animations.forEach(function (animation) {
         animation.cancel();
       });

--- a/src/util/animate_color.js
+++ b/src/util/animate_color.js
@@ -34,6 +34,7 @@
     options = options || {};
 
     return fabric.util.animate(fabric.util.object.extend(options, {
+      target: this,
       duration: duration || 500,
       startValue: startColor,
       endValue: endColor,

--- a/src/util/animate_color.js
+++ b/src/util/animate_color.js
@@ -34,7 +34,6 @@
     options = options || {};
 
     return fabric.util.animate(fabric.util.object.extend(options, {
-      target: this,
       duration: duration || 500,
       startValue: startColor,
       endValue: endColor,

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -119,7 +119,8 @@
     fabric.util.animate(options);
     fabric.util.animate(options);
     assert.equal(fabric.runningAnimations.length, 4, 'should have registered animations');
-    fabric.runningAnimations.cancelAll();
+    var cancelledAnimations = fabric.runningAnimations.cancelAll();
+    assert.equal(cancelledAnimations.length, 4, 'should return cancelled animations');
     assert.equal(fabric.runningAnimations.length, 0, 'should have registered animations');
     //  make sure splice didn't destroy instance
     assert.ok(fabric.runningAnimations instanceof Array);

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -131,8 +131,9 @@
     assert.equal(fabric.runningAnimations.length, 1, 'should have registered animation');
     assert.equal(fabric.runningAnimations.findAnimationIndex(abort), 0, 'animation should exist in registry');
     assert.equal(fabric.runningAnimations.findAnimation(abort).cancel, abort, 'animation should exist in registry');
-    abort();
+    var context = abort();
     assert.equal(fabric.runningAnimations.length, 0, 'should have unregistered animation');
+    assert.equal(context.foo, 'bar', 'should return animation context');
   });
 
   QUnit.test('fabric.runningAnimations cancelAll', function (assert) {

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -121,6 +121,11 @@
     assert.equal(fabric.runningAnimations.length, 4, 'should have registered animations');
     fabric.runningAnimations.cancelAll();
     assert.equal(fabric.runningAnimations.length, 0, 'should have registered animations');
+    //  make sure splice didn't destroy instance
+    assert.ok(fabric.runningAnimations instanceof Array);
+    assert.ok(typeof fabric.runningAnimations.cancelAll === 'function');
+    assert.ok(typeof fabric.runningAnimations.findAnimationIndex === 'function');
+    assert.ok(typeof fabric.runningAnimations.findAnimation === 'function');
   });
 
   QUnit.test('animate', function(assert) {

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -59,8 +59,13 @@
     assert.ok(typeof fabric.runningAnimations.findAnimationIndex === 'function');
     assert.ok(typeof fabric.runningAnimations.findAnimation === 'function');
     assert.equal(fabric.runningAnimations.length, 0, 'should have registered animation');
+    var abort;
     var options = {
-      onChange() {
+      onChange(currentValue, completionRate, durationRate) {
+        var context = fabric.runningAnimations.findAnimation(abort);
+        assert.equal(context.currentValue, currentValue, 'context.currentValue is wrong');
+        assert.equal(context.completionRate, completionRate, 'context.completionRate is wrong');
+        assert.equal(context.durationRate, durationRate, 'context.durationRate is wrong');
         assert.equal(fabric.runningAnimations.findAnimationIndex(abort), 0, 'animation should exist in registry');
       },
       onComplete() {
@@ -70,10 +75,14 @@
         }, 0);
       }
     };
-    var abort = fabric.util.animate(options);
+    abort = fabric.util.animate(options);
+    var context = fabric.runningAnimations.findAnimation(abort);
     assert.equal(fabric.runningAnimations.length, 1, 'should have registered animation');
     assert.equal(fabric.runningAnimations.findAnimationIndex(abort), 0, 'animation should exist in registry');
-    assert.equal(fabric.runningAnimations.findAnimation(abort).cancel, abort, 'animation should exist in registry');
+    assert.equal(context.cancel, abort, 'animation should exist in registry');
+    assert.equal(context.currentValue, 0, 'context.currentValue is wrong');
+    assert.equal(context.completionRate, 0, 'context.completionRate is wrong');
+    assert.equal(context.durationRate, 0, 'context.durationRate is wrong');
   });
 
   QUnit.test('fabric.runningAnimations with abort', function (assert) {

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -112,6 +112,17 @@
     assert.equal(fabric.runningAnimations.length, 0, 'should have unregistered animation');
   });
 
+  QUnit.test('fabric.runningAnimations cancelAll', function (assert) {
+    var options = { foo: 'bar' };
+    fabric.util.animate(options);
+    fabric.util.animate(options);
+    fabric.util.animate(options);
+    fabric.util.animate(options);
+    assert.equal(fabric.runningAnimations.length, 4, 'should have registered animations');
+    fabric.runningAnimations.cancelAll();
+    assert.equal(fabric.runningAnimations.length, 0, 'should have registered animations');
+  });
+
   QUnit.test('animate', function(assert) {
     var done = assert.async();
     var object = new fabric.Object({ left: 20, top: 30, width: 40, height: 50, angle: 43 });

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1275,7 +1275,7 @@
     assert.ok(typeof canvas.centerObjectH === 'function');
     var rect = makeRect({ left: 102, top: 202 });
     canvas.add(rect);
-    assert.equal(canvas.centerObjectH(rect), canvas, 'should be chainable');
+    canvas.centerObjectH(rect);
     assert.equal(rect.getCenterPoint().x, upperCanvasEl.width / 2, 'object\'s "left" property should correspond to canvas element\'s center');
   });
 
@@ -1283,7 +1283,7 @@
     assert.ok(typeof canvas.centerObjectV === 'function');
     var rect = makeRect({ left: 102, top: 202 });
     canvas.add(rect);
-    assert.equal(canvas.centerObjectV(rect), canvas, 'should be chainable');
+    canvas.centerObjectV(rect);
     assert.equal(rect.getCenterPoint().y, upperCanvasEl.height / 2, 'object\'s "top" property should correspond to canvas element\'s center');
   });
 
@@ -1291,7 +1291,7 @@
     assert.ok(typeof canvas.centerObject === 'function');
     var rect = makeRect({ left: 102, top: 202 });
     canvas.add(rect);
-    assert.equal(canvas.centerObject(rect), canvas, 'should be chainable');
+    canvas.centerObject(rect);
 
     assert.equal(rect.getCenterPoint().y, upperCanvasEl.height / 2, 'object\'s "top" property should correspond to canvas element\'s center');
     assert.equal(rect.getCenterPoint().x, upperCanvasEl.width / 2, 'object\'s "left" property should correspond to canvas element\'s center');
@@ -1301,7 +1301,7 @@
     assert.ok(typeof canvas.straightenObject === 'function');
     var rect = makeRect({ angle: 10 });
     canvas.add(rect);
-    assert.equal(canvas.straightenObject(rect), canvas, 'should be chainable');
+    canvas.straightenObject(rect);
     assert.equal(rect.get('angle'), 0, 'angle should be coerced to 0 (from 10)');
 
     rect.rotate('60');
@@ -2343,7 +2343,7 @@
     }
 
     assert.equal(canvas.item(0), rect);
-    assert.equal(canvas.fxRemove(rect, { onComplete: onComplete }), canvas, 'should be chainable');
+    assert.ok(typeof canvas.fxRemove(rect, { onComplete: onComplete }) === 'function', 'should return animation abort function');
 
     setTimeout(function() {
       assert.equal(canvas.item(0), undefined);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -2057,8 +2057,11 @@
     assert.notEqual(parentEl.firstChild, canvas.getElement(), 'canvas should not be parent div firstChild');
     assert.ok(typeof canvas.dispose === 'function');
     canvas.add(makeRect(), makeRect(), makeRect());
+    canvas.item(0).animate('scaleX', 10);
+    assert.equal(fabric.runningAnimations.length, 1, 'should have a running animation');
     canvas.dispose();
     canvas.cancelRequestedRender();
+    assert.equal(fabric.runningAnimations.length, 0, 'dispose should clear running animations');
     assert.equal(canvas.getObjects().length, 0, 'dispose should clear canvas');
     assert.equal(parentEl.childNodes.length, 1, 'parent has always 1 child');
     if (!fabric.isLikelyNode) {

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -657,7 +657,7 @@
     assert.ok(typeof canvas.centerObjectH === 'function');
     var rect = makeRect({ left: 102, top: 202 });
     canvas.add(rect);
-    assert.equal(canvas.centerObjectH(rect), canvas, 'should be chainable');
+    canvas.centerObjectH(rect);
     assert.equal(rect.getCenterPoint().x, canvas.width / 2, 'object\'s "center.y" property should correspond to canvas element\'s center');
     canvas.setZoom(4);
     assert.equal(rect.getCenterPoint().x, canvas.height / 2, 'object\'s "center.x" property should correspond to canvas element\'s center when canvas is transformed');
@@ -668,7 +668,7 @@
     assert.ok(typeof canvas.centerObjectV === 'function');
     var rect = makeRect({ left: 102, top: 202 });
     canvas.add(rect);
-    assert.equal(canvas.centerObjectV(rect), canvas, 'should be chainable');
+    canvas.centerObjectV(rect);
     assert.equal(rect.getCenterPoint().y, canvas.height / 2, 'object\'s "center.y" property should correspond to canvas element\'s center');
     canvas.setZoom(2);
     assert.equal(rect.getCenterPoint().y, canvas.height / 2, 'object\'s "center.y" property should correspond to canvas element\'s center when canvas is transformed');
@@ -679,7 +679,7 @@
     assert.ok(typeof canvas.centerObject === 'function');
     var rect = makeRect({ left: 102, top: 202 });
     canvas.add(rect);
-    assert.equal(canvas.centerObject(rect), canvas, 'should be chainable');
+    canvas.centerObject(rect);
 
     assert.equal(rect.getCenterPoint().y, canvas.height / 2, 'object\'s "center.y" property should correspond to canvas element\'s center');
     assert.equal(rect.getCenterPoint().x, canvas.height / 2, 'object\'s "center.x" property should correspond to canvas element\'s center');
@@ -695,7 +695,7 @@
     canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
     canvas.add(rect);
     var oldY = rect.top;
-    assert.equal(canvas.viewportCenterObjectH(rect), canvas, 'should be chainable');
+    canvas.viewportCenterObjectH(rect);
     assert.equal(rect.getCenterPoint().x, canvas.width / 2, 'object\'s "center.x" property should correspond to canvas element\'s center when canvas is not transformed');
     assert.equal(rect.top, oldY, 'object\'s "top" should not change');
     canvas.setZoom(2);
@@ -714,7 +714,7 @@
     canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
     canvas.add(rect);
     var oldX = rect.left;
-    assert.equal(canvas.viewportCenterObjectV(rect), canvas, 'should be chainable');
+    canvas.viewportCenterObjectV(rect);
     assert.equal(rect.getCenterPoint().y, canvas.height / 2, 'object\'s "center.y" property should correspond to canvas element\'s center when canvas is not transformed');
     assert.equal(rect.left, oldX, 'x position did not change');
     canvas.setZoom(2);
@@ -732,7 +732,7 @@
     var rect = makeRect({ left: 102, top: 202 }), pan = 10;
     canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
     canvas.add(rect);
-    assert.equal(canvas.viewportCenterObject(rect), canvas, 'should be chainable');
+    canvas.viewportCenterObject(rect);
     assert.equal(rect.getCenterPoint().y, canvas.height / 2, 'object\'s "center.y" property should correspond to canvas element\'s center when canvas is not transformed');
     assert.equal(rect.getCenterPoint().x, canvas.width / 2, 'object\'s "center.x" property should correspond to canvas element\'s center when canvas is not transformed');
 
@@ -752,7 +752,7 @@
     assert.ok(typeof canvas.straightenObject === 'function');
     var rect = makeRect({ angle: 10 });
     canvas.add(rect);
-    assert.equal(canvas.straightenObject(rect), canvas, 'should be chainable');
+    canvas.straightenObject(rect);
     assert.equal(rect.get('angle'), 0, 'angle should be coerced to 0 (from 10)');
 
     rect.rotate('60');
@@ -1627,7 +1627,7 @@
     }
 
     assert.ok(canvas.item(0) === rect);
-    assert.equal(canvas.fxRemove(rect, { onComplete: onComplete }), canvas, 'should be chainable');
+    assert.ok(typeof canvas.fxRemove(rect, { onComplete: onComplete }) === 'function', 'should return animation abort function');
   });
 
   QUnit.test('options in setBackgroundImage from URL', function(assert) {

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -569,13 +569,13 @@
 
     var callbacks = { onComplete: onComplete, onChange: onChange };
     assert.ok(typeof object.fxStraighten === 'function');
-    assert.equal(object.fxStraighten(callbacks), object, 'should be chainable');
+    assert.ok(typeof object.fxStraighten(callbacks) === 'function', 'should return animation abort function');
     assert.equal(fabric.util.toFixed(object.get('angle'), 0), 43);
     setTimeout(function(){
       assert.ok(onCompleteFired);
       assert.ok(onChangeFired);
       assert.equal(object.get('angle'), 0, 'angle should be set to 0 by the end of animation');
-      assert.equal(object.fxStraighten(), object, 'should work without callbacks');
+      assert.ok(typeof object.fxStraighten() === 'function', 'should work without callbacks');
       done();
     }, 1000);
   });

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -1209,8 +1209,8 @@
     var object = new fabric.Object({ fill: 'blue', width: 100, height: 100 });
     assert.ok(typeof object.dispose === 'function');
     object.animate('fill', 'red');
-    assert.equal(fabric.runningAnimations.length, 1, 'runningAnimations should be include he animation');
+    assert.equal(fabric.runningAnimations.findAnimationsByTarget(object).length, 1, 'runningAnimations should include the animation');
     object.dispose();
-    assert.equal(fabric.runningAnimations.length, 0, 'runningAnimations should be empty after dispose');
+    assert.equal(fabric.runningAnimations.findAnimationsByTarget(object).length, 0, 'runningAnimations should be empty after dispose');
   });
 })();

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -1205,4 +1205,12 @@
     object.fill = 'transparent';
     assert.equal(object.hasFill(), false, 'with a color that is transparent, hasFill is true');
   });
+  QUnit.test('dispose', function (assert) {
+    var object = new fabric.Object({ fill: 'blue', width: 100, height: 100 });
+    assert.ok(typeof object.dispose === 'function');
+    object.animate('fill', 'red');
+    assert.equal(fabric.runningAnimations.length, 1, 'runningAnimations should be include he animation');
+    object.dispose();
+    assert.equal(fabric.runningAnimations.length, 0, 'runningAnimations should be empty after dispose');
+  });
 })();


### PR DESCRIPTION
### Motivation
1. There's a need to cleanup animations in applications.
Currently the dev needs to implement something by themselves.
For example in react while developing when react does a hot reload or whatever and fabric is animating an error raises because the canvas is trying to access the context which react just disposed.
2. Another use case I can think of is with erasing. It makes sense to iterate over all animations before erasing starts to make the objects non erasable. (I wanted this to be default behavior but lacked the mechanism to do so)
In general, knowing what is animating is crucial information for good UX/UI. 

I think this should be handled by fabric.

### gist
Exposed `fabric.runningAnimations` (is this a good name? is fabric the right level to hold this ref?
It is an array containing the options object passed to `animate` and the `cancel` function. This means that it can contain additional context if such is passed to animate allowing the dev freedom. 
Exposed the following methods: `cancelAll`, finders
For example we could pass the object/canvas as context, this will make it very simple to cancel relevant animations.


IMO It makes sense that an object holds a ref to all it's running animations and that it's `dispose` method should cancel them. 
What do you think?