### PR TITLE
Prevent dividing by 0 in for touch gestures

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -1368,7 +1368,11 @@ root.gesture = function(conf) {
 			var dx = touch.move.x - self.x;
 			var dy = touch.move.y - self.y;
 			var distance = Math.sqrt(dx * dx + dy * dy);
-			scale += distance / start.distance;
+      // If touch start.distance from centroid is 0, scale should not be updated. 
+      // This prevents dividing by 0 in cases where start.distance is oddly 0.
+      if (start.distance !== 0) {
+        scale += distance / start.distance;
+      }
 			// Calculate rotation.
 			var angle = Math.atan2(dx, dy) / RAD_DEG;
 			var rotate = (start.angle - angle + 360) % 360 - 180;

--- a/lib/event.js
+++ b/lib/event.js
@@ -1370,9 +1370,9 @@ root.gesture = function(conf) {
 			var distance = Math.sqrt(dx * dx + dy * dy);
       // If touch start.distance from centroid is 0, scale should not be updated. 
       // This prevents dividing by 0 in cases where start.distance is oddly 0.
-      if (start.distance !== 0) {
-        scale += distance / start.distance;
-      }
+			if (start.distance !== 0) {
+			  scale += distance / start.distance;
+			}
 			// Calculate rotation.
 			var angle = Math.atan2(dx, dy) / RAD_DEG;
 			var rotate = (start.angle - angle + 360) % 360 - 180;

--- a/lib/event.js
+++ b/lib/event.js
@@ -1368,8 +1368,8 @@ root.gesture = function(conf) {
 			var dx = touch.move.x - self.x;
 			var dy = touch.move.y - self.y;
 			var distance = Math.sqrt(dx * dx + dy * dy);
-      // If touch start.distance from centroid is 0, scale should not be updated. 
-      // This prevents dividing by 0 in cases where start.distance is oddly 0.
+			// If touch start.distance from centroid is 0, scale should not be updated. 
+			// This prevents dividing by 0 in cases where start.distance is oddly 0.
 			if (start.distance !== 0) {
 			  scale += distance / start.distance;
 			}


### PR DESCRIPTION
In scenarios where the distance resolves to 0 as not moved from the same point. 

`start.x - self.x, start.y - self.y` where start and self are the same numbers will make distance 0. 

`start.distance = Math.sqrt(0 * 0 + 0 * 0)`