### PR TITLE
fix(`canvas.renderAll`): `setDimensions` edge case

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -413,6 +413,7 @@
       }
       if (this.hasLostContext) {
         this.renderTopLayer(this.contextTop);
+        this.hasLostContext = false;
       }
       var canvasToDrawOn = this.contextContainer;
       this.renderCanvas(canvasToDrawOn, this._chooseObjectsToRender());


### PR DESCRIPTION
Motivation:
#6112 

The flag `hasLostContext` is turned on here:
https://github.com/fabricjs/fabric.js/blob/a709d3be8e5bbdf520ae385ff28bca17a9566d76/src/static_canvas.class.js#L602

And is never turned off.
And that seems to be the problem.

closes #6112