### PR TITLE
fix(test): Remove expect assertion

### DIFF
--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -334,7 +334,6 @@
 
   QUnit.test('animate with list of values', function(assert) {
     var done = assert.async();
-    assert.expect(52)
 
     fabric.util.animate({
       startValue: [1, 2, 3],


### PR DESCRIPTION
Due to different browser framerates and timing intervals, the
assertion would fail. 144fps browser, `requestAnimationFrame`, and
`setTimeout` would cause inconsistent assertions.