### PR TITLE
fix(tests): windows paths

### DIFF
--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -35,25 +35,23 @@ QUnit.config.testTimeout = 15000;
 QUnit.config.noglobals = true;
 QUnit.config.hidePassed = true;
 
-QUnit.addAssertions = function () {
-  /**
+/**
  * 
  * @param {*} actual 
  * @param {*} [expected]
  */
-  QUnit.assert.sameImageObject = function (actual, expected) {
-    var a = {}, b = {};
-    expected = expected || REFERENCE_IMG_OBJECT;
-    Object.assign(a, actual, { src: path.basename(actual.src) });
-    Object.assign(b, expected, { src: path.basename(expected.src) });
-    QUnit.equiv(a, b, 'image object not equal');
-    this.pushResult({
-      result: QUnit.equiv(a, b),
-      actual: actual,
-      expected: expected,
-      message: 'image object equal to ref'
-    })
-  }
+QUnit.assert.sameImageObject = function (actual, expected) {
+  var a = {}, b = {};
+  expected = expected || REFERENCE_IMG_OBJECT;
+  Object.assign(a, actual, { src: path.basename(actual.src) });
+  Object.assign(b, expected, { src: path.basename(expected.src) });
+  QUnit.equiv(a, b, 'image object not equal');
+  this.pushResult({
+    result: QUnit.equiv(a, b),
+    actual: actual,
+    expected: expected,
+    message: 'image object equal to ref'
+  })
 }
 
 QUnit.addAssertions();

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -45,7 +45,6 @@ QUnit.assert.sameImageObject = function (actual, expected) {
   expected = expected || REFERENCE_IMG_OBJECT;
   Object.assign(a, actual, { src: path.basename(actual.src) });
   Object.assign(b, expected, { src: path.basename(expected.src) });
-  QUnit.equiv(a, b, 'image object not equal');
   this.pushResult({
     result: QUnit.equiv(a, b),
     actual: actual,

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -1,5 +1,6 @@
 // set the fabric framework as a global for tests
 var chalk = require('chalk');
+var path = require('path');
 global.fabric = require('../dist/fabric').fabric;
 global.pixelmatch = require('pixelmatch');
 global.fs = require('fs');
@@ -32,6 +33,25 @@ global.imageDataToChalk = function(imageData) {
 QUnit.config.testTimeout = 15000;
 QUnit.config.noglobals = true;
 QUnit.config.hidePassed = true;
+
+/**
+ * 
+ * @param {*} actual 
+ * @param {*} [expected]
+ */
+QUnit.assert.sameImageObject = function (actual, expected) {
+  var a = {}, b = {};
+  expected = expected || REFERENCE_IMG_OBJECT;
+  Object.assign(a, actual, { src: path.basename(actual.src) });
+  Object.assign(b, expected, { src: path.basename(expected.src) });
+  QUnit.equiv(a, b, 'image object not equal');
+  this.pushResult({
+    result: QUnit.equiv(a, b),
+    actual: actual,
+    expected: expected,
+    message: 'image object equal to ref'
+  })
+}
 
 var jsdom = require('jsdom');
 

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -4,6 +4,7 @@ var path = require('path');
 global.fabric = require('../dist/fabric').fabric;
 global.pixelmatch = require('pixelmatch');
 global.fs = require('fs');
+global.path = path;
 global.visualCallback = {
   addArguments: function() {},
 };

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -35,26 +35,6 @@ QUnit.config.testTimeout = 15000;
 QUnit.config.noglobals = true;
 QUnit.config.hidePassed = true;
 
-/**
- * 
- * @param {*} actual 
- * @param {*} [expected]
- */
-QUnit.assert.sameImageObject = function (actual, expected) {
-  var a = {}, b = {};
-  expected = expected || REFERENCE_IMG_OBJECT;
-  Object.assign(a, actual, { src: path.basename(actual.src) });
-  Object.assign(b, expected, { src: path.basename(expected.src) });
-  this.pushResult({
-    result: QUnit.equiv(a, b),
-    actual: actual,
-    expected: expected,
-    message: 'image object equal to ref'
-  })
-}
-
-QUnit.addAssertions();
-
 var jsdom = require('jsdom');
 
 // make a jsdom version for tests that does not spam too much.

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -4,7 +4,6 @@ var path = require('path');
 global.fabric = require('../dist/fabric').fabric;
 global.pixelmatch = require('pixelmatch');
 global.fs = require('fs');
-global.path = path;
 global.visualCallback = {
   addArguments: function() {},
 };

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -1,6 +1,5 @@
 // set the fabric framework as a global for tests
 var chalk = require('chalk');
-var path = require('path');
 global.fabric = require('../dist/fabric').fabric;
 global.pixelmatch = require('pixelmatch');
 global.fs = require('fs');

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -35,24 +35,28 @@ QUnit.config.testTimeout = 15000;
 QUnit.config.noglobals = true;
 QUnit.config.hidePassed = true;
 
-/**
+QUnit.addAssertions = function () {
+  /**
  * 
  * @param {*} actual 
  * @param {*} [expected]
  */
-QUnit.assert.sameImageObject = function (actual, expected) {
-  var a = {}, b = {};
-  expected = expected || REFERENCE_IMG_OBJECT;
-  Object.assign(a, actual, { src: path.basename(actual.src) });
-  Object.assign(b, expected, { src: path.basename(expected.src) });
-  QUnit.equiv(a, b, 'image object not equal');
-  this.pushResult({
-    result: QUnit.equiv(a, b),
-    actual: actual,
-    expected: expected,
-    message: 'image object equal to ref'
-  })
+  QUnit.assert.sameImageObject = function (actual, expected) {
+    var a = {}, b = {};
+    expected = expected || REFERENCE_IMG_OBJECT;
+    Object.assign(a, actual, { src: path.basename(actual.src) });
+    Object.assign(b, expected, { src: path.basename(expected.src) });
+    QUnit.equiv(a, b, 'image object not equal');
+    this.pushResult({
+      result: QUnit.equiv(a, b),
+      actual: actual,
+      expected: expected,
+      message: 'image object equal to ref'
+    })
+  }
 }
+
+QUnit.addAssertions();
 
 var jsdom = require('jsdom');
 

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -94,7 +94,24 @@
     return new fabric.Triangle(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
-  QUnit.addAssertions();
+  /**
+   * 
+   * @param {*} actual 
+   * @param {*} [expected]
+   */
+  QUnit.assert.sameImageObject = function (actual, expected) {
+    var a = {}, b = {};
+    expected = expected || REFERENCE_IMG_OBJECT;
+    Object.assign(a, actual, { src: path.basename(actual.src) });
+    Object.assign(b, expected, { src: path.basename(expected.src) });
+    QUnit.equiv(a, b, 'image object not equal');
+    this.pushResult({
+      result: QUnit.equiv(a, b),
+      actual: actual,
+      expected: expected,
+      message: 'image object equal to ref'
+    })
+  }
 
   QUnit.module('fabric.Canvas', {
     beforeEach: function() {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -94,6 +94,8 @@
     return new fabric.Triangle(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
+  QUnit.addAssertions();
+
   QUnit.module('fabric.Canvas', {
     beforeEach: function() {
       upperCanvasEl.style.display = '';

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -78,8 +78,12 @@
     return src;
   }
 
-  var IMG_SRC = fabric.isLikelyNode ? ('file://' + __dirname + '/../fixtures/test_image.gif') : getAbsolutePath('../fixtures/test_image.gif');
+  var path = require('path');
 
+  var IMG_SRC = fabric.isLikelyNode ?
+    ('file://' + path.normalize(path.join(__dirname + '/../fixtures/test_image.gif'))) :
+    path.normalize(getAbsolutePath('../fixtures/test_image.gif'));
+  
   var canvas = this.canvas = new fabric.Canvas(null, {enableRetinaScaling: false, width: 600, height: 600});
   var upperCanvasEl = canvas.upperCanvasEl;
   var lowerCanvasEl = canvas.lowerCanvasEl;
@@ -1658,9 +1662,11 @@
 
   QUnit.test('loadFromJSON with custom properties on Canvas with image', function(assert) {
     var done = assert.async();
-    var JSON_STRING = '{"objects":[{"type":"image","originX":"left","originY":"top","left":13.6,"top":-1.4,"width":3000,"height":3351,"fill":"rgb(0,0,0)","stroke":null,"strokeWidth":0,"strokeDashArray":null,"strokeLineCap":"butt","strokeDashOffset":0,"strokeLineJoin":"miter","strokeMiterLimit":4,"scaleX":0.05,"scaleY":0.05,"angle":0,"flipX":false,"flipY":false,"opacity":1,"shadow":null,"visible":true,"backgroundColor":"","fillRule":"nonzero","globalCompositeOperation":"source-over","skewX":0,"skewY":0,"src":"' + IMG_SRC + '","filters":[],"crossOrigin":""}],'
-+ '"background":"green"}';
-    var serialized = JSON.parse(JSON_STRING);
+    var serialized = JSON.stringify({
+      "objects": [
+        { "type": "image", "originX": "left", "originY": "top", "left": 13.6, "top": -1.4, "width": 3000, "height": 3351, "fill": "rgb(0,0,0)", "stroke": null, "strokeWidth": 0, "strokeDashArray": null, "strokeLineCap": "butt", "strokeDashOffset": 0, "strokeLineJoin": "miter", "strokeMiterLimit": 4, "scaleX": 0.05, "scaleY": 0.05, "angle": 0, "flipX": false, "flipY": false, "opacity": 1, "shadow": null, "visible": true, "backgroundColor": "", "fillRule": "nonzero", "globalCompositeOperation": "source-over", "skewX": 0, "skewY": 0, "src": IMG_SRC, "filters": [], "crossOrigin": "" }],
+      "background": "green"
+    });
     serialized.controlsAboveOverlay = true;
     serialized.preserveObjectStacking = true;
     assert.equal(canvas.controlsAboveOverlay, fabric.Canvas.prototype.controlsAboveOverlay);

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -78,11 +78,7 @@
     return src;
   }
 
-  var path = require('path');
-
-  var IMG_SRC = fabric.isLikelyNode ?
-    ('file://' + path.normalize(path.join(__dirname + '/../fixtures/test_image.gif'))) :
-    path.normalize(getAbsolutePath('../fixtures/test_image.gif'));
+  var IMG_SRC = fabric.isLikelyNode ? ('file://' + __dirname + '/../fixtures/test_image.gif') : getAbsolutePath('../fixtures/test_image.gif');
   
   var canvas = this.canvas = new fabric.Canvas(null, {enableRetinaScaling: false, width: 600, height: 600});
   var upperCanvasEl = canvas.upperCanvasEl;

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -94,6 +94,10 @@
     return new fabric.Triangle(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
+  function basename(path) {
+    return path.slice(Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/')) + 1);
+  }
+
   /**
    * 
    * @param {*} actual 
@@ -102,8 +106,8 @@
   QUnit.assert.sameImageObject = function (actual, expected) {
     var a = {}, b = {};
     expected = expected || REFERENCE_IMG_OBJECT;
-    Object.assign(a, actual, { src: path.basename(actual.src) });
-    Object.assign(b, expected, { src: path.basename(expected.src) });
+    Object.assign(a, actual, { src: basename(actual.src) });
+    Object.assign(b, expected, { src: basename(expected.src) });
     this.pushResult({
       result: QUnit.equiv(a, b),
       actual: actual,

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -104,7 +104,6 @@
     expected = expected || REFERENCE_IMG_OBJECT;
     Object.assign(a, actual, { src: path.basename(actual.src) });
     Object.assign(b, expected, { src: path.basename(expected.src) });
-    QUnit.equiv(a, b, 'image object not equal');
     this.pushResult({
       result: QUnit.equiv(a, b),
       actual: actual,

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1662,11 +1662,11 @@
 
   QUnit.test('loadFromJSON with custom properties on Canvas with image', function(assert) {
     var done = assert.async();
-    var serialized = JSON.stringify({
+    var serialized = {
       "objects": [
         { "type": "image", "originX": "left", "originY": "top", "left": 13.6, "top": -1.4, "width": 3000, "height": 3351, "fill": "rgb(0,0,0)", "stroke": null, "strokeWidth": 0, "strokeDashArray": null, "strokeLineCap": "butt", "strokeDashOffset": 0, "strokeLineJoin": "miter", "strokeMiterLimit": 4, "scaleX": 0.05, "scaleY": 0.05, "angle": 0, "flipX": false, "flipY": false, "opacity": 1, "shadow": null, "visible": true, "backgroundColor": "", "fillRule": "nonzero", "globalCompositeOperation": "source-over", "skewX": 0, "skewY": 0, "src": IMG_SRC, "filters": [], "crossOrigin": "" }],
       "background": "green"
-    });
+    };
     serialized.controlsAboveOverlay = true;
     serialized.preserveObjectStacking = true;
     assert.equal(canvas.controlsAboveOverlay, fabric.Canvas.prototype.controlsAboveOverlay);

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -155,6 +155,10 @@
     return new fabric.Rect(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
+  function basename(path) {
+    return path.slice(Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/')) + 1);
+  }
+
   /**
    * 
    * @param {*} actual 
@@ -163,8 +167,8 @@
   QUnit.assert.sameImageObject = function (actual, expected) {
     var a = {}, b = {};
     expected = expected || REFERENCE_IMG_OBJECT;
-    Object.assign(a, actual, { src: path.basename(actual.src) });
-    Object.assign(b, expected, { src: path.basename(expected.src) });
+    Object.assign(a, actual, { src: basename(actual.src) });
+    Object.assign(b, expected, { src: basename(expected.src) });
     this.pushResult({
       result: QUnit.equiv(a, b),
       actual: actual,

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -165,7 +165,6 @@
     expected = expected || REFERENCE_IMG_OBJECT;
     Object.assign(a, actual, { src: path.basename(actual.src) });
     Object.assign(b, expected, { src: path.basename(expected.src) });
-    QUnit.equiv(a, b, 'image object not equal');
     this.pushResult({
       result: QUnit.equiv(a, b),
       actual: actual,

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -158,7 +158,7 @@
   /**
    * 
    * @param {*} actual 
-   * @param {*} [expected]
+   * @param {*} [expected] 
    */
   QUnit.assert.sameImageObject = function (actual, expected) {
     var a = {}, b = {};

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -155,7 +155,24 @@
     return new fabric.Rect(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
-  QUnit.addAssertions();
+  /**
+   * 
+   * @param {*} actual 
+   * @param {*} [expected]
+   */
+  QUnit.assert.sameImageObject = function (actual, expected) {
+    var a = {}, b = {};
+    expected = expected || REFERENCE_IMG_OBJECT;
+    Object.assign(a, actual, { src: path.basename(actual.src) });
+    Object.assign(b, expected, { src: path.basename(expected.src) });
+    QUnit.equiv(a, b, 'image object not equal');
+    this.pushResult({
+      result: QUnit.equiv(a, b),
+      actual: actual,
+      expected: expected,
+      message: 'image object equal to ref'
+    })
+  }
 
   QUnit.module('fabric.StaticCanvas', {
     beforeEach: function() {

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -155,6 +155,8 @@
     return new fabric.Rect(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
+  QUnit.addAssertions();
+
   QUnit.module('fabric.StaticCanvas', {
     beforeEach: function() {
       fabric.Object.__uid = 0;

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -974,7 +974,7 @@
       var json = canvas.toJSON();
 
       fixImageDimension(json.backgroundImage);
-      assert.deepEqual(json.backgroundImage, REFERENCE_IMG_OBJECT);
+      assert.sameImageObject(json.backgroundImage, REFERENCE_IMG_OBJECT);
 
       canvas.backgroundImage = null;
 
@@ -1003,7 +1003,7 @@
       var json = canvas.toJSON();
 
       fixImageDimension(json.overlayImage);
-      assert.deepEqual(json.overlayImage, REFERENCE_IMG_OBJECT);
+      assert.sameImageObject(json.overlayImage, REFERENCE_IMG_OBJECT);
 
       canvas.overlayImage = null;
 

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1247,7 +1247,7 @@
     var done = assert.async();
     var serialized = JSON.parse(PATH_JSON);
     serialized.background = 'green';
-    serialized.backgroundImage = JSON.parse('{"type":"image","originX":"left","originY":"top","left":13.6,"top":-1.4,"width":3000,"height":3351,"fill":"rgb(0,0,0)","stroke":null,"strokeWidth":0,"strokeDashArray":null,"strokeLineCap":"butt","strokeDashOffset":0,"strokeLineJoin":"miter","strokeMiterLimit":4,"scaleX":0.05,"scaleY":0.05,"angle":0,"flipX":false,"flipY":false,"opacity":1,"shadow":null,"visible":true,"backgroundColor":"","fillRule":"nonzero","globalCompositeOperation":"source-over","skewX":0,"skewY":0,"src":"' + IMG_SRC + '","filters":[],"crossOrigin":""}');
+    serialized.backgroundImage = { "type": "image", "originX": "left", "originY": "top", "left": 13.6, "top": -1.4, "width": 3000, "height": 3351, "fill": "rgb(0,0,0)", "stroke": null, "strokeWidth": 0, "strokeDashArray": null, "strokeLineCap": "butt", "strokeDashOffset": 0, "strokeLineJoin": "miter", "strokeMiterLimit": 4, "scaleX": 0.05, "scaleY": 0.05, "angle": 0, "flipX": false, "flipY": false, "opacity": 1, "shadow": null, "visible": true, "backgroundColor": "", "fillRule": "nonzero", "globalCompositeOperation": "source-over", "skewX": 0, "skewY": 0, "src": IMG_SRC, "filters": [], "crossOrigin": "" };
     canvas.loadFromJSON(serialized, function() {
       assert.ok(!canvas.isEmpty(), 'canvas is not empty');
       assert.equal(canvas.backgroundColor, 'green');

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -117,7 +117,24 @@
     });
   }
 
-  QUnit.addAssertions();
+  /**
+   * 
+   * @param {*} actual 
+   * @param {*} [expected]
+   */
+  QUnit.assert.sameImageObject = function (actual, expected) {
+    var a = {}, b = {};
+    expected = expected || REFERENCE_IMG_OBJECT;
+    Object.assign(a, actual, { src: path.basename(actual.src) });
+    Object.assign(b, expected, { src: path.basename(expected.src) });
+    QUnit.equiv(a, b, 'image object not equal');
+    this.pushResult({
+      result: QUnit.equiv(a, b),
+      actual: actual,
+      expected: expected,
+      message: 'image object equal to ref'
+    })
+  }
 
   QUnit.module('fabric.Image');
 

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -24,10 +24,8 @@
     return element;
   }
 
-  var path = require('path');
-
-  var IMG_SRC = fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : getAbsolutePath('../fixtures/test_image.gif'),
-    IMG_SRC_REL = fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : '../fixtures/test_image.gif',
+  var IMG_SRC     = fabric.isLikelyNode ? ('file://' + require('path').join(__dirname + '/../fixtures/test_image.gif')) : getAbsolutePath('../fixtures/test_image.gif'),
+      IMG_SRC_REL = fabric.isLikelyNode ? ('file://' + require('path').join(__dirname + '/../fixtures/test_image.gif')) : '../fixtures/test_image.gif',
       IMG_WIDTH   = 276,
       IMG_HEIGHT  = 110;
 

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -26,8 +26,8 @@
 
   var path = require('path');
 
-  var IMG_SRC = (fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : getAbsolutePath('../fixtures/test_image.gif')).replace(/\\/g, '/'),
-    IMG_SRC_REL = (fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : '../fixtures/test_image.gif').replace(/\\/g, '/'),
+  var IMG_SRC = fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : getAbsolutePath('../fixtures/test_image.gif'),
+    IMG_SRC_REL = fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : '../fixtures/test_image.gif',
       IMG_WIDTH   = 276,
       IMG_HEIGHT  = 110;
 

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -127,7 +127,6 @@
     expected = expected || REFERENCE_IMG_OBJECT;
     Object.assign(a, actual, { src: path.basename(actual.src) });
     Object.assign(b, expected, { src: path.basename(expected.src) });
-    QUnit.equiv(a, b, 'image object not equal');
     this.pushResult({
       result: QUnit.equiv(a, b),
       actual: actual,

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -24,7 +24,9 @@
     return element;
   }
 
-  var IMG_SRC     = fabric.isLikelyNode ? ('file://' + require('path').join(__dirname + '/../fixtures/test_image.gif')) : getAbsolutePath('../fixtures/test_image.gif'),
+  var path = require('path');
+
+  var IMG_SRC = path.normalize(fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : getAbsolutePath('../fixtures/test_image.gif')),
       IMG_SRC_REL = fabric.isLikelyNode ? ('file://' + require('path').join(__dirname + '/../fixtures/test_image.gif')) : '../fixtures/test_image.gif',
       IMG_WIDTH   = 276,
       IMG_HEIGHT  = 110;

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -26,12 +26,25 @@
 
   var path = require('path');
 
-  var IMG_SRC = path.normalize(fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : getAbsolutePath('../fixtures/test_image.gif')),
-      IMG_SRC_REL = fabric.isLikelyNode ? ('file://' + require('path').join(__dirname + '/../fixtures/test_image.gif')) : '../fixtures/test_image.gif',
+  var IMG_SRC = (fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : getAbsolutePath('../fixtures/test_image.gif')).replace(/\\/g, '/'),
+    IMG_SRC_REL = (fabric.isLikelyNode ? ('file://' + path.join(__dirname + '/../fixtures/test_image.gif')) : '../fixtures/test_image.gif').replace(/\\/g, '/'),
       IMG_WIDTH   = 276,
       IMG_HEIGHT  = 110;
 
   var IMG_URL_NON_EXISTING = 'http://www.google.com/non-existing';
+
+  QUnit.assert.equalImageSVG = function (actual, expected) {
+    function extractBasename(s) {
+      var p = 'xlink:href', pos = s.indexOf(p) + p.length;
+      return path.basename(s.slice(pos, s.indexOf(' ', pos)));
+    }
+    this.pushResult({
+      result: extractBasename(actual) === extractBasename(expected),
+      actual: actual,
+      expected: expected,
+      message: 'svg is not equal to ref'
+    });
+  }
 
   var REFERENCE_IMG_OBJECT = {
     version:                  fabric.version,
@@ -134,7 +147,7 @@
       if (toObject.height === 0) {
         toObject.height = IMG_HEIGHT;
       }
-      assert.deepEqual(toObject, REFERENCE_IMG_OBJECT);
+      assert.sameImageObject(toObject, REFERENCE_IMG_OBJECT);
       done();
     });
   });
@@ -186,7 +199,7 @@
       if (toObject.height === 0) {
         toObject.height = IMG_HEIGHT;
       }
-      assert.deepEqual(toObject, REFERENCE_IMG_OBJECT);
+      assert.sameImageObject(toObject, REFERENCE_IMG_OBJECT);
       done();
     });
   });
@@ -265,7 +278,7 @@
     var done = assert.async();
     createImageObject(function(image) {
       assert.ok(typeof image.toString === 'function');
-      assert.equal(image.toString(), '#<fabric.Image: { src: "' + IMG_SRC + '" }>');
+      assert.equal(image.toString(), '#<fabric.Image: { src: "' + image.getSrc() + '" }>');
       done();
     });
   });
@@ -279,7 +292,7 @@
       image.height -= 2;
       fabric.Object.__uid = 1;
       var expectedSVG = '<g transform=\"matrix(1 0 0 1 137 54)\"  >\n<clipPath id=\"imageCrop_1\">\n\t<rect x=\"-137\" y=\"-54\" width=\"274\" height=\"108\" />\n</clipPath>\n\t<image style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  xlink:href=\"' + IMG_SRC + '\" x=\"-138\" y=\"-55\" width=\"276\" height=\"110\" clip-path=\"url(#imageCrop_1)\" ></image>\n</g>\n';
-      assert.equal(image.toSVG(), expectedSVG);
+      assert.equalImageSVG(image.toSVG(), expectedSVG);
       done();
     });
   });
@@ -308,7 +321,7 @@
     createImageObject(function(image) {
       assert.ok(typeof image.toSVG === 'function');
       var expectedSVG = '<g transform=\"matrix(1 0 0 1 138 55)\"  >\n\t<image style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  xlink:href=\"' + IMG_SRC + '\" x=\"-138\" y=\"-55\" width=\"276\" height=\"110\"></image>\n</g>\n';
-      assert.equal(image.toSVG(), expectedSVG);
+      assert.equalImageSVG(image.toSVG(), expectedSVG);
       done();
     });
   });
@@ -319,7 +332,7 @@
       image.imageSmoothing = false;
       assert.ok(typeof image.toSVG === 'function');
       var expectedSVG = '<g transform="matrix(1 0 0 1 138 55)"  >\n\t<image style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  xlink:href=\"' + IMG_SRC + '\" x=\"-138\" y=\"-55\" width=\"276\" height=\"110\" image-rendering=\"optimizeSpeed\"></image>\n</g>\n';
-      assert.equal(image.toSVG(), expectedSVG);
+      assert.equalImageSVG(image.toSVG(), expectedSVG);
       done();
     });
   });
@@ -330,7 +343,7 @@
       delete image._element;
       assert.ok(typeof image.toSVG === 'function');
       var expectedSVG = '<g transform="matrix(1 0 0 1 138 55)"  >\n</g>\n';
-      assert.equal(image.toSVG(), expectedSVG);
+      assert.equalImageSVG(image.toSVG(), expectedSVG);
       done();
     });
   });
@@ -339,7 +352,7 @@
     var done = assert.async();
     createImageObject(function(image) {
       assert.ok(typeof image.getSrc === 'function');
-      assert.equal(image.getSrc(), IMG_SRC);
+      assert.equal(path.basename(image.getSrc()), path.basename(IMG_SRC));
       done();
     });
   });
@@ -521,7 +534,7 @@
     assert.ok(typeof fabric.Image.fromURL === 'function');
     fabric.Image.fromURL(IMG_SRC, function(instance) {
       assert.ok(instance instanceof fabric.Image);
-      assert.deepEqual(REFERENCE_IMG_OBJECT, instance.toObject());
+      assert.sameImageObject(REFERENCE_IMG_OBJECT, instance.toObject());
       done();
     });
   });

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -31,19 +31,6 @@
 
   var IMG_URL_NON_EXISTING = 'http://www.google.com/non-existing';
 
-  QUnit.assert.equalImageSVG = function (actual, expected) {
-    function extractBasename(s) {
-      var p = 'xlink:href', pos = s.indexOf(p) + p.length;
-      return path.basename(s.slice(pos, s.indexOf(' ', pos)));
-    }
-    this.pushResult({
-      result: extractBasename(actual) === extractBasename(expected),
-      actual: actual,
-      expected: expected,
-      message: 'svg is not equal to ref'
-    });
-  }
-
   var REFERENCE_IMG_OBJECT = {
     version:                  fabric.version,
     type:                     'image',
@@ -116,6 +103,21 @@
     };
     img.src = src;
   }
+
+  QUnit.assert.equalImageSVG = function (actual, expected) {
+    function extractBasename(s) {
+      var p = 'xlink:href', pos = s.indexOf(p) + p.length;
+      return path.basename(s.slice(pos, s.indexOf(' ', pos)));
+    }
+    this.pushResult({
+      result: extractBasename(actual) === extractBasename(expected),
+      actual: actual,
+      expected: expected,
+      message: 'svg is not equal to ref'
+    });
+  }
+
+  QUnit.addAssertions();
 
   QUnit.module('fabric.Image');
 

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -104,10 +104,14 @@
     img.src = src;
   }
 
+  function basename(path) {
+    return path.slice(Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/')) + 1);
+  }
+
   QUnit.assert.equalImageSVG = function (actual, expected) {
     function extractBasename(s) {
       var p = 'xlink:href', pos = s.indexOf(p) + p.length;
-      return path.basename(s.slice(pos, s.indexOf(' ', pos)));
+      return basename(s.slice(pos, s.indexOf(' ', pos)));
     }
     this.pushResult({
       result: extractBasename(actual) === extractBasename(expected),
@@ -125,8 +129,8 @@
   QUnit.assert.sameImageObject = function (actual, expected) {
     var a = {}, b = {};
     expected = expected || REFERENCE_IMG_OBJECT;
-    Object.assign(a, actual, { src: path.basename(actual.src) });
-    Object.assign(b, expected, { src: path.basename(expected.src) });
+    Object.assign(a, actual, { src: basename(actual.src) });
+    Object.assign(b, expected, { src: basename(expected.src) });
     this.pushResult({
       result: QUnit.equiv(a, b),
       actual: actual,
@@ -368,7 +372,7 @@
     var done = assert.async();
     createImageObject(function(image) {
       assert.ok(typeof image.getSrc === 'function');
-      assert.equal(path.basename(image.getSrc()), path.basename(IMG_SRC));
+      assert.equal(basename(image.getSrc()), basename(IMG_SRC));
       done();
     });
   });

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -22,6 +22,8 @@
 
   var IMG_URL_NON_EXISTING = 'http://www.google.com/non-existing';
 
+  var path = require('path');
+
   QUnit.test('fabric.util.toFixed', function(assert) {
     assert.ok(typeof fabric.util.toFixed === 'function');
 
@@ -475,7 +477,7 @@
     }
     try {
       fabric.util.loadImage(IMG_URL, function(img, isError) {
-        assert.equal(img.src, IMG_URL, 'src is set');
+        assert.equal(path.basename(img.src), path.basename(IMG_URL), 'src is set');
         assert.equal(img.crossOrigin, 'anonymous', 'crossOrigin is set');
         assert.ok(!isError);
         done();

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -22,8 +22,6 @@
 
   var IMG_URL_NON_EXISTING = 'http://www.google.com/non-existing';
 
-  var path = require('path');
-
   QUnit.test('fabric.util.toFixed', function(assert) {
     assert.ok(typeof fabric.util.toFixed === 'function');
 

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -16,6 +16,10 @@
     return src;
   }
 
+  function basename(path) {
+    return path.slice(Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/')) + 1);
+  }
+
   var IMG_URL = fabric.isLikelyNode
     ? 'file://' + require('path').join(__dirname, '../fixtures/', 'very_large_image.jpg')
     : getAbsolutePath('../fixtures/very_large_image.jpg');
@@ -475,7 +479,7 @@
     }
     try {
       fabric.util.loadImage(IMG_URL, function(img, isError) {
-        assert.equal(path.basename(img.src), path.basename(IMG_URL), 'src is set');
+        assert.equal(basename(img.src), basename(IMG_URL), 'src is set');
         assert.equal(img.crossOrigin, 'anonymous', 'crossOrigin is set');
         assert.ok(!isError);
         done();


### PR DESCRIPTION
Fixed the annoying tests that failed because of path resolution.
I've changed tests to run on the basename of the path rather than the entire ugly path.