### PR TITLE
feat(): `includeDefaultValues` arg

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1237,13 +1237,13 @@
     /**
      * @private
      */
-    _toObject: function(instance, methodName, propertiesToInclude) {
+    _toObject: function(instance, methodName, propertiesToInclude, includeDefaultValues) {
       //If the object is part of the current selection group, it should
       //be transformed appropriately
       //i.e. it should be serialised as it would appear if the selection group
       //were to be destroyed.
       var originalProperties = this._realizeGroupTransformOnObject(instance),
-          object = this.callSuper('_toObject', instance, methodName, propertiesToInclude);
+          object = this.callSuper('_toObject', instance, methodName, propertiesToInclude, includeDefaultValues);
       //Undo the damage we did by changing all of its properties
       this._unwindGroupTransformOnObject(instance, originalProperties);
       return object;

--- a/src/gradient.class.js
+++ b/src/gradient.class.js
@@ -193,10 +193,10 @@
 
     /**
      * Returns object representation of a gradient
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object}
      */
-    toObject: function(propertiesToInclude) {
+    toObject: function(options) {
       var object = {
         type: this.type,
         coords: this.coords,
@@ -206,7 +206,7 @@
         gradientUnits: this.gradientUnits,
         gradientTransform: this.gradientTransform ? this.gradientTransform.concat() : this.gradientTransform
       };
-      fabric.util.populateWithProperties(this, object, propertiesToInclude);
+      fabric.util.populateWithProperties(this, object, options);
 
       return object;
     },

--- a/src/gradient.class.js
+++ b/src/gradient.class.js
@@ -193,10 +193,10 @@
 
     /**
      * Returns object representation of a gradient
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @return {Object}
      */
-    toObject: function(options) {
+    toObject: function(propertiesToInclude) {
       var object = {
         type: this.type,
         coords: this.coords,
@@ -206,7 +206,7 @@
         gradientUnits: this.gradientUnits,
         gradientTransform: this.gradientTransform ? this.gradientTransform.concat() : this.gradientTransform
       };
-      fabric.util.populateWithProperties(this, object, options);
+      fabric.util.populateWithProperties(this, object, propertiesToInclude);
 
       return object;
     },

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -60,7 +60,7 @@
     /**
      * Returns an object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -59,14 +59,14 @@
 
     /**
      * Returns an object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} Object representation of an instance
      */
-    toObject: function (propertiesToInclude, includeDefaultValues) {
-      var object = _toObject.call(this, ['erasable'].concat(propertiesToInclude), includeDefaultValues);
+    toObject: function (options) {
+      var opt = fabric.util.extendSerializationOptions(options, ['erasable']);
+      var object = _toObject.call(this, opt);
       if (this.eraser && !this.eraser.excludeFromExport) {
-        object.eraser = this.eraser.toObject(propertiesToInclude, includeDefaultValues);
+        object.eraser = this.eraser.toObject(opt);
       }
       return object;
     },

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -60,7 +60,7 @@
     /**
      * Returns an object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -60,12 +60,13 @@
     /**
      * Returns an object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} Object representation of an instance
      */
-    toObject: function (propertiesToInclude) {
-      var object = _toObject.call(this, ['erasable'].concat(propertiesToInclude));
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      var object = _toObject.call(this, ['erasable'].concat(propertiesToInclude), includeDefaultValues);
       if (this.eraser && !this.eraser.excludeFromExport) {
-        object.eraser = this.eraser.toObject(propertiesToInclude);
+        object.eraser = this.eraser.toObject(propertiesToInclude, includeDefaultValues);
       }
       return object;
     },

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -59,14 +59,14 @@
 
     /**
      * Returns an object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
-    toObject: function (options) {
-      var opt = fabric.util.extendSerializationOptions(options, ['erasable']);
-      var object = _toObject.call(this, opt);
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      var object = _toObject.call(this, ['erasable'].concat(propertiesToInclude), includeDefaultValues);
       if (this.eraser && !this.eraser.excludeFromExport) {
-        object.eraser = this.eraser.toObject(opt);
+        object.eraser = this.eraser.toObject(propertiesToInclude, includeDefaultValues);
       }
       return object;
     },

--- a/src/pattern.class.js
+++ b/src/pattern.class.js
@@ -67,10 +67,10 @@
 
     /**
      * Returns object representation of a pattern
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} Object representation of a pattern instance
      */
-    toObject: function(propertiesToInclude) {
+    toObject: function(options) {
       var NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
           source, object;
 
@@ -92,7 +92,7 @@
         offsetY: toFixed(this.offsetY, NUM_FRACTION_DIGITS),
         patternTransform: this.patternTransform ? this.patternTransform.concat() : null
       };
-      fabric.util.populateWithProperties(this, object, propertiesToInclude);
+      fabric.util.populateWithProperties(this, object, options);
 
       return object;
     },

--- a/src/pattern.class.js
+++ b/src/pattern.class.js
@@ -67,10 +67,10 @@
 
     /**
      * Returns object representation of a pattern
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @return {Object} Object representation of a pattern instance
      */
-    toObject: function(options) {
+    toObject: function(propertiesToInclude) {
       var NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
           source, object;
 
@@ -92,7 +92,7 @@
         offsetY: toFixed(this.offsetY, NUM_FRACTION_DIGITS),
         patternTransform: this.patternTransform ? this.patternTransform.concat() : null
       };
-      fabric.util.populateWithProperties(this, object, options);
+      fabric.util.populateWithProperties(this, object, propertiesToInclude);
 
       return object;
     },

--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -53,6 +53,13 @@
     affectStroke: false,
 
     /**
+     * Indicates whether toObject should include default values
+     * @type Boolean
+     * @default
+     */
+    includeDefaultValues: true,
+
+    /**
      * When `false`, the shadow will scale with the object.
      * When `true`, the shadow's offsetX, offsetY, and blur will not be affected by the object's scale.
      * default to false
@@ -151,10 +158,11 @@
 
     /**
      * Returns object representation of a shadow
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of a shadow instance
      */
     toObject: function (includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
       if (includeDefaultValues) {
         return {
           color: this.color,

--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -158,13 +158,11 @@
 
     /**
      * Returns object representation of a shadow
-     * @param {Object} [options] serialization options
-     * @param {boolean} [options.includeDefaultValues] include/exclude default values
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of a shadow instance
      */
-    toObject: function (options) {
-      var opt = fabric.util.extendSerializationOptions(options);
-      var includeDefaultValues = opt && typeof opt.includeDefaultValues === 'boolean' ?
+    toObject: function (includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
         includeDefaultValues :
         this.includeDefaultValues;
       if (includeDefaultValues) {

--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -20,6 +20,13 @@
   fabric.Shadow = fabric.util.createClass(/** @lends fabric.Shadow.prototype */ {
 
     /**
+     * @readonly
+     * @default
+     * @type string
+     */
+    type: 'shadow',
+
+    /**
      * Shadow color
      * @type String
      * @default
@@ -61,6 +68,8 @@
      * @default
      */
     nonScaling: false,
+
+    stateProperties: ['color', 'blur', 'offsetX', 'offsetY', 'affectStroke', 'nonScaling'],
 
     /**
      * Constructor
@@ -157,6 +166,7 @@
      */
     toObject: function (includeDefaultValues) {
       var data = {
+        type: this.type,
         color: this.color,
         blur: this.blur,
         offsetX: this.offsetX,
@@ -164,7 +174,7 @@
         affectStroke: this.affectStroke,
         nonScaling: this.nonScaling
       };
-      return includeDefaultValues ? data : removeDefaultValues(data);
+      return includeDefaultValues ? data : removeDefaultValues(data, Object.getPrototypeOf(this));
     }
   });
 

--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -162,7 +162,9 @@
      * @return {Object} Object representation of a shadow instance
      */
     toObject: function (includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       if (includeDefaultValues) {
         return {
           color: this.color,

--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -158,11 +158,13 @@
 
     /**
      * Returns object representation of a shadow
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {Object} [options] serialization options
+     * @param {boolean} [options.includeDefaultValues] include/exclude default values
      * @return {Object} Object representation of a shadow instance
      */
-    toObject: function (includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+    toObject: function (options) {
+      var opt = fabric.util.extendSerializationOptions(options);
+      var includeDefaultValues = opt && typeof opt.includeDefaultValues === 'boolean' ?
         includeDefaultValues :
         this.includeDefaultValues;
       if (includeDefaultValues) {

--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -53,13 +53,6 @@
     affectStroke: false,
 
     /**
-     * Indicates whether toObject should include default values
-     * @type Boolean
-     * @default
-     */
-    includeDefaultValues: true,
-
-    /**
      * When `false`, the shadow will scale with the object.
      * When `true`, the shadow's offsetX, offsetY, and blur will not be affected by the object's scale.
      * default to false
@@ -158,13 +151,10 @@
 
     /**
      * Returns object representation of a shadow
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} Object representation of a shadow instance
      */
     toObject: function (includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
       if (includeDefaultValues) {
         return {
           color: this.color,

--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -53,13 +53,6 @@
     affectStroke: false,
 
     /**
-     * Indicates whether toObject should include default values
-     * @type Boolean
-     * @default
-     */
-    includeDefaultValues: true,
-
-    /**
      * When `false`, the shadow will scale with the object.
      * When `true`, the shadow's offsetX, offsetY, and blur will not be affected by the object's scale.
      * default to false
@@ -158,10 +151,11 @@
 
     /**
      * Returns object representation of a shadow
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} Object representation of a shadow instance
      */
-    toObject: function() {
-      if (this.includeDefaultValues) {
+    toObject: function (includeDefaultValues) {
+      if (includeDefaultValues) {
         return {
           color: this.color,
           blur: this.blur,

--- a/src/shadow.class.js
+++ b/src/shadow.class.js
@@ -3,7 +3,8 @@
   'use strict';
 
   var fabric = global.fabric || (global.fabric = { }),
-      toFixed = fabric.util.toFixed;
+      toFixed = fabric.util.toFixed,
+      removeDefaultValues = fabric.util.removeDefaultValues;
 
   if (fabric.Shadow) {
     fabric.warn('fabric.Shadow is already defined.');
@@ -155,25 +156,15 @@
      * @return {Object} Object representation of a shadow instance
      */
     toObject: function (includeDefaultValues) {
-      if (includeDefaultValues) {
-        return {
-          color: this.color,
-          blur: this.blur,
-          offsetX: this.offsetX,
-          offsetY: this.offsetY,
-          affectStroke: this.affectStroke,
-          nonScaling: this.nonScaling
-        };
-      }
-      var obj = { }, proto = fabric.Shadow.prototype;
-
-      ['color', 'blur', 'offsetX', 'offsetY', 'affectStroke', 'nonScaling'].forEach(function(prop) {
-        if (this[prop] !== proto[prop]) {
-          obj[prop] = this[prop];
-        }
-      }, this);
-
-      return obj;
+      var data = {
+        color: this.color,
+        blur: this.blur,
+        offsetX: this.offsetX,
+        offsetY: this.offsetY,
+        affectStroke: this.affectStroke,
+        nonScaling: this.nonScaling
+      };
+      return includeDefaultValues ? data : removeDefaultValues(data);
     }
   });
 

--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -73,7 +73,11 @@
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
-      return this.callSuper('toObject', ['radius', 'startAngle', 'endAngle'].concat(propertiesToInclude), includeDefaultValues);
+      return this.callSuper(
+        'toObject',
+        ['radius', 'startAngle', 'endAngle'].concat(propertiesToInclude),
+        includeDefaultValues
+      );
     },
 
     /* _TO_SVG_START_ */

--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -68,12 +68,16 @@
 
     /**
      * Returns object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
-    toObject: function (options) {
-      var opt = fabric.util.extendSerializationOptions(options, ['radius', 'startAngle', 'endAngle']);
-      return this.callSuper('toObject', opt);
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return this.callSuper(
+        'toObject',
+        ['radius', 'startAngle', 'endAngle'].concat(propertiesToInclude),
+        includeDefaultValues
+      );
     },
 
     /* _TO_SVG_START_ */

--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -68,16 +68,12 @@
 
     /**
      * Returns object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
-    toObject: function (propertiesToInclude, includeDefaultValues) {
-      return this.callSuper(
-        'toObject',
-        ['radius', 'startAngle', 'endAngle'].concat(propertiesToInclude),
-        includeDefaultValues
-      );
+    toObject: function (options) {
+      var opt = fabric.util.extendSerializationOptions(options, ['radius', 'startAngle', 'endAngle']);
+      return this.callSuper('toObject', opt);
     },
 
     /* _TO_SVG_START_ */

--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -69,7 +69,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -69,7 +69,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/circle.class.js
+++ b/src/shapes/circle.class.js
@@ -69,10 +69,11 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
-      return this.callSuper('toObject', ['radius', 'startAngle', 'endAngle'].concat(propertiesToInclude));
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return this.callSuper('toObject', ['radius', 'startAngle', 'endAngle'].concat(propertiesToInclude), includeDefaultValues);
     },
 
     /* _TO_SVG_START_ */

--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -95,12 +95,12 @@
 
     /**
      * Returns object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
-    toObject: function (propertiesToInclude, includeDefaultValues) {
-      return this.callSuper('toObject', ['rx', 'ry'].concat(propertiesToInclude), includeDefaultValues);
+    toObject: function (options) {
+      var opt = fabric.util.extendSerializationOptions(options, ['rx', 'ry']);
+      return this.callSuper('toObject', opt);
     },
 
     /* _TO_SVG_START_ */

--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -96,7 +96,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -96,7 +96,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -95,12 +95,12 @@
 
     /**
      * Returns object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
-    toObject: function (options) {
-      var opt = fabric.util.extendSerializationOptions(options, ['rx', 'ry']);
-      return this.callSuper('toObject', opt);
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return this.callSuper('toObject', ['rx', 'ry'].concat(propertiesToInclude), includeDefaultValues);
     },
 
     /* _TO_SVG_START_ */

--- a/src/shapes/ellipse.class.js
+++ b/src/shapes/ellipse.class.js
@@ -96,10 +96,11 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
-      return this.callSuper('toObject', ['rx', 'ry'].concat(propertiesToInclude));
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return this.callSuper('toObject', ['rx', 'ry'].concat(propertiesToInclude), includeDefaultValues);
     },
 
     /* _TO_SVG_START_ */

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -236,13 +236,10 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
       var objsToObject = this._objects
         .filter(function (obj) {
           return !obj.excludeFromExport;
@@ -258,13 +255,10 @@
     /**
      * Returns object representation of an instance, in dataless mode.
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
       var objsToObject, sourcePath = this.sourcePath;
       if (sourcePath) {
         objsToObject = sourcePath;

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -235,28 +235,36 @@
 
     /**
      * Returns object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
-    toObject: function (options) {
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       var objsToObject = this._objects
         .filter(function (obj) {
           return !obj.excludeFromExport;
         })
         .map(function (obj) {
-          return obj.toObject(options);
+          return obj.toObject(propertiesToInclude, includeDefaultValues);
         });
-      var obj = fabric.Object.prototype.toObject.call(this, options);
+      var obj = fabric.Object.prototype.toObject.call(this, propertiesToInclude, includeDefaultValues);
       obj.objects = objsToObject;
       return obj;
     },
 
     /**
      * Returns object representation of an instance, in dataless mode.
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
-    toDatalessObject: function (options) {
+    toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       var objsToObject, sourcePath = this.sourcePath;
       if (sourcePath) {
         objsToObject = sourcePath;
@@ -267,10 +275,10 @@
             return !obj.excludeFromExport;
           })
           .map(function (obj) {
-            return obj.toDatalessObject(options);
+            return obj.toDatalessObject(propertiesToInclude, includeDefaultValues);
           });
       }
-      var obj = fabric.Object.prototype.toDatalessObject.call(this, options);
+      var obj = fabric.Object.prototype.toDatalessObject.call(this, propertiesToInclude, includeDefaultValues);
       obj.objects = objsToObject;
       return obj;
     },

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -240,7 +240,9 @@
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       var objsToObject = this._objects
         .filter(function (obj) {
           return !obj.excludeFromExport;
@@ -260,7 +262,9 @@
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       var objsToObject, sourcePath = this.sourcePath;
       if (sourcePath) {
         objsToObject = sourcePath;

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -235,36 +235,28 @@
 
     /**
      * Returns object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
-    toObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
+    toObject: function (options) {
       var objsToObject = this._objects
         .filter(function (obj) {
           return !obj.excludeFromExport;
         })
         .map(function (obj) {
-          return obj.toObject(propertiesToInclude, includeDefaultValues);
+          return obj.toObject(options);
         });
-      var obj = fabric.Object.prototype.toObject.call(this, propertiesToInclude, includeDefaultValues);
+      var obj = fabric.Object.prototype.toObject.call(this, options);
       obj.objects = objsToObject;
       return obj;
     },
 
     /**
      * Returns object representation of an instance, in dataless mode.
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
-    toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
+    toDatalessObject: function (options) {
       var objsToObject, sourcePath = this.sourcePath;
       if (sourcePath) {
         objsToObject = sourcePath;
@@ -275,10 +267,10 @@
             return !obj.excludeFromExport;
           })
           .map(function (obj) {
-            return obj.toDatalessObject(propertiesToInclude, includeDefaultValues);
+            return obj.toDatalessObject(options);
           });
       }
-      var obj = fabric.Object.prototype.toDatalessObject.call(this, propertiesToInclude, includeDefaultValues);
+      var obj = fabric.Object.prototype.toDatalessObject.call(this, options);
       obj.objects = objsToObject;
       return obj;
     },

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -236,22 +236,18 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
-      var _includeDefaultValues = this.includeDefaultValues;
+    toObject: function (propertiesToInclude, includeDefaultValues) {
       var objsToObject = this._objects
         .filter(function (obj) {
           return !obj.excludeFromExport;
         })
         .map(function (obj) {
-          var originalDefaults = obj.includeDefaultValues;
-          obj.includeDefaultValues = _includeDefaultValues;
-          var _obj = obj.toObject(propertiesToInclude);
-          obj.includeDefaultValues = originalDefaults;
-          return _obj;
+          return obj.toObject(propertiesToInclude, includeDefaultValues);
         });
-      var obj = fabric.Object.prototype.toObject.call(this, propertiesToInclude);
+      var obj = fabric.Object.prototype.toObject.call(this, propertiesToInclude, includeDefaultValues);
       obj.objects = objsToObject;
       return obj;
     },
@@ -259,24 +255,24 @@
     /**
      * Returns object representation of an instance, in dataless mode.
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toDatalessObject: function(propertiesToInclude) {
+    toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
       var objsToObject, sourcePath = this.sourcePath;
       if (sourcePath) {
         objsToObject = sourcePath;
       }
       else {
-        var _includeDefaultValues = this.includeDefaultValues;
-        objsToObject = this._objects.map(function(obj) {
-          var originalDefaults = obj.includeDefaultValues;
-          obj.includeDefaultValues = _includeDefaultValues;
-          var _obj = obj.toDatalessObject(propertiesToInclude);
-          obj.includeDefaultValues = originalDefaults;
-          return _obj;
-        });
+        objsToObject = this._objects
+          .filter(function (obj) {
+            return !obj.excludeFromExport;
+          })
+          .map(function (obj) {
+            return obj.toDatalessObject(propertiesToInclude, includeDefaultValues);
+          });
       }
-      var obj = fabric.Object.prototype.toDatalessObject.call(this, propertiesToInclude);
+      var obj = fabric.Object.prototype.toDatalessObject.call(this, propertiesToInclude, includeDefaultValues);
       obj.objects = objsToObject;
       return obj;
     },

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -236,10 +236,11 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
       var objsToObject = this._objects
         .filter(function (obj) {
           return !obj.excludeFromExport;
@@ -255,10 +256,11 @@
     /**
      * Returns object representation of an instance, in dataless mode.
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
       var objsToObject, sourcePath = this.sourcePath;
       if (sourcePath) {
         objsToObject = sourcePath;

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -251,8 +251,7 @@
 
     /**
      * Returns object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -252,7 +252,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -252,9 +252,10 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} Object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
+    toObject: function (propertiesToInclude, includeDefaultValues) {
       var filters = [];
 
       this.filters.forEach(function(filterObj) {
@@ -265,7 +266,8 @@
       var object = extend(
         this.callSuper(
           'toObject',
-          ['cropX', 'cropY'].concat(propertiesToInclude)
+          ['cropX', 'cropY'].concat(propertiesToInclude),
+          includeDefaultValues
         ), {
           src: this.getSrc(),
           crossOrigin: this.getCrossOrigin(),

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -252,7 +252,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -251,7 +251,8 @@
 
     /**
      * Returns object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -186,7 +186,7 @@
      * Returns object representation of an instance
      * @method toObject
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -185,7 +185,8 @@
     /**
      * Returns object representation of an instance
      * @method toObject
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -185,8 +185,7 @@
     /**
      * Returns object representation of an instance
      * @method toObject
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -186,7 +186,7 @@
      * Returns object representation of an instance
      * @method toObject
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/line.class.js
+++ b/src/shapes/line.class.js
@@ -186,10 +186,11 @@
      * Returns object representation of an instance
      * @method toObject
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
-      return extend(this.callSuper('toObject', propertiesToInclude), this.calcLinePoints());
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return extend(this.callSuper('toObject', propertiesToInclude, includeDefaultValues), this.calcLinePoints());
     },
 
     /*

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -8,6 +8,7 @@
       toFixed = fabric.util.toFixed,
       capitalize = fabric.util.string.capitalize,
       degreesToRadians = fabric.util.degreesToRadians,
+      removeDefaultValues = fabric.util.removeDefaultValues,
       objectCaching = !fabric.isLikelyNode,
       ALIASING_LIMIT = 2;
 
@@ -875,9 +876,7 @@
 
       fabric.util.populateWithProperties(this, object, propertiesToInclude);
 
-      return includeDefaultValues ?
-        object :
-        this._removeDefaultValues(object);
+      return includeDefaultValues ? object : removeDefaultValues(object);
     },
 
     /**
@@ -900,30 +899,6 @@
     toJSON: function (propertiesToInclude, includeDefaultValues) {
       // delegate, not alias
       return this.toObject(propertiesToInclude, includeDefaultValues);
-    },
-
-    /**
-     * @private
-     * @param {Object} object
-     */
-    _removeDefaultValues: function(object) {
-      var prototype = fabric.util.getKlass(object.type).prototype,
-          stateProperties = prototype.stateProperties;
-      stateProperties.forEach(function(prop) {
-        if (prop === 'left' || prop === 'top') {
-          return;
-        }
-        if (object[prop] === prototype[prop]) {
-          delete object[prop];
-        }
-        // basically a check for [] === []
-        if (Array.isArray(object[prop]) && Array.isArray(prototype[prop])
-          && object[prop].length === 0 && prototype[prop].length === 0) {
-          delete object[prop];
-        }
-      });
-
-      return object;
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1677,7 +1677,7 @@
      * @returns {Promise<fabric.Object>}
      */
     clone: function(propertiesToInclude) {
-      var objectForm = this.toObject(propertiesToInclude, false);
+      var objectForm = this.toObject(propertiesToInclude);
       return this.constructor.fromObject(objectForm);
     },
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -911,7 +911,7 @@
 
     /**
      * Return the object scale factor counting also the group scaling
-     * @return {fabric.Point} 
+     * @return {fabric.Point}
      */
     getObjectScaling: function() {
       // if the object is a top level one, on the canvas, we go for simple aritmetic

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -830,7 +830,8 @@
 
     /**
      * Returns an object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
@@ -891,7 +892,8 @@
 
     /**
      * Returns (dataless) object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
@@ -901,7 +903,8 @@
 
     /**
      * Returns a JSON representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} JSON
      */
     toJSON: function (propertiesToInclude, includeDefaultValues) {
@@ -1659,6 +1662,7 @@
 
     /**
      * Clones an instance.
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @returns {Promise<fabric.Object>}
      */
     clone: function(propertiesToInclude) {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -830,8 +830,7 @@
 
     /**
      * Returns an object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
@@ -892,8 +891,7 @@
 
     /**
      * Returns (dataless) object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} Object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
@@ -903,8 +901,7 @@
 
     /**
      * Returns a JSON representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} JSON
      */
     toJSON: function (propertiesToInclude, includeDefaultValues) {
@@ -1673,7 +1670,6 @@
 
     /**
      * Clones an instance.
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @returns {Promise<fabric.Object>}
      */
     clone: function(propertiesToInclude) {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1630,8 +1630,9 @@
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @returns {Promise<fabric.Object>}
      */
-    clone: function(propertiesToInclude) {
-      var objectForm = this.toObject(propertiesToInclude);
+    clone: function (propertiesToInclude) {
+      //  for performance we set `includeDefaultValues` to true to reduce computation
+      var objectForm = this.toObject(propertiesToInclude, true);
       return this.constructor.fromObject(objectForm);
     },
 

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -428,6 +428,13 @@
      * @default
      */
     perPixelTargetFind:       false,
+    
+    /**
+     * When `false`, default object's values are not included in its serialization
+     * @type Boolean
+     * @default
+     */
+    includeDefaultValues:     true,
 
     /**
      * When `true`, object horizontal movement is locked
@@ -824,10 +831,11 @@
     /**
      * Returns an object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
       var NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
 
           object = {
@@ -880,7 +888,7 @@
     /**
      * Returns (dataless) object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
@@ -891,7 +899,7 @@
     /**
      * Returns a JSON representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} JSON
      */
     toJSON: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -835,7 +835,9 @@
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       var NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
 
           object = {
@@ -847,8 +849,10 @@
             top:                      toFixed(this.top, NUM_FRACTION_DIGITS),
             width:                    toFixed(this.width, NUM_FRACTION_DIGITS),
             height:                   toFixed(this.height, NUM_FRACTION_DIGITS),
-            fill:                     (this.fill && this.fill.toObject) ? this.fill.toObject(includeDefaultValues) : this.fill,
-            stroke:                   (this.stroke && this.stroke.toObject) ? this.stroke.toObject(includeDefaultValues) : this.stroke,
+            fill:                     (this.fill && this.fill.toObject) ?
+              this.fill.toObject(includeDefaultValues) : this.fill,
+            stroke:                   (this.stroke && this.stroke.toObject) ?
+              this.stroke.toObject(includeDefaultValues) : this.stroke,
             strokeWidth:              toFixed(this.strokeWidth, NUM_FRACTION_DIGITS),
             strokeDashArray:          this.strokeDashArray ? this.strokeDashArray.concat() : this.strokeDashArray,
             strokeLineCap:            this.strokeLineCap,
@@ -862,7 +866,8 @@
             flipX:                    this.flipX,
             flipY:                    this.flipY,
             opacity:                  toFixed(this.opacity, NUM_FRACTION_DIGITS),
-            shadow:                   (this.shadow && this.shadow.toObject) ? this.shadow.toObject(includeDefaultValues) : this.shadow,
+            shadow:                   (this.shadow && this.shadow.toObject) ?
+              this.shadow.toObject(includeDefaultValues) : this.shadow,
             visible:                  this.visible,
             backgroundColor:          this.backgroundColor,
             fillRule:                 this.fillRule,

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -428,7 +428,7 @@
      * @default
      */
     perPixelTargetFind:       false,
-    
+
     /**
      * When `false`, default object's values are not included in its serialization
      * @type Boolean

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -430,13 +430,6 @@
     perPixelTargetFind:       false,
 
     /**
-     * When `false`, default object's values are not included in its serialization
-     * @type Boolean
-     * @default
-     */
-    includeDefaultValues:     true,
-
-    /**
      * When `true`, object horizontal movement is locked
      * @type Boolean
      * @default
@@ -831,13 +824,10 @@
     /**
      * Returns an object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
       var NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
 
           object = {
@@ -850,9 +840,9 @@
             width:                    toFixed(this.width, NUM_FRACTION_DIGITS),
             height:                   toFixed(this.height, NUM_FRACTION_DIGITS),
             fill:                     (this.fill && this.fill.toObject) ?
-              this.fill.toObject(includeDefaultValues) : this.fill,
+              this.fill.toObject(propertiesToInclude, includeDefaultValues) : this.fill,
             stroke:                   (this.stroke && this.stroke.toObject) ?
-              this.stroke.toObject(includeDefaultValues) : this.stroke,
+              this.stroke.toObject(propertiesToInclude, includeDefaultValues) : this.stroke,
             strokeWidth:              toFixed(this.strokeWidth, NUM_FRACTION_DIGITS),
             strokeDashArray:          this.strokeDashArray ? this.strokeDashArray.concat() : this.strokeDashArray,
             strokeLineCap:            this.strokeLineCap,
@@ -893,7 +883,7 @@
     /**
      * Returns (dataless) object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
@@ -904,7 +894,7 @@
     /**
      * Returns a JSON representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} JSON
      */
     toJSON: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -430,13 +430,6 @@
     perPixelTargetFind:       false,
 
     /**
-     * When `false`, default object's values are not included in its serialization
-     * @type Boolean
-     * @default
-     */
-    includeDefaultValues:     true,
-
-    /**
      * When `true`, object horizontal movement is locked
      * @type Boolean
      * @default
@@ -831,9 +824,10 @@
     /**
      * Returns an object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} Object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
+    toObject: function (propertiesToInclude, includeDefaultValues) {
       var NUM_FRACTION_DIGITS = fabric.Object.NUM_FRACTION_DIGITS,
 
           object = {
@@ -845,8 +839,8 @@
             top:                      toFixed(this.top, NUM_FRACTION_DIGITS),
             width:                    toFixed(this.width, NUM_FRACTION_DIGITS),
             height:                   toFixed(this.height, NUM_FRACTION_DIGITS),
-            fill:                     (this.fill && this.fill.toObject) ? this.fill.toObject() : this.fill,
-            stroke:                   (this.stroke && this.stroke.toObject) ? this.stroke.toObject() : this.stroke,
+            fill:                     (this.fill && this.fill.toObject) ? this.fill.toObject(includeDefaultValues) : this.fill,
+            stroke:                   (this.stroke && this.stroke.toObject) ? this.stroke.toObject(includeDefaultValues) : this.stroke,
             strokeWidth:              toFixed(this.strokeWidth, NUM_FRACTION_DIGITS),
             strokeDashArray:          this.strokeDashArray ? this.strokeDashArray.concat() : this.strokeDashArray,
             strokeLineCap:            this.strokeLineCap,
@@ -860,7 +854,7 @@
             flipX:                    this.flipX,
             flipY:                    this.flipY,
             opacity:                  toFixed(this.opacity, NUM_FRACTION_DIGITS),
-            shadow:                   (this.shadow && this.shadow.toObject) ? this.shadow.toObject() : this.shadow,
+            shadow:                   (this.shadow && this.shadow.toObject) ? this.shadow.toObject(includeDefaultValues) : this.shadow,
             visible:                  this.visible,
             backgroundColor:          this.backgroundColor,
             fillRule:                 this.fillRule,
@@ -871,27 +865,38 @@
           };
 
       if (this.clipPath && !this.clipPath.excludeFromExport) {
-        object.clipPath = this.clipPath.toObject(propertiesToInclude);
+        object.clipPath = this.clipPath.toObject(propertiesToInclude, includeDefaultValues);
         object.clipPath.inverted = this.clipPath.inverted;
         object.clipPath.absolutePositioned = this.clipPath.absolutePositioned;
       }
 
       fabric.util.populateWithProperties(this, object, propertiesToInclude);
-      if (!this.includeDefaultValues) {
-        object = this._removeDefaultValues(object);
-      }
 
-      return object;
+      return includeDefaultValues ?
+        this._removeDefaultValues(object) :
+        object;
     },
 
     /**
      * Returns (dataless) object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} Object representation of an instance
      */
-    toDatalessObject: function(propertiesToInclude) {
+    toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
       // will be overwritten by subclasses
-      return this.toObject(propertiesToInclude);
+      return this.toObject(propertiesToInclude, includeDefaultValues);
+    },
+
+    /**
+     * Returns a JSON representation of an instance
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @return {Object} JSON
+     */
+    toJSON: function (propertiesToInclude, includeDefaultValues) {
+      // delegate, not alias
+      return this.toObject(propertiesToInclude, includeDefaultValues);
     },
 
     /**
@@ -1659,7 +1664,7 @@
      * @returns {Promise<fabric.Object>}
      */
     clone: function(propertiesToInclude) {
-      var objectForm = this.toObject(propertiesToInclude);
+      var objectForm = this.toObject(propertiesToInclude, false);
       return this.constructor.fromObject(objectForm);
     },
 
@@ -1803,16 +1808,6 @@
      */
     complexity: function() {
       return 1;
-    },
-
-    /**
-     * Returns a JSON representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @return {Object} JSON
-     */
-    toJSON: function(propertiesToInclude) {
-      // delegate, not alias
-      return this.toObject(propertiesToInclude);
     },
 
     /**

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -886,8 +886,8 @@
       fabric.util.populateWithProperties(this, object, propertiesToInclude);
 
       return includeDefaultValues ?
-        this._removeDefaultValues(object) :
-        object;
+        object :
+        this._removeDefaultValues(object);
     },
 
     /**

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -166,7 +166,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
@@ -178,7 +178,7 @@
     /**
      * Returns dataless object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -166,10 +166,11 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
-      return extend(this.callSuper('toObject', propertiesToInclude), {
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return extend(this.callSuper('toObject', propertiesToInclude, includeDefaultValues), {
         path: this.path.map(function(item) { return item.slice(); }),
       });
     },
@@ -177,10 +178,11 @@
     /**
      * Returns dataless object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toDatalessObject: function(propertiesToInclude) {
-      var o = this.toObject(['sourcePath'].concat(propertiesToInclude));
+    toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
+      var o = this.toObject(['sourcePath'].concat(propertiesToInclude), includeDefaultValues);
       if (o.sourcePath) {
         delete o.path;
       }

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -162,7 +162,8 @@
 
     /**
      * Returns object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
@@ -173,7 +174,8 @@
 
     /**
      * Returns dataless object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -165,8 +165,7 @@
 
     /**
      * Returns object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
@@ -177,8 +176,7 @@
 
     /**
      * Returns dataless object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/path.class.js
+++ b/src/shapes/path.class.js
@@ -163,7 +163,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
@@ -175,7 +175,7 @@
     /**
      * Returns dataless object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -142,8 +142,7 @@
 
     /**
      * Returns object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -143,10 +143,11 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} Object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
-      return extend(this.callSuper('toObject', propertiesToInclude), {
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return extend(this.callSuper('toObject', propertiesToInclude, includeDefaultValues), {
         points: this.points.concat()
       });
     },

--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -142,7 +142,8 @@
 
     /**
      * Returns object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -143,7 +143,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -143,7 +143,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -113,8 +113,7 @@
 
     /**
      * Returns object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -114,10 +114,11 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
-      return this.callSuper('toObject', ['rx', 'ry'].concat(propertiesToInclude));
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return this.callSuper('toObject', ['rx', 'ry'].concat(propertiesToInclude), includeDefaultValues);
     },
 
     /* _TO_SVG_START_ */

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -114,7 +114,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -113,7 +113,8 @@
 
     /**
      * Returns object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -114,7 +114,7 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1533,10 +1533,11 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
       var allProperties = additionalProps.concat(propertiesToInclude);
       var obj = this.callSuper('toObject', allProperties, includeDefaultValues);
       // styles will be overridden with a properly cloned structure

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1545,7 +1545,7 @@
       // styles will be overridden with a properly cloned structure
       obj.styles = clone(this.styles, true);
       if (obj.path) {
-        obj.path = this.path.toObject(includeDefaultValues);
+        obj.path = this.path.toObject(propertiesToInclude, includeDefaultValues);
       }
       return obj;
     },

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1533,15 +1533,16 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} Object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
+    toObject: function (propertiesToInclude, includeDefaultValues) {
       var allProperties = additionalProps.concat(propertiesToInclude);
-      var obj = this.callSuper('toObject', allProperties);
+      var obj = this.callSuper('toObject', allProperties, includeDefaultValues);
       // styles will be overridden with a properly cloned structure
       obj.styles = clone(this.styles, true);
       if (obj.path) {
-        obj.path = this.path.toObject();
+        obj.path = this.path.toObject(includeDefaultValues);
       }
       return obj;
     },

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1532,7 +1532,8 @@
 
     /**
      * Returns object representation of an instance
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1532,8 +1532,7 @@
 
     /**
      * Returns object representation of an instance
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1537,7 +1537,9 @@
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       var allProperties = additionalProps.concat(propertiesToInclude);
       var obj = this.callSuper('toObject', allProperties, includeDefaultValues);
       // styles will be overridden with a properly cloned structure

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1533,13 +1533,10 @@
     /**
      * Returns object representation of an instance
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} Object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
       var allProperties = additionalProps.concat(propertiesToInclude);
       var obj = this.callSuper('toObject', allProperties, includeDefaultValues);
       // styles will be overridden with a properly cloned structure

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -437,8 +437,7 @@
     /**
      * Returns object representation of an instance
      * @method toObject
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -442,7 +442,11 @@
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
-      return this.callSuper('toObject', ['minWidth', 'splitByGrapheme'].concat(propertiesToInclude), includeDefaultValues);
+      return this.callSuper(
+        'toObject',
+        ['minWidth', 'splitByGrapheme'].concat(propertiesToInclude),
+        includeDefaultValues
+      );
     }
   });
 

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -438,7 +438,7 @@
      * Returns object representation of an instance
      * @method toObject
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -438,10 +438,11 @@
      * Returns object representation of an instance
      * @method toObject
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toObject: function(propertiesToInclude) {
-      return this.callSuper('toObject', ['minWidth', 'splitByGrapheme'].concat(propertiesToInclude));
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return this.callSuper('toObject', ['minWidth', 'splitByGrapheme'].concat(propertiesToInclude), includeDefaultValues);
     }
   });
 

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -438,7 +438,7 @@
      * Returns object representation of an instance
      * @method toObject
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -437,7 +437,8 @@
     /**
      * Returns object representation of an instance
      * @method toObject
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -924,20 +924,22 @@
 
     /**
      * Returns object representation of canvas
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
-    toObject: function (options) {
-      return this._toObjectMethod('toObject', options);
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return this._toObjectMethod('toObject', propertiesToInclude, includeDefaultValues);
     },
 
     /**
      * Returns dataless object representation of canvas
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
-    toDatalessObject: function (options) {
-      return this._toObjectMethod('toDatalessObject', options);
+    toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
+      return this._toObjectMethod('toDatalessObject', propertiesToInclude, includeDefaultValues);
     },
 
     /**
@@ -946,6 +948,7 @@
      * the toJSON object will be invoked if it exists.
      * Having a toJSON method means you can do JSON.stringify(myCanvas)
      * @function
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @return {Object} JSON compatible object
      * @tutorial {@link http://fabricjs.com/fabric-intro-part-3#serialization}
      * @see {@link http://jsfiddle.net/fabricjs/pec86/|jsFiddle demo}
@@ -956,34 +959,38 @@
      * @example <caption>JSON with default values</caption>
      * var json = canvas.toJSON(true);
      */
-    toJSON: function (options) {
-      return this.toObject(options);
+    toJSON: function (propertiesToInclude, includeDefaultValues) {
+      return this.toObject(propertiesToInclude, includeDefaultValues);
     },
 
     /**
      * Returns dataless JSON representation of canvas
-     * @param {fabric.util.SerializationOptions} [options] serialization options
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {String} json string
      */
-    toDatalessJSON: function (options) {
-      return this.toDatalessObject(options);
+    toDatalessJSON: function (propertiesToInclude, includeDefaultValues) {
+      return this.toDatalessObject(propertiesToInclude, includeDefaultValues);
     },
 
 
     /**
      * @private
      */
-    _toObjectMethod: function (methodName, options) {
+    _toObjectMethod: function (methodName, propertiesToInclude, includeDefaultValues) {
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       var clipPath = this.clipPath, data = {
         version: fabric.version,
-        objects: this._toObjects(methodName, options),
+        objects: this._toObjects(methodName, propertiesToInclude, includeDefaultValues),
       };
       if (clipPath && !clipPath.excludeFromExport) {
-        data.clipPath = this._toObject(this.clipPath, methodName, options);
+        data.clipPath = this._toObject(this.clipPath, methodName, propertiesToInclude, includeDefaultValues);
       }
-      extend(data, this.__serializeBgOverlay(methodName, options));
+      extend(data, this.__serializeBgOverlay(methodName, propertiesToInclude, includeDefaultValues));
 
-      fabric.util.populateWithProperties(this, data, options);
+      fabric.util.populateWithProperties(this, data, propertiesToInclude);
 
       return data;
     },
@@ -991,31 +998,31 @@
     /**
      * @private
      */
-    _toObjects: function (methodName, options) {
+    _toObjects: function (methodName, propertiesToInclude, includeDefaultValues) {
       return this._objects.filter(function(object) {
         return !object.excludeFromExport;
       }).map(function(instance) {
-        return this._toObject(instance, methodName, options);
+        return this._toObject(instance, methodName, propertiesToInclude, includeDefaultValues);
       }, this);
     },
 
     /**
      * @private
      */
-    _toObject: function (instance, methodName, options) {
-      return instance[methodName](options);
+    _toObject: function (instance, methodName, propertiesToInclude, includeDefaultValues) {
+      return instance[methodName](propertiesToInclude, includeDefaultValues);
     },
 
     /**
      * @private
      */
-    __serializeBgOverlay: function (methodName, options) {
+    __serializeBgOverlay: function (methodName, propertiesToInclude, includeDefaultValues) {
       var data = {}, bgImage = this.backgroundImage, overlayImage = this.overlayImage,
           bgColor = this.backgroundColor, overlayColor = this.overlayColor;
 
       if (bgColor && bgColor.toObject) {
         if (!bgColor.excludeFromExport) {
-          data.background = bgColor.toObject(options);
+          data.background = bgColor.toObject(propertiesToInclude, includeDefaultValues);
         }
       }
       else if (bgColor) {
@@ -1024,7 +1031,7 @@
 
       if (overlayColor && overlayColor.toObject) {
         if (!overlayColor.excludeFromExport) {
-          data.overlay = overlayColor.toObject(options);
+          data.overlay = overlayColor.toObject(propertiesToInclude, includeDefaultValues);
         }
       }
       else if (overlayColor) {
@@ -1032,10 +1039,10 @@
       }
 
       if (bgImage && !bgImage.excludeFromExport) {
-        data.backgroundImage = this._toObject(bgImage, methodName, options);
+        data.backgroundImage = this._toObject(bgImage, methodName, propertiesToInclude, includeDefaultValues);
       }
       if (overlayImage && !overlayImage.excludeFromExport) {
-        data.overlayImage = this._toObject(overlayImage, methodName, options);
+        data.overlayImage = this._toObject(overlayImage, methodName, propertiesToInclude, includeDefaultValues);
       }
 
       return data;

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -826,7 +826,7 @@
 
     /**
      * Returns coordinates of a center of canvas.
-     * @return {fabric.Point} 
+     * @return {fabric.Point}
      */
     getCenterPoint: function () {
       return new fabric.Point(this.width / 2, this.height / 2);

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -83,14 +83,6 @@
     overlayImage: null,
 
     /**
-     * Indicates whether toObject/toDatalessObject should include default values
-     * if set to false, takes precedence over the object value.
-     * @type Boolean
-     * @default
-     */
-    includeDefaultValues: true,
-
-    /**
      * Indicates whether objects' state should be saved
      * @type Boolean
      * @default
@@ -925,7 +917,7 @@
     /**
      * Returns object representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
@@ -935,7 +927,7 @@
     /**
      * Returns dataless object representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
@@ -966,7 +958,7 @@
     /**
      * Returns dataless JSON representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {boolean} [includeDefaultValues] include/exclude default values
      * @return {String} json string
      */
     toDatalessJSON: function (propertiesToInclude, includeDefaultValues) {
@@ -978,9 +970,6 @@
      * @private
      */
     _toObjectMethod: function (methodName, propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
       var clipPath = this.clipPath, data = {
         version: fabric.version,
         objects: this._toObjects(methodName, propertiesToInclude, includeDefaultValues),

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -83,14 +83,6 @@
     overlayImage: null,
 
     /**
-     * Indicates whether toObject/toDatalessObject should include default values
-     * if set to false, takes precedence over the object value.
-     * @type Boolean
-     * @default
-     */
-    includeDefaultValues: true,
-
-    /**
      * Indicates whether objects' state should be saved
      * @type Boolean
      * @default
@@ -925,43 +917,46 @@
     /**
      * Returns dataless JSON representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {String} json string
      */
-    toDatalessJSON: function (propertiesToInclude) {
-      return this.toDatalessObject(propertiesToInclude);
+    toDatalessJSON: function (propertiesToInclude, includeDefaultValues) {
+      return this.toDatalessObject(propertiesToInclude, includeDefaultValues);
     },
 
     /**
      * Returns object representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toObject: function (propertiesToInclude) {
-      return this._toObjectMethod('toObject', propertiesToInclude);
+    toObject: function (propertiesToInclude, includeDefaultValues) {
+      return this._toObjectMethod('toObject', propertiesToInclude, includeDefaultValues);
     },
 
     /**
      * Returns dataless object representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] default values are not included in serialization
      * @return {Object} object representation of an instance
      */
-    toDatalessObject: function (propertiesToInclude) {
-      return this._toObjectMethod('toDatalessObject', propertiesToInclude);
+    toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
+      return this._toObjectMethod('toDatalessObject', propertiesToInclude, includeDefaultValues);
     },
 
     /**
      * @private
      */
-    _toObjectMethod: function (methodName, propertiesToInclude) {
+    _toObjectMethod: function (methodName, propertiesToInclude, includeDefaultValues) {
 
       var clipPath = this.clipPath, data = {
         version: fabric.version,
-        objects: this._toObjects(methodName, propertiesToInclude),
+        objects: this._toObjects(methodName, propertiesToInclude, includeDefaultValues),
       };
       if (clipPath && !clipPath.excludeFromExport) {
-        data.clipPath = this._toObject(this.clipPath, methodName, propertiesToInclude);
+        data.clipPath = this._toObject(this.clipPath, methodName, propertiesToInclude, includeDefaultValues);
       }
-      extend(data, this.__serializeBgOverlay(methodName, propertiesToInclude));
+      extend(data, this.__serializeBgOverlay(methodName, propertiesToInclude, includeDefaultValues));
 
       fabric.util.populateWithProperties(this, data, propertiesToInclude);
 
@@ -971,42 +966,31 @@
     /**
      * @private
      */
-    _toObjects: function(methodName, propertiesToInclude) {
+    _toObjects: function (methodName, propertiesToInclude, includeDefaultValues) {
       return this._objects.filter(function(object) {
         return !object.excludeFromExport;
       }).map(function(instance) {
-        return this._toObject(instance, methodName, propertiesToInclude);
+        return this._toObject(instance, methodName, propertiesToInclude, includeDefaultValues);
       }, this);
     },
 
     /**
      * @private
      */
-    _toObject: function(instance, methodName, propertiesToInclude) {
-      var originalValue;
-
-      if (!this.includeDefaultValues) {
-        originalValue = instance.includeDefaultValues;
-        instance.includeDefaultValues = false;
-      }
-
-      var object = instance[methodName](propertiesToInclude);
-      if (!this.includeDefaultValues) {
-        instance.includeDefaultValues = originalValue;
-      }
-      return object;
+    _toObject: function (instance, methodName, propertiesToInclude, includeDefaultValues) {
+      return instance[methodName](propertiesToInclude, includeDefaultValues);
     },
 
     /**
      * @private
      */
-    __serializeBgOverlay: function(methodName, propertiesToInclude) {
+    __serializeBgOverlay: function (methodName, propertiesToInclude, includeDefaultValues) {
       var data = {}, bgImage = this.backgroundImage, overlayImage = this.overlayImage,
           bgColor = this.backgroundColor, overlayColor = this.overlayColor;
 
       if (bgColor && bgColor.toObject) {
         if (!bgColor.excludeFromExport) {
-          data.background = bgColor.toObject(propertiesToInclude);
+          data.background = bgColor.toObject(propertiesToInclude, includeDefaultValues);
         }
       }
       else if (bgColor) {
@@ -1015,7 +999,7 @@
 
       if (overlayColor && overlayColor.toObject) {
         if (!overlayColor.excludeFromExport) {
-          data.overlay = overlayColor.toObject(propertiesToInclude);
+          data.overlay = overlayColor.toObject(propertiesToInclude, includeDefaultValues);
         }
       }
       else if (overlayColor) {
@@ -1023,10 +1007,10 @@
       }
 
       if (bgImage && !bgImage.excludeFromExport) {
-        data.backgroundImage = this._toObject(bgImage, methodName, propertiesToInclude);
+        data.backgroundImage = this._toObject(bgImage, methodName, propertiesToInclude, includeDefaultValues);
       }
       if (overlayImage && !overlayImage.excludeFromExport) {
-        data.overlayImage = this._toObject(overlayImage, methodName, propertiesToInclude);
+        data.overlayImage = this._toObject(overlayImage, methodName, propertiesToInclude, includeDefaultValues);
       }
 
       return data;
@@ -1650,9 +1634,8 @@
    * var json = canvas.toJSON();
    * @example <caption>JSON with additional properties included</caption>
    * var json = canvas.toJSON(['lockMovementX', 'lockMovementY', 'lockRotation', 'lockScalingX', 'lockScalingY']);
-   * @example <caption>JSON without default values</caption>
-   * canvas.includeDefaultValues = false;
-   * var json = canvas.toJSON();
+   * @example <caption>JSON with default values</caption>
+   * var json = canvas.toJSON(true);
    */
   fabric.StaticCanvas.prototype.toJSON = fabric.StaticCanvas.prototype.toObject;
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -923,16 +923,6 @@
     },
 
     /**
-     * Returns dataless JSON representation of canvas
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
-     * @return {String} json string
-     */
-    toDatalessJSON: function (propertiesToInclude, includeDefaultValues) {
-      return this.toDatalessObject(propertiesToInclude, includeDefaultValues);
-    },
-
-    /**
      * Returns object representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
@@ -951,6 +941,38 @@
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
       return this._toObjectMethod('toDatalessObject', propertiesToInclude, includeDefaultValues);
     },
+
+    /**
+     * Returns Object representation of canvas
+     * this alias is provided because if you call JSON.stringify on an instance,
+     * the toJSON object will be invoked if it exists.
+     * Having a toJSON method means you can do JSON.stringify(myCanvas)
+     * @function
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @return {Object} JSON compatible object
+     * @tutorial {@link http://fabricjs.com/fabric-intro-part-3#serialization}
+     * @see {@link http://jsfiddle.net/fabricjs/pec86/|jsFiddle demo}
+     * @example <caption>JSON without additional properties</caption>
+     * var json = canvas.toJSON();
+     * @example <caption>JSON with additional properties included</caption>
+     * var json = canvas.toJSON(['lockMovementX', 'lockMovementY', 'lockRotation', 'lockScalingX', 'lockScalingY']);
+     * @example <caption>JSON with default values</caption>
+     * var json = canvas.toJSON(true);
+     */
+    toJSON: function (propertiesToInclude, includeDefaultValues) {
+      return this.toObject(propertiesToInclude, includeDefaultValues);
+    },
+
+    /**
+     * Returns dataless JSON representation of canvas
+     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @return {String} json string
+     */
+    toDatalessJSON: function (propertiesToInclude, includeDefaultValues) {
+      return this.toDatalessObject(propertiesToInclude, includeDefaultValues);
+    },
+
 
     /**
      * @private
@@ -1629,25 +1651,6 @@
       }
     }
   });
-
-  /**
-   * Returns Object representation of canvas
-   * this alias is provided because if you call JSON.stringify on an instance,
-   * the toJSON object will be invoked if it exists.
-   * Having a toJSON method means you can do JSON.stringify(myCanvas)
-   * @function
-   * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-   * @return {Object} JSON compatible object
-   * @tutorial {@link http://fabricjs.com/fabric-intro-part-3#serialization}
-   * @see {@link http://jsfiddle.net/fabricjs/pec86/|jsFiddle demo}
-   * @example <caption>JSON without additional properties</caption>
-   * var json = canvas.toJSON();
-   * @example <caption>JSON with additional properties included</caption>
-   * var json = canvas.toJSON(['lockMovementX', 'lockMovementY', 'lockRotation', 'lockScalingX', 'lockScalingY']);
-   * @example <caption>JSON with default values</caption>
-   * var json = canvas.toJSON(true);
-   */
-  fabric.StaticCanvas.prototype.toJSON = fabric.StaticCanvas.prototype.toObject;
 
   if (fabric.isLikelyNode) {
     fabric.StaticCanvas.prototype.createPNGStream = function() {

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -83,6 +83,14 @@
     overlayImage: null,
 
     /**
+     * Indicates whether toObject/toDatalessObject should include default values
+     * if set to false, takes precedence over the object value.
+     * @type Boolean
+     * @default
+     */
+    includeDefaultValues: true,
+
+    /**
      * Indicates whether objects' state should be saved
      * @type Boolean
      * @default
@@ -917,7 +925,7 @@
     /**
      * Returns dataless JSON representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {String} json string
      */
     toDatalessJSON: function (propertiesToInclude, includeDefaultValues) {
@@ -927,7 +935,7 @@
     /**
      * Returns object representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toObject: function (propertiesToInclude, includeDefaultValues) {
@@ -937,7 +945,7 @@
     /**
      * Returns dataless object representation of canvas
      * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] default values are not included in serialization
+     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
      * @return {Object} object representation of an instance
      */
     toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
@@ -948,7 +956,7 @@
      * @private
      */
     _toObjectMethod: function (methodName, propertiesToInclude, includeDefaultValues) {
-
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
       var clipPath = this.clipPath, data = {
         version: fabric.version,
         objects: this._toObjects(methodName, propertiesToInclude, includeDefaultValues),

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -924,22 +924,20 @@
 
     /**
      * Returns object representation of canvas
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
-    toObject: function (propertiesToInclude, includeDefaultValues) {
-      return this._toObjectMethod('toObject', propertiesToInclude, includeDefaultValues);
+    toObject: function (options) {
+      return this._toObjectMethod('toObject', options);
     },
 
     /**
      * Returns dataless object representation of canvas
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {Object} object representation of an instance
      */
-    toDatalessObject: function (propertiesToInclude, includeDefaultValues) {
-      return this._toObjectMethod('toDatalessObject', propertiesToInclude, includeDefaultValues);
+    toDatalessObject: function (options) {
+      return this._toObjectMethod('toDatalessObject', options);
     },
 
     /**
@@ -948,7 +946,6 @@
      * the toJSON object will be invoked if it exists.
      * Having a toJSON method means you can do JSON.stringify(myCanvas)
      * @function
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
      * @return {Object} JSON compatible object
      * @tutorial {@link http://fabricjs.com/fabric-intro-part-3#serialization}
      * @see {@link http://jsfiddle.net/fabricjs/pec86/|jsFiddle demo}
@@ -959,38 +956,34 @@
      * @example <caption>JSON with default values</caption>
      * var json = canvas.toJSON(true);
      */
-    toJSON: function (propertiesToInclude, includeDefaultValues) {
-      return this.toObject(propertiesToInclude, includeDefaultValues);
+    toJSON: function (options) {
+      return this.toObject(options);
     },
 
     /**
      * Returns dataless JSON representation of canvas
-     * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @param {boolean} [includeDefaultValues] override instance config to include/exclude default values
+     * @param {fabric.util.SerializationOptions} [options] serialization options
      * @return {String} json string
      */
-    toDatalessJSON: function (propertiesToInclude, includeDefaultValues) {
-      return this.toDatalessObject(propertiesToInclude, includeDefaultValues);
+    toDatalessJSON: function (options) {
+      return this.toDatalessObject(options);
     },
 
 
     /**
      * @private
      */
-    _toObjectMethod: function (methodName, propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
-        includeDefaultValues :
-        this.includeDefaultValues;
+    _toObjectMethod: function (methodName, options) {
       var clipPath = this.clipPath, data = {
         version: fabric.version,
-        objects: this._toObjects(methodName, propertiesToInclude, includeDefaultValues),
+        objects: this._toObjects(methodName, options),
       };
       if (clipPath && !clipPath.excludeFromExport) {
-        data.clipPath = this._toObject(this.clipPath, methodName, propertiesToInclude, includeDefaultValues);
+        data.clipPath = this._toObject(this.clipPath, methodName, options);
       }
-      extend(data, this.__serializeBgOverlay(methodName, propertiesToInclude, includeDefaultValues));
+      extend(data, this.__serializeBgOverlay(methodName, options));
 
-      fabric.util.populateWithProperties(this, data, propertiesToInclude);
+      fabric.util.populateWithProperties(this, data, options);
 
       return data;
     },
@@ -998,31 +991,31 @@
     /**
      * @private
      */
-    _toObjects: function (methodName, propertiesToInclude, includeDefaultValues) {
+    _toObjects: function (methodName, options) {
       return this._objects.filter(function(object) {
         return !object.excludeFromExport;
       }).map(function(instance) {
-        return this._toObject(instance, methodName, propertiesToInclude, includeDefaultValues);
+        return this._toObject(instance, methodName, options);
       }, this);
     },
 
     /**
      * @private
      */
-    _toObject: function (instance, methodName, propertiesToInclude, includeDefaultValues) {
-      return instance[methodName](propertiesToInclude, includeDefaultValues);
+    _toObject: function (instance, methodName, options) {
+      return instance[methodName](options);
     },
 
     /**
      * @private
      */
-    __serializeBgOverlay: function (methodName, propertiesToInclude, includeDefaultValues) {
+    __serializeBgOverlay: function (methodName, options) {
       var data = {}, bgImage = this.backgroundImage, overlayImage = this.overlayImage,
           bgColor = this.backgroundColor, overlayColor = this.overlayColor;
 
       if (bgColor && bgColor.toObject) {
         if (!bgColor.excludeFromExport) {
-          data.background = bgColor.toObject(propertiesToInclude, includeDefaultValues);
+          data.background = bgColor.toObject(options);
         }
       }
       else if (bgColor) {
@@ -1031,7 +1024,7 @@
 
       if (overlayColor && overlayColor.toObject) {
         if (!overlayColor.excludeFromExport) {
-          data.overlay = overlayColor.toObject(propertiesToInclude, includeDefaultValues);
+          data.overlay = overlayColor.toObject(options);
         }
       }
       else if (overlayColor) {
@@ -1039,10 +1032,10 @@
       }
 
       if (bgImage && !bgImage.excludeFromExport) {
-        data.backgroundImage = this._toObject(bgImage, methodName, propertiesToInclude, includeDefaultValues);
+        data.backgroundImage = this._toObject(bgImage, methodName, options);
       }
       if (overlayImage && !overlayImage.excludeFromExport) {
-        data.overlayImage = this._toObject(overlayImage, methodName, propertiesToInclude, includeDefaultValues);
+        data.overlayImage = this._toObject(overlayImage, methodName, options);
       }
 
       return data;

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -956,7 +956,9 @@
      * @private
      */
     _toObjectMethod: function (methodName, propertiesToInclude, includeDefaultValues) {
-      includeDefaultValues = typeof includeDefaultValues === 'boolean' ? includeDefaultValues : this.includeDefaultValues;
+      includeDefaultValues = typeof includeDefaultValues === 'boolean' ?
+        includeDefaultValues :
+        this.includeDefaultValues;
       var clipPath = this.clipPath, data = {
         version: fabric.version,
         objects: this._toObjects(methodName, propertiesToInclude, includeDefaultValues),

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -587,22 +587,6 @@
     },
 
     /**
-     * @typedef {Object} SerializationOptions
-     * @property {string[]} [options.propertiesToInclude] extend the list of properties to export
-     * @property {boolean} [options.includeDefaultValues] include/exclude default values
-     * 
-     * @private
-     * @param {SerializationOptions} options 
-     * @param {string[]} [propertiesToInclude]
-     * @returns 
-     */
-    extendSerializationOptions: function (options, propertiesToInclude) {
-      var opts = options || {};
-      propertiesToInclude && (opts.propertiesToInclude = propertiesToInclude.concat(opts.propertiesToInclude));
-      return opts;
-    },
-
-    /**
      * Creates canvas element
      * @static
      * @memberOf fabric.util

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -587,6 +587,22 @@
     },
 
     /**
+     * @typedef {Object} SerializationOptions
+     * @property {string[]} [options.propertiesToInclude] extend the list of properties to export
+     * @property {boolean} [options.includeDefaultValues] include/exclude default values
+     * 
+     * @private
+     * @param {SerializationOptions} options 
+     * @param {string[]} [propertiesToInclude]
+     * @returns 
+     */
+    extendSerializationOptions: function (options, propertiesToInclude) {
+      var opts = options || {};
+      propertiesToInclude && (opts.propertiesToInclude = propertiesToInclude.concat(opts.propertiesToInclude));
+      return opts;
+    },
+
+    /**
      * Creates canvas element
      * @static
      * @memberOf fabric.util

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -593,7 +593,7 @@
      */
     removeDefaultValues: function (object) {
       var prototype = fabric.util.getKlass(object.type).prototype,
-        stateProperties = prototype.stateProperties;
+          stateProperties = prototype.stateProperties;
       stateProperties.forEach(function (prop) {
         if (prop === 'left' || prop === 'top') {
           return;

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -587,6 +587,31 @@
     },
 
     /**
+     * Removes default values from an object by comparing it to it's prototype
+     * @private
+     * @param {Object} object
+     */
+    removeDefaultValues: function (object) {
+      var prototype = fabric.util.getKlass(object.type).prototype,
+        stateProperties = prototype.stateProperties;
+      stateProperties.forEach(function (prop) {
+        if (prop === 'left' || prop === 'top') {
+          return;
+        }
+        if (object[prop] === prototype[prop]) {
+          delete object[prop];
+        }
+        // basically a check for [] === []
+        if (Array.isArray(object[prop]) && Array.isArray(prototype[prop])
+          && object[prop].length === 0 && prototype[prop].length === 0) {
+          delete object[prop];
+        }
+      });
+
+      return object;
+    },
+
+    /**
      * Creates canvas element
      * @static
      * @memberOf fabric.util

--- a/test/unit/activeselection.js
+++ b/test/unit/activeselection.js
@@ -50,9 +50,9 @@
 
     assert.ok(typeof group.toObject === 'function');
 
-    var clone = group.toObject();
+    var clone = group.toObject(true);
 
-    var expectedObject = {
+    var expectedObject = fabric.util.removeDefaultValues({
       version:                  fabric.version,
       type:                     'activeSelection',
       originX:                  'left',
@@ -85,7 +85,7 @@
       skewY:                    0,
       strokeUniform:            false,
       objects:                  clone.objects
-    };
+    });
 
     assert.deepEqual(clone, expectedObject);
 
@@ -96,7 +96,6 @@
 
   QUnit.test('toObject without default values', function(assert) {
     var group = makeAsWith2Objects();
-    group.includeDefaultValues = false;
     var clone = group.toObject();
     var objects = [{
       version:                  fabric.version,

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -138,7 +138,6 @@
 
   QUnit.test('initialProperties', function(assert) {
     assert.ok('backgroundColor' in canvas);
-    assert.equal(canvas.includeDefaultValues, true);
   });
 
   QUnit.test('getObjects', function(assert) {
@@ -1390,7 +1389,7 @@
   QUnit.test('toObject with clipPath', function(assert) {
     var clipPath = makeRect();
     var canvasWithClipPath = new fabric.Canvas(null, { clipPath: clipPath });
-    var expectedObject = {
+    var expectedObject = fabric.util.removeDefaultValues({
       version: fabric.version,
       objects: canvasWithClipPath.getObjects(),
       clipPath: {
@@ -1428,7 +1427,7 @@
         ry: 0,
         strokeUniform: false
       }
-    };
+    });
 
     assert.ok(typeof canvasWithClipPath.toObject === 'function');
     assert.deepEqual(expectedObject, canvasWithClipPath.toObject());

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1346,9 +1346,9 @@
     assert.equal(JSON.stringify(canvas.toJSON()), EMPTY_JSON);
     canvas.backgroundColor = '#ff5555';
     canvas.overlayColor = 'rgba(0,0,0,0.2)';
-    assert.equal(JSON.stringify(canvas.toJSON()), '{"version":"' + fabric.version + '","objects":[],"background":"#ff5555","overlay":"rgba(0,0,0,0.2)"}', '`background` and `overlayColor` value should be reflected in json');
+    assert.equal(JSON.stringify(canvas.toJSON(undefined, true)), '{"version":"' + fabric.version + '","objects":[],"background":"#ff5555","overlay":"rgba(0,0,0,0.2)"}', '`background` and `overlayColor` value should be reflected in json');
     canvas.add(makeRect());
-    assert.deepEqual(JSON.stringify(canvas.toJSON()), RECT_JSON);
+    assert.deepEqual(JSON.stringify(canvas.toJSON(undefined, true)), RECT_JSON);
   });
 
   QUnit.test('toJSON with active group', function(assert) {
@@ -1368,7 +1368,7 @@
       sourcePath: 'http://example.com/'
     });
     canvas.add(path);
-    assert.equal(JSON.stringify(canvas.toDatalessJSON()), PATH_DATALESS_JSON);
+    assert.equal(JSON.stringify(canvas.toDatalessJSON(undefined, true)), PATH_DATALESS_JSON);
   });
 
   QUnit.test('toObject', function(assert) {
@@ -1389,45 +1389,46 @@
   QUnit.test('toObject with clipPath', function(assert) {
     var clipPath = makeRect();
     var canvasWithClipPath = new fabric.Canvas(null, { clipPath: clipPath });
-    var expectedObject = fabric.util.removeDefaultValues({
+    var CLIP_PATH_REF = fabric.util.removeDefaultValues({
+      type: 'rect',
+      version: fabric.version,
+      originX: 'left',
+      originY: 'top',
+      left: 0,
+      top: 0,
+      width: 10,
+      height: 10,
+      fill: 'rgb(0,0,0)',
+      stroke: null,
+      strokeWidth: 1,
+      strokeDashArray: null,
+      strokeLineCap: 'butt',
+      strokeDashOffset: 0,
+      strokeLineJoin: 'miter',
+      strokeMiterLimit: 4,
+      scaleX: 1,
+      scaleY: 1,
+      angle: 0,
+      flipX: false,
+      flipY: false,
+      opacity: 1,
+      shadow: null,
+      visible: true,
+      backgroundColor: '',
+      fillRule: 'nonzero',
+      paintFirst: 'fill',
+      globalCompositeOperation: 'source-over',
+      skewX: 0,
+      skewY: 0,
+      rx: 0,
+      ry: 0,
+      strokeUniform: false
+    });
+    var expectedObject = {
       version: fabric.version,
       objects: canvasWithClipPath.getObjects(),
-      clipPath: {
-        type: 'rect',
-        version: fabric.version,
-        originX: 'left',
-        originY: 'top',
-        left: 0,
-        top: 0,
-        width: 10,
-        height: 10,
-        fill: 'rgb(0,0,0)',
-        stroke: null,
-        strokeWidth: 1,
-        strokeDashArray: null,
-        strokeLineCap: 'butt',
-        strokeDashOffset: 0,
-        strokeLineJoin: 'miter',
-        strokeMiterLimit: 4,
-        scaleX: 1,
-        scaleY: 1,
-        angle: 0,
-        flipX: false,
-        flipY: false,
-        opacity: 1,
-        shadow: null,
-        visible: true,
-        backgroundColor: '',
-        fillRule: 'nonzero',
-        paintFirst: 'fill',
-        globalCompositeOperation: 'source-over',
-        skewX: 0,
-        skewY: 0,
-        rx: 0,
-        ry: 0,
-        strokeUniform: false
-      }
-    });
+      clipPath: CLIP_PATH_REF
+    };
 
     assert.ok(typeof canvasWithClipPath.toObject === 'function');
     assert.deepEqual(expectedObject, canvasWithClipPath.toObject());

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -71,7 +71,7 @@
       IMG_WIDTH   = 276,
       IMG_HEIGHT  = 110;
 
-  var REFERENCE_IMG_OBJECT = {
+  var REFERENCE_IMG_OBJECT = fabric.util.removeDefaultValues({
     version: fabric.version,
     type: 'image',
     originX: 'left',
@@ -108,7 +108,7 @@
     cropX: 0,
     cropY: 0,
     strokeUniform: false
-  };
+  });
 
   function _createImageElement() {
     return fabric.document.createElement('img');
@@ -203,7 +203,6 @@
     assert.ok('overlayColor' in canvas);
     assert.ok('backgroundImage' in canvas);
     assert.ok('overlayImage' in canvas);
-    assert.ok('includeDefaultValues' in canvas);
     assert.ok('stateful' in canvas);
     assert.ok('renderOnAddRemove' in canvas);
     assert.ok('controlsAboveOverlay' in canvas);
@@ -212,7 +211,6 @@
     assert.ok('backgroundVpt' in canvas);
     assert.ok('overlayVpt' in canvas);
 
-    assert.equal(canvas.includeDefaultValues, true);
     assert.equal(canvas.stateful, false);
     assert.equal(canvas.renderOnAddRemove, true);
     assert.equal(canvas.controlsAboveOverlay, false);
@@ -964,9 +962,9 @@
     assert.equal(JSON.stringify(canvas.toJSON()), '{"version":"' + fabric.version + '","objects":[]}');
     canvas.backgroundColor = '#ff5555';
     canvas.overlayColor = 'rgba(0,0,0,0.2)';
-    assert.equal(JSON.stringify(canvas.toJSON()), '{"version":"' + fabric.version + '","objects":[],"background":"#ff5555","overlay":"rgba(0,0,0,0.2)"}', '`background` and `overlay` value should be reflected in json');
+    assert.equal(JSON.stringify(canvas.toJSON(undefined, true)), '{"version":"' + fabric.version + '","objects":[],"background":"#ff5555","overlay":"rgba(0,0,0,0.2)"}', '`background` and `overlay` value should be reflected in json');
     canvas.add(makeRect());
-    assert.deepEqual(JSON.stringify(canvas.toJSON()), RECT_JSON);
+    assert.deepEqual(JSON.stringify(canvas.toJSON(undefined, true)), RECT_JSON);
   });
 
   QUnit.test('toJSON custom properties non-existence check', function(assert) {
@@ -1071,9 +1069,6 @@
     var rect = makeRect();
     canvas.add(rect);
     var cObject = canvas.toObject(undefined, false);
-    canvas.includeDefaultValues = false;
-    assert.deepEqual(canvas.toObject(), cObject, 'instance `includeDefaultValues` prop should remove defaults');
-    canvas.includeDefaultValues = true;
     var expectedRect = { version: fabric.version, type: 'rect', width: 10, height: 10, top: 0, left: 0 };
     assert.deepEqual(cObject.objects[0], expectedRect, 'Rect should be exported withoud defaults');
   });
@@ -1287,8 +1282,8 @@
 
     canvas.add(rect);
 
-    var jsonWithoutFoo = JSON.stringify(canvas.toJSON(['padding']));
-    var jsonWithFoo = JSON.stringify(canvas.toJSON(['padding', 'foo']));
+    var jsonWithoutFoo = JSON.stringify(canvas.toJSON(['padding'], true));
+    var jsonWithFoo = JSON.stringify(canvas.toJSON(['padding', 'foo'], true));
 
     assert.equal(jsonWithFoo, RECT_JSON_WITH_PADDING);
     assert.ok(jsonWithoutFoo !== RECT_JSON_WITH_PADDING);

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1070,7 +1070,7 @@
   QUnit.test('toObject non includeDefaultValues', function(assert) {
     var rect = makeRect();
     canvas.add(rect);
-    var cObject = canvas.toObject(false);
+    var cObject = canvas.toObject(undefined, false);
     canvas.includeDefaultValues = false;
     assert.deepEqual(canvas.toObject(), cObject, 'instance `includeDefaultValues` prop should remove defaults');
     canvas.includeDefaultValues = true;

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1068,13 +1068,14 @@
   });
 
   QUnit.test('toObject non includeDefaultValues', function(assert) {
-    canvas.includeDefaultValues = false;
     var rect = makeRect();
     canvas.add(rect);
-    var cObject = canvas.toObject();
+    var cObject = canvas.toObject(false);
+    canvas.includeDefaultValues = false;
+    assert.deepEqual(canvas.toObject(), cObject, 'instance `includeDefaultValues` prop should remove defaults');
+    canvas.includeDefaultValues = true;
     var expectedRect = { version: fabric.version, type: 'rect', width: 10, height: 10, top: 0, left: 0 };
     assert.deepEqual(cObject.objects[0], expectedRect, 'Rect should be exported withoud defaults');
-    canvas.includeDefaultValues = true;
   });
 
   QUnit.test('toObject excludeFromExport', function(assert) {

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1048,7 +1048,7 @@
       sourcePath: 'http://example.com/'
     });
     canvas.add(path);
-    assert.equal(JSON.stringify(canvas.toDatalessJSON()), PATH_DATALESS_JSON);
+    assert.equal(JSON.stringify(canvas.toDatalessJSON(undefined, true)), PATH_DATALESS_JSON);
   });
 
   QUnit.test('toObject', function(assert) {

--- a/test/unit/circle.js
+++ b/test/unit/circle.js
@@ -85,7 +85,7 @@
 
   QUnit.test('toObject', function(assert) {
     var circle = new fabric.Circle();
-    var defaultProperties = {
+    var defaultProperties = fabric.util.removeDefaultValues({
       version:                  fabric.version,
       type:                     'circle',
       originX:                  'left',
@@ -120,7 +120,7 @@
       skewX:                    0,
       skewY:                    0,
       strokeUniform:            false
-    };
+    });
     assert.ok(typeof circle.toObject === 'function');
     assert.deepEqual(circle.toObject(), defaultProperties);
 

--- a/test/unit/ellipse.js
+++ b/test/unit/ellipse.js
@@ -25,7 +25,7 @@
 
   QUnit.test('toObject', function(assert) {
     var ellipse = new fabric.Ellipse();
-    var defaultProperties = {
+    var defaultProperties = fabric.util.removeDefaultValues({
       version:                  fabric.version,
       type:                     'ellipse',
       originX:                  'left',
@@ -59,7 +59,7 @@
       paintFirst:               'fill',
       globalCompositeOperation: 'source-over',
       strokeUniform:            false,
-    };
+    });
     assert.ok(typeof ellipse.toObject === 'function');
     assert.deepEqual(ellipse.toObject(), defaultProperties);
 

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -158,7 +158,7 @@
 
     var clone = group.toObject();
 
-    var expectedObject = {
+    var expectedObject = fabric.util.removeDefaultValues({
       version: fabric.version,
       type:                     'group',
       originX:                  'left',
@@ -191,7 +191,7 @@
       skewY:                    0,
       objects:                  clone.objects,
       strokeUniform:            false
-    };
+    });
 
     assert.deepEqual(clone, expectedObject);
 

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -202,8 +202,7 @@
 
   QUnit.test('toObject without default values', function(assert) {
     var group = makeGroupWith2Objects();
-    group.includeDefaultValues = false;
-    var clone = group.toObject();
+    var clone = group.toObject(false);
     var objects = [{
       version: fabric.version,
       type: 'rect',

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -202,7 +202,7 @@
 
   QUnit.test('toObject without default values', function(assert) {
     var group = makeGroupWith2Objects();
-    var clone = group.toObject(false);
+    var clone = group.toObject(undefined, false);
     var objects = [{
       version: fabric.version,
       type: 'rect',

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -31,7 +31,7 @@
 
   var IMG_URL_NON_EXISTING = 'http://www.google.com/non-existing';
 
-  var REFERENCE_IMG_OBJECT = {
+  var REFERENCE_IMG_OBJECT = fabric.util.removeDefaultValues({
     version:                  fabric.version,
     type:                     'image',
     originX:                  'left',
@@ -68,7 +68,7 @@
     cropX:                    0,
     cropY:                    0,
     strokeUniform:            false
-  };
+  });
 
   function _createImageElement() {
     return fabric.document.createElement('img');

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -1,7 +1,7 @@
 (function() {
   var canvas = this.canvas = new fabric.Canvas();
 
-  var ITEXT_OBJECT = {
+  var ITEXT_OBJECT = fabric.util.removeDefaultValues({
     version:                  fabric.version,
     type:                     'text',
     originX:                  'left',
@@ -51,7 +51,7 @@
     pathStartOffset:          0,
     pathSide:                 'left',
     pathAlign:                'baseline'
-  };
+  });
 
 
   QUnit.module('fabric.IText', function(hooks) {

--- a/test/unit/line.js
+++ b/test/unit/line.js
@@ -1,6 +1,6 @@
 (function(){
 
-  var LINE_OBJECT = {
+  var LINE_OBJECT = fabric.util.removeDefaultValues({
     version:                  fabric.version,
     type:                     'line',
     originX:                  'left',
@@ -36,7 +36,7 @@
     skewX:                    0,
     skewY:                    0,
     strokeUniform:            false
-  };
+  });
 
   QUnit.module('fabric.Line');
 

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -261,8 +261,7 @@
 
     var cObj = new fabric.Object(),
         toObjectObj;
-    cObj.includeDefaultValues = false;
-    assert.deepEqual(emptyObjectRepr, cObj.toObject(), 'top and left are always maintained');
+    assert.deepEqual(emptyObjectRepr, cObj.toObject(false), 'top and left are always maintained');
 
     cObj.set('left', 10)
       .set('top', 20)
@@ -274,7 +273,9 @@
       .set('strokeLineCap', 'round')
       .set('strokeLineJoin', 'bevel')
       .set('strokeMiterLimit', 5);
-    toObjectObj = cObj.toObject();
+    toObjectObj = cObj.toObject(false);
+    cObj.includeDefaultValues = false;
+    assert.deepEqual(cObj.toObject(), toObjectObj, 'instance `includeDefaultValues` prop should remove defaults');
     assert.deepEqual(augmentedObjectRepr, toObjectObj);
     assert.notEqual(augmentedObjectRepr.strokeDashArray, toObjectObj.strokeDashArray);
     assert.deepEqual(augmentedObjectRepr.strokeDashArray, toObjectObj.strokeDashArray);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -26,7 +26,6 @@
     assert.ok(cObj.constructor === fabric.Object);
 
     assert.equal(cObj.type, 'object');
-    assert.equal(cObj.includeDefaultValues, true);
     assert.equal(cObj.selectable, true);
   });
 
@@ -130,11 +129,11 @@
       .set('strokeLineJoin', 'bevel')
       .set('strokeMiterLimit', 5);
 
-    assert.equal(JSON.stringify(cObj.toJSON()), augmentedJSON);
+    assert.equal(JSON.stringify(cObj.toJSON(undefined, true)), augmentedJSON);
   });
 
   QUnit.test('toObject', function(assert) {
-    var emptyObjectRepr = {
+    var emptyObjectRepr = fabric.util.removeDefaultValues({
       version:                  fabric.version,
       type:                     'object',
       originX:                  'left',
@@ -166,9 +165,9 @@
       skewX:                      0,
       skewY:                      0,
       strokeUniform:              false
-    };
+    });
 
-    var augmentedObjectRepr = {
+    var augmentedObjectRepr = fabric.util.removeDefaultValues({
       version:                  fabric.version,
       type:                     'object',
       originX:                  'left',
@@ -200,7 +199,7 @@
       skewX:                      0,
       skewY:                      0,
       strokeUniform:              false
-    };
+    });
 
     var cObj = new fabric.Object();
     assert.deepEqual(emptyObjectRepr, cObj.toObject());
@@ -274,8 +273,6 @@
       .set('strokeLineJoin', 'bevel')
       .set('strokeMiterLimit', 5);
     toObjectObj = cObj.toObject(undefined, false);
-    cObj.includeDefaultValues = false;
-    assert.deepEqual(cObj.toObject(), toObjectObj, 'instance `includeDefaultValues` prop should remove defaults');
     assert.deepEqual(augmentedObjectRepr, toObjectObj);
     assert.notEqual(augmentedObjectRepr.strokeDashArray, toObjectObj.strokeDashArray);
     assert.deepEqual(augmentedObjectRepr.strokeDashArray, toObjectObj.strokeDashArray);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -118,7 +118,7 @@
 
     var cObj = new fabric.Object();
     assert.ok(typeof cObj.toJSON === 'function');
-    assert.equal(JSON.stringify(cObj.toJSON()), emptyObjectJSON);
+    assert.equal(JSON.stringify(cObj.toJSON(undefined, true)), emptyObjectJSON);
 
     cObj.set('opacity', 0.88)
       .set('scaleX', 1.3)

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -261,7 +261,7 @@
 
     var cObj = new fabric.Object(),
         toObjectObj;
-    assert.deepEqual(emptyObjectRepr, cObj.toObject(false), 'top and left are always maintained');
+    assert.deepEqual(emptyObjectRepr, cObj.toObject(undefined, false), 'top and left are always maintained');
 
     cObj.set('left', 10)
       .set('top', 20)
@@ -273,7 +273,7 @@
       .set('strokeLineCap', 'round')
       .set('strokeLineJoin', 'bevel')
       .set('strokeMiterLimit', 5);
-    toObjectObj = cObj.toObject(false);
+    toObjectObj = cObj.toObject(undefined, false);
     cObj.includeDefaultValues = false;
     assert.deepEqual(cObj.toObject(), toObjectObj, 'instance `includeDefaultValues` prop should remove defaults');
     assert.deepEqual(augmentedObjectRepr, toObjectObj);

--- a/test/unit/object_clipPath.js
+++ b/test/unit/object_clipPath.js
@@ -15,7 +15,7 @@
   });
 
   QUnit.test('toObject with clipPath', function(assert) {
-    var emptyObjectRepr = {
+    var emptyObjectRepr = fabric.util.removeDefaultValues({
       version:                  fabric.version,
       type:                     'object',
       originX:                  'left',
@@ -47,7 +47,7 @@
       skewX:                     0,
       skewY:                     0,
       strokeUniform:             false
-    };
+    });
 
     var cObj = new fabric.Object();
     assert.deepEqual(emptyObjectRepr, cObj.toObject());

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -1,6 +1,6 @@
 (function() {
 
-  var REFERENCE_PATH_OBJECT = {
+  var REFERENCE_PATH_OBJECT = fabric.util.removeDefaultValues({
     version:                  fabric.version,
     type:                     'path',
     originX:                  'left',
@@ -33,7 +33,7 @@
     skewX:                    0,
     skewY:                    0,
     strokeUniform:            false
-  };
+  });
 
   function getPathElement(path) {
     var namespace = 'http://www.w3.org/2000/svg';

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -165,8 +165,7 @@
     makePathObject(function(path) {
       path.top = fabric.Object.prototype.top;
       path.left = fabric.Object.prototype.left;
-      path.includeDefaultValues = false;
-      var obj = path.toObject();
+      var obj = path.toObject(false);
       assert.equal(obj.top, fabric.Object.prototype.top, 'top is available also when equal to prototype');
       assert.equal(obj.left, fabric.Object.prototype.left, 'left is available also when equal to prototype');
       done();

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -165,7 +165,7 @@
     makePathObject(function(path) {
       path.top = fabric.Object.prototype.top;
       path.left = fabric.Object.prototype.left;
-      var obj = path.toObject(false);
+      var obj = path.toObject(undefined, false);
       assert.equal(obj.top, fabric.Object.prototype.top, 'top is available also when equal to prototype');
       assert.equal(obj.left, fabric.Object.prototype.left, 'left is available also when equal to prototype');
       done();

--- a/test/unit/polygon.js
+++ b/test/unit/polygon.js
@@ -7,7 +7,7 @@
     ];
   }
 
-  var REFERENCE_OBJECT = {
+  var REFERENCE_OBJECT = fabric.util.removeDefaultValues({
     version:                  fabric.version,
     type:                     'polygon',
     originX:                  'left',
@@ -40,7 +40,7 @@
     skewX:                    0,
     skewY:                    0,
     strokeUniform:              false
-  };
+  });
 
   var REFERENCE_EMPTY_OBJECT = {
     points: [],

--- a/test/unit/polygon.js
+++ b/test/unit/polygon.js
@@ -122,7 +122,7 @@
     assert.ok(typeof fabric.Polygon.fromElement === 'function');
 
     var empty_object = fabric.util.object.extend({}, REFERENCE_OBJECT);
-    empty_object = fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT);
+    empty_object = fabric.util.removeDefaultValues(fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT));
 
     var elPolygonWithoutPoints = fabric.document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
 
@@ -136,7 +136,7 @@
     var elPolygonWithEmptyPoints = fabric.document.createElementNS(namespace, 'polygon');
     elPolygonWithEmptyPoints.setAttributeNS(namespace, 'points', '');
     var empty_object = fabric.util.object.extend({}, REFERENCE_OBJECT);
-    empty_object = fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT);
+    empty_object = fabric.util.removeDefaultValues(fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT));
     fabric.Polygon.fromElement(elPolygonWithEmptyPoints, function(polygon) {
       assert.deepEqual(polygon.toObject(), empty_object);
     });

--- a/test/unit/polyline.js
+++ b/test/unit/polyline.js
@@ -7,7 +7,7 @@
     ];
   }
 
-  var REFERENCE_OBJECT = {
+  var REFERENCE_OBJECT = fabric.util.removeDefaultValues({
     version:                  fabric.version,
     type:                     'polyline',
     originX:                  'left',
@@ -40,15 +40,15 @@
     skewX:                    0,
     skewY:                    0,
     strokeUniform:              false
-  };
+  });
 
-  var REFERENCE_EMPTY_OBJECT = {
+  var REFERENCE_EMPTY_OBJECT = fabric.util.removeDefaultValues({
     points: [],
     width: 0,
     height: 0,
     top: 0,
     left: 0
-  };
+  });
 
   QUnit.module('fabric.Polyline');
 

--- a/test/unit/polyline.js
+++ b/test/unit/polyline.js
@@ -42,13 +42,13 @@
     strokeUniform:              false
   });
 
-  var REFERENCE_EMPTY_OBJECT = fabric.util.removeDefaultValues({
+  var REFERENCE_EMPTY_OBJECT = {
     points: [],
     width: 0,
     height: 0,
     top: 0,
     left: 0
-  });
+  };
 
   QUnit.module('fabric.Polyline');
 
@@ -100,7 +100,7 @@
     assert.ok(typeof fabric.Polyline.fromElement === 'function');
     var elPolylineWithoutPoints = fabric.document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
     var empty_object = fabric.util.object.extend({}, REFERENCE_OBJECT);
-    empty_object = fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT);
+    empty_object = fabric.util.removeDefaultValues(fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT));
     fabric.Polyline.fromElement(elPolylineWithoutPoints, function(polyline) {
       assert.deepEqual(polyline.toObject(), empty_object);
     });
@@ -112,7 +112,7 @@
     elPolylineWithEmptyPoints.setAttributeNS(namespace, 'points', '');
     fabric.Polyline.fromElement(elPolylineWithEmptyPoints, function(polyline) {
       var empty_object = fabric.util.object.extend({}, REFERENCE_OBJECT);
-      empty_object = fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT);
+      empty_object = fabric.util.removeDefaultValues(fabric.util.object.extend(empty_object, REFERENCE_EMPTY_OBJECT));
       assert.deepEqual(polyline.toObject(), empty_object);
     });
   });

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -1,6 +1,6 @@
 (function() {
 
-  var REFERENCE_RECT = {
+  var REFERENCE_RECT = fabric.util.removeDefaultValues({
     version:                  fabric.version,
     type:                     'rect',
     originX:                  'left',
@@ -34,7 +34,7 @@
     skewX:                    0,
     skewY:                    0,
     strokeUniform:            false
-  };
+  });
 
   QUnit.module('fabric.Rect');
 

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -207,8 +207,7 @@
   QUnit.test('toObject without default values', function(assert) {
     var options = { type: 'rect', width: 69, height: 50, left: 10, top: 20, version: fabric.version, };
     var rect = new fabric.Rect(options);
-    rect.includeDefaultValues = false;
-    assert.deepEqual(rect.toObject(), options);
+    assert.deepEqual(rect.toObject(false), options);
   });
 
   QUnit.test('paintFirst life cycle', function(assert) {

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -207,7 +207,7 @@
   QUnit.test('toObject without default values', function(assert) {
     var options = { type: 'rect', width: 69, height: 50, left: 10, top: 20, version: fabric.version, };
     var rect = new fabric.Rect(options);
-    assert.deepEqual(rect.toObject(false), options);
+    assert.deepEqual(rect.toObject(undefined, false), options);
   });
 
   QUnit.test('paintFirst life cycle', function(assert) {

--- a/test/unit/shadow.js
+++ b/test/unit/shadow.js
@@ -159,9 +159,9 @@
     var shadow = new fabric.Shadow();
     assert.ok(typeof shadow.toObject === 'function');
 
-    var object = shadow.toObject();
+    var object = shadow.toObject(true);
     assert.equal(JSON.stringify(object), '{}');
-    assert.equal(object.toJSON(true), '{"color":"rgb(0,0,0)","blur":0,"offsetX":0,"offsetY":0,"affectStroke":false,"nonScaling":false}');
+    assert.equal(JSON.stringify(object), '{"color":"rgb(0,0,0)","blur":0,"offsetX":0,"offsetY":0,"affectStroke":false,"nonScaling":false}');
   });
 
   QUnit.test('clone with affectStroke', function(assert) {

--- a/test/unit/shadow.js
+++ b/test/unit/shadow.js
@@ -175,14 +175,14 @@
 
   QUnit.test('toObject without default value', function(assert) {
     var shadow = new fabric.Shadow();
-    shadow.includeDefaultValues = false;
 
-    assert.equal(JSON.stringify(shadow.toObject()), '{}');
+    assert.equal(JSON.stringify(shadow.toObject(false)), '{}');
 
     shadow.color = 'red';
-    assert.equal(JSON.stringify(shadow.toObject()), '{"color":"red"}');
+    assert.equal(JSON.stringify(shadow.toObject(false)), '{"color":"red"}');
 
     shadow.offsetX = 15;
+    shadow.includeDefaultValues = false;
     assert.equal(JSON.stringify(shadow.toObject()), '{"color":"red","offsetX":15}');
   });
 

--- a/test/unit/shadow.js
+++ b/test/unit/shadow.js
@@ -160,7 +160,8 @@
     assert.ok(typeof shadow.toObject === 'function');
 
     var object = shadow.toObject();
-    assert.equal(JSON.stringify(object), '{"color":"rgb(0,0,0)","blur":0,"offsetX":0,"offsetY":0,"affectStroke":false,"nonScaling":false}');
+    assert.equal(JSON.stringify(object), '{}');
+    assert.equal(object.toJSON(true), '{"color":"rgb(0,0,0)","blur":0,"offsetX":0,"offsetY":0,"affectStroke":false,"nonScaling":false}');
   });
 
   QUnit.test('clone with affectStroke', function(assert) {
@@ -176,13 +177,12 @@
   QUnit.test('toObject without default value', function(assert) {
     var shadow = new fabric.Shadow();
 
-    assert.equal(JSON.stringify(shadow.toObject(false)), '{}');
+    assert.equal(JSON.stringify(shadow.toObject()), '{}');
 
     shadow.color = 'red';
-    assert.equal(JSON.stringify(shadow.toObject(false)), '{"color":"red"}');
+    assert.equal(JSON.stringify(shadow.toObject()), '{"color":"red"}');
 
     shadow.offsetX = 15;
-    shadow.includeDefaultValues = false;
     assert.equal(JSON.stringify(shadow.toObject()), '{"color":"red","offsetX":15}');
   });
 

--- a/test/unit/shadow.js
+++ b/test/unit/shadow.js
@@ -159,9 +159,8 @@
     var shadow = new fabric.Shadow();
     assert.ok(typeof shadow.toObject === 'function');
 
-    var object = shadow.toObject(true);
-    assert.equal(JSON.stringify(object), '{}');
-    assert.equal(JSON.stringify(object), '{"color":"rgb(0,0,0)","blur":0,"offsetX":0,"offsetY":0,"affectStroke":false,"nonScaling":false}');
+    assert.deepEqual(shadow.toObject(), { type: 'shadow' });
+    assert.equal(JSON.stringify(shadow.toObject(true)), '{"type":"shadow","color":"rgb(0,0,0)","blur":0,"offsetX":0,"offsetY":0,"affectStroke":false,"nonScaling":false}');
   });
 
   QUnit.test('clone with affectStroke', function(assert) {
@@ -177,13 +176,13 @@
   QUnit.test('toObject without default value', function(assert) {
     var shadow = new fabric.Shadow();
 
-    assert.equal(JSON.stringify(shadow.toObject()), '{}');
+    assert.deepEqual(shadow.toObject(), { type: 'shadow' });
 
     shadow.color = 'red';
-    assert.equal(JSON.stringify(shadow.toObject()), '{"color":"red"}');
+    assert.deepEqual(shadow.toObject(), { type: 'shadow', color: 'red' });
 
     shadow.offsetX = 15;
-    assert.equal(JSON.stringify(shadow.toObject()), '{"color":"red","offsetX":15}');
+    assert.deepEqual(shadow.toObject(), { type: 'shadow', color: 'red', offsetX: 15 });
   });
 
   QUnit.test('toSVG', function(assert) {

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -8,7 +8,7 @@
 
   var CHAR_WIDTH = 20;
 
-  var REFERENCE_TEXT_OBJECT = {
+  var REFERENCE_TEXT_OBJECT = fabric.util.removeDefaultValues({
     version:                   fabric.version,
     type:                      'text',
     originX:                   'left',
@@ -58,7 +58,7 @@
     pathStartOffset:            0,
     pathSide:                   'left',
     pathAlign:                  'baseline'
-  };
+  });
 
   QUnit.test('constructor', function(assert) {
     assert.ok(fabric.Text);
@@ -201,14 +201,14 @@
 
     fabric.Text.fromElement(elText, function(text) {
       assert.ok(text instanceof fabric.Text);
-      var expectedObject = fabric.util.object.extend(fabric.util.object.clone(REFERENCE_TEXT_OBJECT), {
+      var expectedObject = fabric.util.removeDefaultValues(fabric.util.object.extend(fabric.util.object.clone(REFERENCE_TEXT_OBJECT), {
         left: 0,
         top: -14.05,
         width: 8,
         height: 18.08,
         fontSize: 16,
         originX: 'left'
-      });
+      }));
       assert.deepEqual(text.toObject(), expectedObject, 'parsed object is what expected');
     });
   });
@@ -242,7 +242,7 @@
 
       assert.ok(textWithAttrs instanceof fabric.Text);
 
-      var expectedObject = fabric.util.object.extend(fabric.util.object.clone(REFERENCE_TEXT_OBJECT), {
+      var expectedObject = fabric.util.removeDefaultValues(fabric.util.object.extend(fabric.util.object.clone(REFERENCE_TEXT_OBJECT), {
         /* left varies slightly due to node-canvas rendering */
         left:             fabric.util.toFixed(textWithAttrs.left + '', 2),
         top:              -88.03,
@@ -263,7 +263,7 @@
         fontWeight:       'bold',
         fontSize:         123,
         underline:        true,
-      });
+      }));
 
       assert.deepEqual(textWithAttrs.toObject(), expectedObject);
     });

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -6,7 +6,7 @@
     }
   });
 
-  var TEXTBOX_OBJECT = {
+  var TEXTBOX_OBJECT = fabric.util.removeDefaultValues({
     version: fabric.version,
     type: 'textbox',
     originX: 'left',
@@ -58,7 +58,7 @@
     pathStartOffset: 0,
     pathSide: 'left',
     pathAlign: 'baseline'
-  };
+  });
 
   QUnit.test('constructor', function(assert) {
     var textbox = new fabric.Textbox('test');

--- a/test/visual/svg_import.js
+++ b/test/visual/svg_import.js
@@ -22,8 +22,6 @@
         fabric.loadSVGFromString(string, function(objects, options) {
           // something is disabling objectCaching and i cannot find where it is.
           var group = fabric.util.groupSVGElements(objects, options);
-          group.includeDefaultValues = false;
-          canvas.includeDefaultValues = false;
           canvas.add(group);
           canvas.setDimensions({ width: group.width + group.left, height: group.height + group.top });
           canvas.renderAll();


### PR DESCRIPTION
Support accepting `includeDefaultValues` as an argument to `toObject` methods instead of fussing with `object.includeDefaultValues`


I have been wanting this for a long time
I think we should drop `includeDefaultValues` as a prop on the object/canvas level
And I think `excludeFromExport` can go away as well if we accept a filter function
```js
toObject(props, includeDefaultValues, filter) {
// for each object
filter(obj) ? 'include': 'exclude'
}
```