### PR TITLE
feat(animation): Support a list of animation values

### DIFF
--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -6,6 +6,15 @@
   /**
    * @typedef {Object} AnimationOptions
    * Animation of a value or list of values.
+   * When using lists, think of something like this:
+   * fabric.util.animate({
+   *   startValue: [1, 2, 3],
+   *   endValue: [2, 4, 6],
+   *   onChange: function([a, b, c]) {
+   *     canvas.zoomToPoint({x: b, y: c}, a)
+   *     canvas.renderAll()
+   *   }
+   * });
    * @example
    * @property {Function} [onChange] Callback; invoked on every value change
    * @property {Function} [onComplete] Callback; invoked when value change is completed

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -153,8 +153,8 @@
           onComplete = options.onComplete || noop,
           easing = options.easing || defaultEasing,
           isMany = 'startValue' in options ? options.startValue.length > 0 : false,
-          startValue = 'startValue' in options ? (isMany ? options.startValue : options.startValue) : 0,
-          endValue = 'endValue' in options ? (isMany ? options.endValue.slice() : options.endValue) : 100,
+          startValue = 'startValue' in options ? options.startValue : 0,
+          endValue = 'endValue' in options ? options.endValue : 100,
           byValue = options.byValue || (isMany ? startValue.map(function(value, i) {
             return endValue[i] - startValue[i];
           }) : endValue - startValue);
@@ -188,7 +188,7 @@
           context.durationRate = 1;
           //  execute callbacks
           onChange(isMany ? endValue.slice() : endValue, 1, 1);
-          onComplete(isMany ? endValue.slice() : endValue, 1, 1);
+          onComplete(endValue, 1, 1);
           removeFromRegistry();
           return;
         }

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -170,7 +170,6 @@
             }) : easing(currentTime, startValue, byValue, duration),
             valuePerc = isMany ? Math.abs((current[0] - startValue[0]) / byValue[0])
               : Math.abs((current - startValue) / byValue);
-        console.log('current', current);
         //  update context
         context.currentValue = current;
         context.completionRate = valuePerc;

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -152,9 +152,9 @@
           abort = options.abort || noop,
           onComplete = options.onComplete || noop,
           easing = options.easing || defaultEasing,
-          startValue = 'startValue' in options ? options.startValue : 0,
-          endValue = 'endValue' in options ? options.endValue : 100,
-          isMany = 'startValue' in options ? startValue.length > 0 : false,
+          isMany = 'startValue' in options ? options.startValue.length > 0 : false,
+          startValue = 'startValue' in options ? (isMany ? options.startValue : options.startValue) : 0,
+          endValue = 'endValue' in options ? (isMany ? options.endValue.slice() : options.endValue) : 100,
           byValue = options.byValue || (isMany ? startValue.map(function(value, i) {
             return endValue[i] - startValue[i];
           }) : endValue - startValue);
@@ -171,29 +171,29 @@
             valuePerc = isMany ? Math.abs((current[0] - startValue[0]) / byValue[0])
               : Math.abs((current - startValue) / byValue);
         //  update context
-        context.currentValue = current;
+        context.currentValue = isMany ? current.slice() : current;
         context.completionRate = valuePerc;
         context.durationRate = timePerc;
         if (cancel) {
           return;
         }
-        if (abort(current, valuePerc, timePerc)) {
+        if (abort(isMany ? current.slice() : current, valuePerc, timePerc)) {
           removeFromRegistry();
           return;
         }
         if (time > finish) {
           //  update context
-          context.currentValue = endValue;
+          context.currentValue = isMany ? endValue.slice() : endValue;
           context.completionRate = 1;
           context.durationRate = 1;
           //  execute callbacks
-          onChange(endValue, 1, 1);
-          onComplete(endValue, 1, 1);
+          onChange(isMany ? endValue.slice() : endValue, 1, 1);
+          onComplete(isMany ? endValue.slice() : endValue, 1, 1);
           removeFromRegistry();
           return;
         }
         else {
-          onChange(current, valuePerc, timePerc);
+          onChange(isMany ? current.slice() : current, valuePerc, timePerc);
           requestAnimFrame(tick);
         }
       })(start);

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -5,14 +5,20 @@
 
   /**
    * @typedef {Object} AnimationOptions
-   * @property {Function} [options.onChange] Callback; invoked on every value change
-   * @property {Function} [options.onComplete] Callback; invoked when value change is completed
-   * @property {number | number[]} [options.startValue=0] Starting value
-   * @property {number | number[]} [options.endValue=100] Ending value
-   * @property {number | number[]} [options.byValue=100] Value to modify the property by
-   * @property {Function} [options.easing] Easing function
-   * @property {Number} [options.duration=500] Duration of change (in ms)
-   * @property {Function} [options.abort] Additional function with logic. If returns true, animation aborts.
+   * Animation of a value or list of values.
+   * @example
+   * @property {Function} [onChange] Callback; invoked on every value change
+   * @property {Function} [onComplete] Callback; invoked when value change is completed
+   * @example
+   * // Note: startValue, endValue, and byValue must match the type
+   * var animationOptions = { startValue: 0, endValue: 1, byValue: 0.25 }
+   * var animationOptions = { startValue: [0, 1], endValue: [1, 2], byValue: [0.25, 0.25] }
+   * @property {number | number[]} [startValue=0] Starting value
+   * @property {number | number[]} [endValue=100] Ending value
+   * @property {number | number[]} [byValue=100] Value to modify the property by
+   * @property {Function} [easing] Easing function
+   * @property {Number} [duration=500] Duration of change (in ms)
+   * @property {Function} [abort] Additional function with logic. If returns true, animation aborts.
    *
    * @typedef {() => void} CancelFunction
    *
@@ -122,6 +128,10 @@
    * Changes value from one to another within certain period of time, invoking callbacks as value is being changed.
    * @memberOf fabric.util
    * @param {AnimationOptions} [options] Animation options
+   * @example
+   * // Note: startValue, endValue, and byValue must match the type
+   * fabric.util.animate({ startValue: 0, endValue: 1, byValue: 0.25 })
+   * fabric.util.animate({ startValue: [0, 1], endValue: [1, 2], byValue: [0.25, 0.25] })
    * @returns {CancelFunction} cancel function
    */
   function animate(options) {

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -187,9 +187,8 @@
           context.completionRate = 1;
           context.durationRate = 1;
           //  execute callbacks
-          var end = isMany ? endValue.slice() : endValue;
-          onChange(end, 1, 1);
-          onComplete(end, 1, 1);
+          onChange(isMany ? endValue.slice() : endValue, 1, 1);
+          onComplete(isMany ? endValue.slice() : endValue, 1, 1);
           removeFromRegistry();
           return;
         }

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -154,7 +154,10 @@
           easing = options.easing || defaultEasing,
           startValue = 'startValue' in options ? options.startValue : 0,
           endValue = 'endValue' in options ? options.endValue : 100,
-          byValue = options.byValue || endValue - startValue;
+          isMany = 'startValue' in options ? startValue.length > 0 : false,
+          byValue = options.byValue || (isMany ? startValue.map(function(value, i) {
+            return endValue[i] - startValue[i];
+          }) : endValue - startValue);
 
       options.onStart && options.onStart();
 
@@ -162,8 +165,12 @@
         time = ticktime || +new Date();
         var currentTime = time > finish ? duration : (time - start),
             timePerc = currentTime / duration,
-            current = easing(currentTime, startValue, byValue, duration),
-            valuePerc = Math.abs((current - startValue) / byValue);
+            current = isMany ? startValue.map(function(_value, i) {
+              return easing(currentTime, startValue[i], byValue[i], duration);
+            }) : easing(currentTime, startValue, byValue, duration),
+            valuePerc = isMany ? Math.abs((current[0] - startValue[0]) / byValue[0])
+              : Math.abs((current - startValue) / byValue);
+        console.log('current', current);
         //  update context
         context.currentValue = current;
         context.completionRate = valuePerc;

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -7,9 +7,9 @@
    * @typedef {Object} AnimationOptions
    * @property {Function} [options.onChange] Callback; invoked on every value change
    * @property {Function} [options.onComplete] Callback; invoked when value change is completed
-   * @property {Number} [options.startValue=0] Starting value
-   * @property {Number} [options.endValue=100] Ending value
-   * @property {Number} [options.byValue=100] Value to modify the property by
+   * @property {number | number[]} [options.startValue=0] Starting value
+   * @property {number | number[]} [options.endValue=100] Ending value
+   * @property {number | number[]} [options.byValue=100] Value to modify the property by
    * @property {Function} [options.easing] Easing function
    * @property {Number} [options.duration=500] Duration of change (in ms)
    * @property {Function} [options.abort] Additional function with logic. If returns true, animation aborts.
@@ -17,7 +17,7 @@
    * @typedef {() => void} CancelFunction
    *
    * @typedef {Object} AnimationCurrentState
-   * @property {number} currentValue value in range [`startValue`, `endValue`]
+   * @property {number | number[]} currentValue value in range [`startValue`, `endValue`]
    * @property {number} completionRate value in range [0, 1]
    * @property {number} durationRate value in range [0, 1]
    *
@@ -177,7 +177,7 @@
         if (cancel) {
           return;
         }
-        if (abort(isMany ? current.slice() : current, valuePerc, timePerc)) {
+        if (abort(current, valuePerc, timePerc)) {
           removeFromRegistry();
           return;
         }
@@ -187,13 +187,14 @@
           context.completionRate = 1;
           context.durationRate = 1;
           //  execute callbacks
-          onChange(isMany ? endValue.slice() : endValue, 1, 1);
-          onComplete(isMany ? endValue.slice() : endValue, 1, 1);
+          var end = isMany ? endValue.slice() : endValue;
+          onChange(end, 1, 1);
+          onComplete(end, 1, 1);
           removeFromRegistry();
           return;
         }
         else {
-          onChange(isMany ? current.slice() : current, valuePerc, timePerc);
+          onChange(current, valuePerc, timePerc);
           requestAnimFrame(tick);
         }
       })(start);

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -334,6 +334,7 @@
 
   QUnit.test('animate with list of values', function(assert) {
     var done = assert.async();
+    assert.expect(38)
 
     fabric.util.animate({
       startValue: [1, 2, 3],
@@ -341,10 +342,15 @@
       onValue: [1, 1, 1],
       duration: 96,
       onChange: function(currentValue) {
+        assert.equal(fabric.runningAnimations.length, 1, 'runningAnimations should not be empty');
         assert.equal(currentValue.length, 3)
+        currentValue.forEach(function(v) {
+          assert.ok(v > 0, 'confirm values are not invalid numbers')
+        })
       },
       onComplete: function(endValue) {
         assert.equal(endValue.length, 3)
+        assert.deepEqual(endValue, [2, 4, 6])
         done()
       }
     })

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -339,7 +339,7 @@
     fabric.util.animate({
       startValue: [1, 2, 3],
       endValue: [2, 4, 6],
-      onValue: [1, 1, 1],
+      byValue: [1, 2, 3],
       duration: 96,
       onChange: function(currentValue) {
         assert.equal(fabric.runningAnimations.length, 1, 'runningAnimations should not be empty');
@@ -349,7 +349,7 @@
           assert.ok(v > 0, 'confirm values are not invalid numbers');
         })
         // Make sure mutations are not kept
-        assert.ok(currentValue[0] <= 2, `mutating callback values must not persist ${currentValue[0]}`);
+        assert.ok(currentValue[0] <= 2, 'mutating callback values must not persist');
         currentValue[0] = 200;
       },
       onComplete: function(endValue) {

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -334,7 +334,7 @@
 
   QUnit.test('animate with list of values', function(assert) {
     var done = assert.async();
-    assert.expect(38)
+    assert.expect(52)
 
     fabric.util.animate({
       startValue: [1, 2, 3],
@@ -343,15 +343,19 @@
       duration: 96,
       onChange: function(currentValue) {
         assert.equal(fabric.runningAnimations.length, 1, 'runningAnimations should not be empty');
-        assert.equal(currentValue.length, 3)
+        assert.deepEqual(fabric.runningAnimations[0]['currentValue'], currentValue)
+        assert.equal(currentValue.length, 3);
         currentValue.forEach(function(v) {
-          assert.ok(v > 0, 'confirm values are not invalid numbers')
+          assert.ok(v > 0, 'confirm values are not invalid numbers');
         })
+        // Make sure mutations are not kept
+        assert.ok(currentValue[0] <= 2, `mutating callback values must not persist ${currentValue[0]}`);
+        currentValue[0] = 200;
       },
       onComplete: function(endValue) {
-        assert.equal(endValue.length, 3)
-        assert.deepEqual(endValue, [2, 4, 6])
-        done()
+        assert.equal(endValue.length, 3);
+        assert.deepEqual(endValue, [2, 4, 6]);
+        done();
       }
     })
   });

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -332,6 +332,24 @@
     }, 1000);
   });
 
+  QUnit.test('animate with list of values', function(assert) {
+    var done = assert.async();
+
+    fabric.util.animate({
+      startValue: [1, 2, 3],
+      endValue: [2, 4, 6],
+      onValue: [1, 1, 1],
+      duration: 96,
+      onChange: function(currentValue) {
+        assert.equal(currentValue.length, 3)
+      },
+      onComplete: function(endValue) {
+        assert.equal(endValue.length, 3)
+        done()
+      }
+    })
+  });
+
   QUnit.test('animate with abort', function(assert) {
     var done = assert.async();
     var object = new fabric.Object({ left: 123, top: 124 });


### PR DESCRIPTION
Allow lists of values to be supported in animate. 

```js
fabric.util.animate({
  startValue: [1, 2, 3],
  endValue: [2, 4, 6],
  onChange: function([a, b, c]) {
    canvas.zoomToPoint({x: b, y: c}, a)
    canvas.renderAll()
  }
});
```

Updated types to infer and allow the type to be passed (to allow `number | number []`)

```ts
interface IUtilAnimationOptions<T> {
	/**
	 * Starting value
	 */
	startValue?: T;
	/**
	 * Ending value
	 */
	endValue?: T;
	/**
	 * Value to modify the property by
	 */
	byValue?: T;
	/**
	 * Duration of change (in ms)
	 */
	duration?: number;
	/**
	 * Callback; invoked on every value change
	 */
	onChange?: (currentValue: T, finished: number, timePercentage: number) => void;
	/**
	 * Callback; invoked when value change is completed
	 */
	onComplete?: (endValue: T, finished: number, timePercentage: number) => void;
	/**
	 * Easing function
	 */
	easing?: Function;
}
interface IUtilAnimation {
	/**
	 * Changes value from one to another within certain period of time, invoking callbacks as value is being changed.
	 * @param [options] Animation options
	 */
	animate<T>(options?: IUtilAnimationOptions<T>): void;
}
```