### PR TITLE
perf(SprayBrush): enhance perf using new Group

### DIFF
--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -201,8 +201,8 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       }
 
       if (this.optimizeOverlapping) {
-        key = x + ',' + y;
         // avoid creating duplicate rects at the same coordinates
+        key = x + ',' + y;
         if (hits[key]) {
           continue;
         }

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -51,7 +51,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    * Threshold of dots before creating a new buffering group
    * @type number
    */
-  bufferThreshold: 75,
+  bufferThreshold: 500,
 
   /**
    * Constructor
@@ -64,6 +64,8 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   },
 
   /**
+   * create a group to contain some of the spray chunks, acting as a buffer
+   * position group center at canvas 0,0 so we can add objects relative to group, reducing calculations to a minimum
    * @private
    * @returns {fabric.Group}
    */
@@ -81,6 +83,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   },
 
   /**
+   * layout once and disable future layouting by setting to `fixed`
    * @private
    * @param {fabric.Group} group 
    */
@@ -96,7 +99,6 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   onMouseDown: function(pointer) {
     this.sprayChunks = [];
     this._buffer = this._createBufferingGroup();
-    this._buffer.set({ layout: 'fit-content-lazy' });
     this.canvas.clearContext(this.canvas.contextTop);
     this._setShadow();
 
@@ -125,8 +127,9 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     var group = this._buffer;
     if (this._tempBuffer) {
       this._layoutBufferingGroup(this._tempBuffer);
-      group.add(this._tempBuffer);
+      group.addRelativeToGroup(this._tempBuffer);
     }
+    this._layoutBufferingGroup(group);
     this._buffer = undefined;
     this._tempBuffer = undefined;
     this.shadow && group.set('shadow', new fabric.Shadow(this.shadow));
@@ -223,11 +226,12 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
         originX: 'center',
         originY: 'center',
         fill: this.color,
-        objectCaching: false
+        objectCaching: false,
+        canvas: this.canvas
       });
       if (this._tempBuffer && this._tempBuffer.size() > this.bufferThreshold) {
         this._layoutBufferingGroup(this._tempBuffer);
-        this._buffer.add(this._tempBuffer);
+        this._buffer.addRelativeToGroup(this._tempBuffer);
         this._tempBuffer.renderCache();
         this._tempBuffer = undefined;
       }

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -103,7 +103,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     this._setShadow();
 
     this.addSprayChunk(pointer);
-    this.renderChunck(this.sprayChunkPoints);
+    this.renderChunk(this.sprayChunkPoints);
   },
 
   /**
@@ -115,7 +115,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       return;
     }
     this.addSprayChunk(pointer);
-    this.renderChunck(this.sprayChunkPoints);
+    this.renderChunk(this.sprayChunkPoints);
   },
 
   /**
@@ -126,6 +126,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     this.canvas.renderOnAddRemove = false;
     var group = this._buffer;
     if (this._tempBuffer) {
+      //  add last buffer to main buffer
       this._layoutBufferingGroup(this._tempBuffer);
       group.addRelativeToGroup(this._tempBuffer);
     }
@@ -146,7 +147,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   /**
    * Render new chunk of spray brush
    */
-  renderChunck: function(sprayChunk) {
+  renderChunk: function(sprayChunk) {
     var ctx = this.canvas.contextTop, i, len;
     ctx.fillStyle = this.color;
 
@@ -172,7 +173,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     this._saveAndTransform(ctx);
 
     for (i = 0, ilen = this.sprayChunks.length; i < ilen; i++) {
-      this.renderChunck(this.sprayChunks[i]);
+      this.renderChunk(this.sprayChunks[i]);
     }
     ctx.restore();
   },

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -227,8 +227,8 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       var rect = new fabric.Rect({
         width: point.width,
         height: point.width,
-        left: point.x + 1,
-        top: point.y + 1,
+        left: point.x + point.width / 2,
+        top: point.y + point.width / 2,
         originX: 'center',
         originY: 'center',
         fill: this.color,

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -188,7 +188,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    */
   addSprayChunk: function(pointer) {
     var sprayChunkPoints = [];
-    var i, x, y, key, width, radius = this.width / 2;
+    var i, x, y, key, width, radius = this.width / 2, r;
 
     for (i = 0; i < this.density; i++) {
 
@@ -224,11 +224,12 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       }
 
       sprayChunkPoints.push(point);
+      r = point.width / 2;
       var rect = new fabric.Rect({
         width: point.width,
         height: point.width,
-        left: point.x + point.width / 2,
-        top: point.y + point.width / 2,
+        left: point.x + r,
+        top: point.y + r,
         originX: 'center',
         originY: 'center',
         fill: this.color,

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -102,8 +102,8 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     this.canvas.clearContext(this.canvas.contextTop);
     this._setShadow();
 
-    this.addSprayChunk(pointer);
-    this.renderChunk(this.sprayChunkPoints);
+    var chunk = this.addSprayChunk(pointer);
+    this.renderChunk(chunk);
   },
 
   /**
@@ -114,8 +114,8 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     if (this.limitedToCanvasSize === true && this._isOutSideCanvas(pointer)) {
       return;
     }
-    this.addSprayChunk(pointer);
-    this.renderChunk(this.sprayChunkPoints);
+    var chunk = this.addSprayChunk(pointer);
+    this.renderChunk(chunk);
   },
 
   /**
@@ -182,7 +182,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    * @param {Object} pointer
    */
   addSprayChunk: function(pointer) {
-    this.sprayChunkPoints = [];
+    var sprayChunkPoints = [];
     var i, x, y, key, width, radius = this.width / 2, hits = {};
 
     for (i = 0; i < this.density; i++) {
@@ -218,7 +218,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
         point.opacity = fabric.util.getRandomInt(0, 100) / 100;
       }
 
-      this.sprayChunkPoints.push(point);
+      sprayChunkPoints.push(point);
       var rect = new fabric.Rect({
         width: point.width,
         height: point.width,
@@ -242,6 +242,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       this._tempBuffer.addRelativeToGroup(rect);
     }
 
-    this.sprayChunks.push(this.sprayChunkPoints);
+    this.sprayChunks.push(sprayChunkPoints);
+    return sprayChunkPoints;
   }
 });

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -61,6 +61,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   initialize: function(canvas) {
     this.canvas = canvas;
     this.sprayChunks = [];
+    this.memo = {};
   },
 
   /**
@@ -98,6 +99,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    */
   onMouseDown: function(pointer) {
     this.sprayChunks = [];
+    this.memo = {};
     this._buffer = this._createBufferingGroup();
     this.canvas.clearContext(this.canvas.contextTop);
     this._setShadow();
@@ -133,6 +135,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     this._layoutBufferingGroup(group);
     this._buffer = undefined;
     this._tempBuffer = undefined;
+    this.memo = {};
     this.shadow && group.set('shadow', new fabric.Shadow(this.shadow));
     this.canvas.fire('before:path:created', { path: group });
     this.canvas.add(group);
@@ -183,7 +186,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    */
   addSprayChunk: function(pointer) {
     var sprayChunkPoints = [];
-    var i, x, y, key, width, radius = this.width / 2, hits = {};
+    var i, x, y, key, width, radius = this.width / 2;
 
     for (i = 0; i < this.density; i++) {
 
@@ -203,11 +206,11 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       if (this.optimizeOverlapping) {
         // avoid creating duplicate rects at the same coordinates
         key = x + ',' + y;
-        if (hits[key]) {
+        if (this.memo[key]) {
           continue;
         }
         else {
-          hits[key] = true;
+          this.memo[key] = true;
         }
       }
 

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -133,18 +133,20 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       group.addRelativeToGroup(this._tempBuffer);
     }
     this._layoutBufferingGroup(group);
-    this._buffer = undefined;
-    this._tempBuffer = undefined;
-    this.memo = {};
     this.shadow && group.set('shadow', new fabric.Shadow(this.shadow));
+    // fire events and add
     this.canvas.fire('before:path:created', { path: group });
     this.canvas.add(group);
     this.canvas.fire('path:created', { path: group });
-
+    //  render
     this.canvas.clearContext(this.canvas.contextTop);
     this._resetShadow();
     this.canvas.renderOnAddRemove = originalRenderOnAddRemove;
     this.canvas.requestRenderAll();
+    //  deallocate
+    this._buffer = undefined;
+    this._tempBuffer = undefined;
+    this.memo = {};
   },
 
   /**


### PR DESCRIPTION
This PR is an excellent demonstration of the power of the new Group and what can be unlocked using it
[control](https://codesandbox.io/s/fabric-app-forked-nq1t4)
[perf](https://codesandbox.io/s/fabric-app-forked-ewex1q)

Basically it reduces computation cost by iterating only once over the spray dots instead of a number of times.
It split up the dots into a number of groups that act as buffers to cut down iterations.
I need to get these buffers to render cache once they're maxed out and then performance will rise even more (splitting the rendering of the entire spray into smaller chunks and then at mouseup the create path is a group of groups that have already been cached so overhead will be minimal)

Will merge once v6! stabilizes

The buffering approach can/should be used by canvas for perf

If we wrap the result of the spray brush with another group we enhance perf even more in case it is used with clip path or in other cases that invalidate cache.



## In action
You'll see that the dots double every second or so. That's the buffering group.
Notice that normally there is a massive frame drop on mouse up and here, even though the spray is huge there is no visible drop.

**Zoom in on mouse up**

https://user-images.githubusercontent.com/34343793/155074016-e5d1c1f0-1f5e-49e3-858a-0a9fb6766749.mp4


