### PR TITLE
dep(Canvas#getCenter): migrate to `getCenterPoint`

### DIFF
--- a/src/mixins/animation.mixin.js
+++ b/src/mixins/animation.mixin.js
@@ -26,7 +26,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
     return fabric.util.animate({
       target: this,
       startValue: object.left,
-      endValue: this.getCenter().left,
+      endValue: this.getCenterPoint().x,
       duration: this.FX_DURATION,
       onChange: function(value) {
         object.set('left', value);
@@ -59,7 +59,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
     return fabric.util.animate({
       target: this,
       startValue: object.top,
-      endValue: this.getCenter().top,
+      endValue: this.getCenterPoint().y,
       duration: this.FX_DURATION,
       onChange: function(value) {
         object.set('top', value);

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -815,6 +815,7 @@
      * Returns coordinates of a center of canvas.
      * Returned value is an object with top and left properties
      * @return {Object} object with "top" and "left" number values
+     * @deprecated migrate to `getCenterPoint`
      */
     getCenter: function () {
       return {
@@ -824,12 +825,20 @@
     },
 
     /**
+     * Returns coordinates of a center of canvas.
+     * @return {fabric.Point} 
+     */
+    getCenterPoint: function () {
+      return new fabric.Point(this.height / 2, this.width / 2);
+    },
+
+    /**
      * Centers object horizontally in the canvas
      * @param {fabric.Object} object Object to center horizontally
      * @return {fabric.Canvas} thisArg
      */
     centerObjectH: function (object) {
-      return this._centerObject(object, new fabric.Point(this.getCenter().left, object.getCenterPoint().y));
+      return this._centerObject(object, new fabric.Point(this.getCenterPoint().x, object.getCenterPoint().y));
     },
 
     /**
@@ -839,7 +848,7 @@
      * @chainable
      */
     centerObjectV: function (object) {
-      return this._centerObject(object, new fabric.Point(object.getCenterPoint().x, this.getCenter().top));
+      return this._centerObject(object, new fabric.Point(object.getCenterPoint().x, this.getCenterPoint().y));
     },
 
     /**
@@ -849,9 +858,8 @@
      * @chainable
      */
     centerObject: function(object) {
-      var center = this.getCenter();
-
-      return this._centerObject(object, new fabric.Point(center.left, center.top));
+      var center = this.getCenterPoint();
+      return this._centerObject(object, center);
     },
 
     /**
@@ -862,7 +870,6 @@
      */
     viewportCenterObject: function(object) {
       var vpCenter = this.getVpCenter();
-
       return this._centerObject(object, vpCenter);
     },
 
@@ -896,9 +903,9 @@
      * @chainable
      */
     getVpCenter: function() {
-      var center = this.getCenter(),
+      var center = this.getCenterPoint(),
           iVpt = invertTransform(this.viewportTransform);
-      return transformPoint({ x: center.left, y: center.top }, iVpt);
+      return transformPoint(center, iVpt);
     },
 
     /**

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -829,7 +829,7 @@
      * @return {fabric.Point} 
      */
     getCenterPoint: function () {
-      return new fabric.Point(this.height / 2, this.width / 2);
+      return new fabric.Point(this.width / 2, this.height / 2);
     },
 
     /**

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1286,11 +1286,11 @@
   //     }, 100);
   // });
 
-  QUnit.test('getCenter', function(assert) {
-    assert.ok(typeof canvas.getCenter === 'function');
-    var center = canvas.getCenter();
-    assert.equal(center.left, upperCanvasEl.width / 2);
-    assert.equal(center.top, upperCanvasEl.height / 2);
+  QUnit.test('getCenterPoint', function(assert) {
+    assert.ok(typeof canvas.getCenterPoint === 'function');
+    var center = canvas.getCenterPoint();
+    assert.equal(center.x, upperCanvasEl.width / 2);
+    assert.equal(center.y, upperCanvasEl.height / 2);
   });
 
   QUnit.test('centerObjectH', function(assert) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1286,6 +1286,13 @@
   //     }, 100);
   // });
 
+  QUnit.test('getCenter', function(assert) {
+    assert.ok(typeof canvas.getCenter === 'function');
+    var center = canvas.getCenter();
+    assert.equal(center.left, upperCanvasEl.width / 2);
+    assert.equal(center.top, upperCanvasEl.height / 2);
+  });
+  
   QUnit.test('getCenterPoint', function(assert) {
     assert.ok(typeof canvas.getCenterPoint === 'function');
     var center = canvas.getCenterPoint();


### PR DESCRIPTION
`getCenter` doesn't conform with object's `getCenterPoint` and it should.
This is non breaking, though I think we should remove `getCenter` right away.