### PR TITLE
feat(Object.isType): accept multiple `type`

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1794,7 +1794,7 @@
      * @return {Boolean}
      */
     isType: function(type) {
-      return this.type === type;
+      return arguments.length > 1 ? Array.from(arguments).includes(type) : this.type === type;
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1794,7 +1794,7 @@
      * @return {Boolean}
      */
     isType: function(type) {
-      return arguments.length > 1 ? Array.from(arguments).includes(type) : this.type === type;
+      return arguments.length > 1 ? Array.from(arguments).includes(this.type) : this.type === type;
     },
 
     /**

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -495,6 +495,7 @@
     assert.ok(cObj.isType('rect'));
     assert.ok(!cObj.isType('object'));
     assert.ok(cObj.isType('object', 'rect'));
+    assert.ok(!cObj.isType('object', 'circle'));
   });
 
   QUnit.test('toggle', function(assert) {

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -494,6 +494,7 @@
     cObj = new fabric.Rect();
     assert.ok(cObj.isType('rect'));
     assert.ok(!cObj.isType('object'));
+    assert.ok(cObj.isType('object', 'rect'));
   });
 
   QUnit.test('toggle', function(assert) {


### PR DESCRIPTION
A simple feature testing if an object is one of an array of types
`obj.isType('rect', 'circle')`