### PR TITLE
Add cacheContext checks

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1088,7 +1088,7 @@
 
     renderCache: function(options) {
       options = options || {};
-      if (!this._cacheCanvas) {
+      if (!this._cacheCanvas || !this._cacheContext) {
         this._createCacheCanvas();
       }
       if (this.isCacheDirty()) {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1261,7 +1261,7 @@
       if (this.isNotVisible()) {
         return false;
       }
-      if (this._cacheCanvas && !skipCanvas && this._updateCacheCanvas()) {
+      if (this._cacheCanvas && this._cacheContext && !skipCanvas && this._updateCacheCanvas()) {
         // in this case the context is already cleared.
         return true;
       }
@@ -1270,7 +1270,7 @@
           (this.clipPath && this.clipPath.absolutePositioned) ||
           (this.statefullCache && this.hasStateChanged('cacheProperties'))
         ) {
-          if (this._cacheCanvas && !skipCanvas) {
+          if (this._cacheCanvas && this._cacheContext && !skipCanvas) {
             var width = this.cacheWidth / this.zoomX;
             var height = this.cacheHeight / this.zoomY;
             this._cacheContext.clearRect(-width / 2, -height / 2, width, height);

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1103,6 +1103,7 @@
      */
     _removeCacheCanvas: function() {
       this._cacheCanvas = null;
+      this._cacheContext = null;
       this.cacheWidth = 0;
       this.cacheHeight = 0;
     },


### PR DESCRIPTION
Relates to https://github.com/fabricjs/fabric.js/issues/7693

Errors get thrown about 
`null is not an object (evaluating 'this._cacheContext.translate')`
`null is not an object (evaluating 'this._cacheContext.setTransform')`

Added multiple checks for cacheContext `cacheContext`, should fix the issues occuring