### PR TITLE
chore(): Replace deprecated String.prototype.substr() with Array.prototype.slice()

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -237,7 +237,7 @@ var eventManager = function(target, type, listener, configure, trigger, fromOver
 		}
 		return createBatchCommands(events);
 	} else if (type.indexOf("on") === 0) { // to support things like "onclick" instead of "click"
-		type = type.substr(2);
+		type = type.slice(2);
 	}
 
 	// Ensure listener is a function.
@@ -1368,7 +1368,7 @@ root.gesture = function(conf) {
 			var dx = touch.move.x - self.x;
 			var dy = touch.move.y - self.y;
 			var distance = Math.sqrt(dx * dx + dy * dy);
-			// If touch start.distance from centroid is 0, scale should not be updated. 
+			// If touch start.distance from centroid is 0, scale should not be updated.
 			// This prevents dividing by 0 in cases where start.distance is oddly 0.
 			if (start.distance !== 0) {
 			  scale += distance / start.distance;

--- a/src/parser.js
+++ b/src/parser.js
@@ -477,7 +477,7 @@
         return;
       }
 
-      var xlink = xlinkAttribute.substr(1),
+      var xlink = xlinkAttribute.slice(1),
           x = el.getAttribute('x') || 0,
           y = el.getAttribute('y') || 0,
           el2 = elementById(doc, xlink).cloneNode(true),
@@ -749,7 +749,7 @@
   function recursivelyParseGradientsXlink(doc, gradient) {
     var gradientsAttrs = ['gradientTransform', 'x1', 'x2', 'y1', 'y2', 'gradientUnits', 'cx', 'cy', 'r', 'fx', 'fy'],
         xlinkAttr = 'xlink:href',
-        xLink = gradient.getAttribute(xlinkAttr).substr(1),
+        xLink = gradient.getAttribute(xlinkAttr).slice(1),
         referencedGradient = elementById(doc, xLink);
     if (referencedGradient && referencedGradient.getAttribute(xlinkAttr)) {
       recursivelyParseGradientsXlink(doc, referencedGradient);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.