### PR TITLE
fix(fabric.Text): support text alignments in RTL text

### DIFF
--- a/src/mixins/itext.svg_export.js
+++ b/src/mixins/itext.svg_export.js
@@ -53,6 +53,7 @@
         (this.fontStyle ? 'font-style="' + this.fontStyle + '" ' : ''),
         (this.fontWeight ? 'font-weight="' + this.fontWeight + '" ' : ''),
         (textDecoration ? 'text-decoration="' + textDecoration + '" ' : ''),
+        (this.direction === 'rtl' ? 'direction="' + this.direction + '" ' : ''),
         'style="', this.getSvgStyles(noShadow), '"', this.addPaintOrder(), ' >',
         textAndBg.textSpans.join(''),
         '</text>\n'
@@ -75,6 +76,9 @@
       // text and text-background
       for (var i = 0, len = this._textLines.length; i < len; i++) {
         lineOffset = this._getLineLeftOffset(i);
+        if (this.direction === 'rtl') {
+          lineOffset += this.width;
+        }
         if (this.textBackgroundColor || this.styleHas('textBackgroundColor', i)) {
           this._setSVGTextLineBg(textBgRects, i, textLeftOffset + lineOffset, height);
         }

--- a/src/mixins/itext.svg_export.js
+++ b/src/mixins/itext.svg_export.js
@@ -153,7 +153,12 @@
           textSpans.push(this._createTextCharSpan(charsToRender, style, textLeftOffset, textTopOffset));
           charsToRender = '';
           actualStyle = nextStyle;
-          textLeftOffset += boxWidth;
+          if (this.direction === 'rtl') {
+            textLeftOffset -= boxWidth;
+          }
+          else {
+            textLeftOffset += boxWidth;
+          }
           boxWidth = 0;
         }
       }

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -230,7 +230,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
         break;
       }
     }
-    lineLeftOffset = this._getLineLeftOffset(lineIndex);
+    lineLeftOffset = Math.abs(this._getLineLeftOffset(lineIndex));
     width = lineLeftOffset * this.scaleX;
     line = this._textLines[lineIndex];
     // handling of RTL: in order to get things work correctly,
@@ -238,7 +238,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     // so in position detection we mirror the X offset, and when is time
     // of rendering it, we mirror it again.
     if (this.direction === 'rtl') {
-      mouseOffset.x = this.width * this.scaleX - mouseOffset.x + width;
+      mouseOffset.x = this.width * this.scaleX - mouseOffset.x;
     }
     for (var j = 0, jlen = line.length; j < jlen; j++) {
       prevWidth = width;

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -366,7 +366,15 @@
         left: lineLeftOffset + (leftOffset > 0 ? leftOffset : 0),
       };
       if (this.direction === 'rtl') {
-        boundaries.left *= -1;
+        if (this.textAlign === 'right' || this.textAlign === 'justify'){
+          boundaries.left *= -1;
+        }
+        else if (this.textAlign === 'left') {
+          boundaries.left = lineLeftOffset - (leftOffset > 0 ? leftOffset : 0);
+        }
+        else if (this.textAlign === 'center') {
+          boundaries.left = lineLeftOffset - (leftOffset > 0 ? leftOffset : 0);
+        }
       }
       this.cursorOffsetCache = boundaries;
       return this.cursorOffsetCache;
@@ -455,7 +463,15 @@
           ctx.fillStyle = this.selectionColor;
         }
         if (this.direction === 'rtl') {
-          drawStart = this.width - drawStart - drawWidth;
+          if (this.textAlign === 'right' || this.textAlign === 'justify') {
+            drawStart = this.width - drawStart - drawWidth;
+          }
+          else if (this.textAlign === 'left') {
+            drawStart = boundaries.left + lineOffset - boxEnd;
+          }
+          else if (this.textAlign === 'center') {
+            drawStart = boundaries.left + lineOffset - boxEnd;
+          }
         }
         ctx.fillRect(
           drawStart,

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -366,13 +366,13 @@
         left: lineLeftOffset + (leftOffset > 0 ? leftOffset : 0),
       };
       if (this.direction === 'rtl') {
-        if (this.textAlign === 'right' || this.textAlign === 'justify'){
+        if (this.textAlign === 'right' || this.textAlign === 'justify' || this.textAlign === 'justify-right') {
           boundaries.left *= -1;
         }
-        else if (this.textAlign === 'left') {
+        else if (this.textAlign === 'left' || this.textAlign === 'justify-left') {
           boundaries.left = lineLeftOffset - (leftOffset > 0 ? leftOffset : 0);
         }
-        else if (this.textAlign === 'center') {
+        else if (this.textAlign === 'center' || this.textAlign === 'justify-center') {
           boundaries.left = lineLeftOffset - (leftOffset > 0 ? leftOffset : 0);
         }
       }
@@ -463,13 +463,13 @@
           ctx.fillStyle = this.selectionColor;
         }
         if (this.direction === 'rtl') {
-          if (this.textAlign === 'right' || this.textAlign === 'justify') {
+          if (this.textAlign === 'right' || this.textAlign === 'justify' || this.textAlign === 'justify-right') {
             drawStart = this.width - drawStart - drawWidth;
           }
-          else if (this.textAlign === 'left') {
+          else if (this.textAlign === 'left' || this.textAlign === 'justify-left') {
             drawStart = boundaries.left + lineOffset - boxEnd;
           }
-          else if (this.textAlign === 'center') {
+          else if (this.textAlign === 'center' || this.textAlign === 'justify-center') {
             drawStart = boundaries.left + lineOffset - boxEnd;
           }
         }

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1044,7 +1044,7 @@
           path = this.path,
           shortCut = !isJustify && this.charSpacing === 0 && this.isEmptyStyles(lineIndex) && !path,
           isLtr = this.direction === 'ltr', sign = this.direction === 'ltr' ? 1 : -1,
-          drawingLeft, currentDirection = ctx.canvas.getAttribute('dir');
+          drawingLeft, currentDirection = ctx.direction;
       ctx.save();
       if (currentDirection !== this.direction) {
         ctx.canvas.setAttribute('dir', isLtr ? 'ltr' : 'rtl');
@@ -1306,7 +1306,15 @@
         leftOffset = lineDiff;
       }
       if (direction === 'rtl') {
-        leftOffset -= lineDiff;
+        if (textAlign === 'right' || textAlign === 'justify'){
+          leftOffset = 0;
+        }
+        else if (textAlign === 'left') {
+          leftOffset = -lineDiff;
+        }
+        else if (textAlign === 'center') {
+          leftOffset = -lineDiff / 2;
+        }
       }
       return leftOffset;
     },

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1306,13 +1306,13 @@
         leftOffset = lineDiff;
       }
       if (direction === 'rtl') {
-        if (textAlign === 'right' || textAlign === 'justify'){
+        if (textAlign === 'right' || textAlign === 'justify' || textAlign === 'justify-right') {
           leftOffset = 0;
         }
-        else if (textAlign === 'left') {
+        else if (textAlign === 'left' || textAlign === 'justify-left') {
           leftOffset = -lineDiff;
         }
-        else if (textAlign === 'center') {
+        else if (textAlign === 'center' || textAlign === 'justify-center') {
           leftOffset = -lineDiff / 2;
         }
       }

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1044,6 +1044,8 @@
           path = this.path,
           shortCut = !isJustify && this.charSpacing === 0 && this.isEmptyStyles(lineIndex) && !path,
           isLtr = this.direction === 'ltr', sign = this.direction === 'ltr' ? 1 : -1,
+          // this was changed in the PR #7674
+          // currentDirection = ctx.canvas.getAttribute('dir');
           drawingLeft, currentDirection = ctx.direction;
       ctx.save();
       if (currentDirection !== this.direction) {


### PR DESCRIPTION
The RTL text support was initially added in version 4.5, but it had some problem specially with cursor placement and toSVG mode. The cursor position was correct only if 'textAlign' was set to 'right'.

In this PR I considered the cursor position in 'left', 'center' and 'justify' text alignments and also considered the direction and text alignment in the toSVG method.