### PR TITLE
fix(v6!): force initial layout

### DIFF
--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -781,8 +781,8 @@
        * Provided for layout customization, override if necessary.
        * Complements `getLayoutStrategyResult`, which is called at the beginning of layout.
        * @public
-       * @param {*} context layout context
-       * @param {Object|undefined} result layout result
+       * @param {LayoutContext} context layout context
+       * @param {LayoutResult} result layout result
        */
       onLayout: function (/* context, result */) {
         //  override by subclass
@@ -793,7 +793,7 @@
        * @private
        * @param {'toObject'|'toDatalessObject'} [method]
        * @param {string[]} [propertiesToInclude] Any properties that you might want to additionally include in the output
-       * @returns {Object[]} serialized objects
+       * @returns {fabric.Object[]} serialized objects
        */
       __serializeObjects: function (method, propertiesToInclude) {
         var _includeDefaultValues = this.includeDefaultValues;

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -94,6 +94,7 @@
         this.__objectMonitor = this.__objectMonitor.bind(this);
         this.__objectSelectionTracker = this.__objectSelectionMonitor.bind(this, true);
         this.__objectSelectionDisposer = this.__objectSelectionMonitor.bind(this, false);
+        this._firstLayoutDone = false;
         this.callSuper('initialize', options);
         if (objectsRelativeToGroup) {
           this.forEachObject(function (object) {
@@ -456,10 +457,15 @@
        */
       _applyLayoutStrategy: function (context) {
         var isFirstLayout = context.type === 'initialization';
+        if (!isFirstLayout && !this._firstLayoutDone) {
+          //  reject layout requests before initialization layout
+          return;
+        }
         var center = this.getRelativeCenterPoint();
         var result = this.getLayoutStrategyResult(this.layout, this._objects.concat(), context);
         if (!result) {
           //  fire hook on first layout  (firing layout event won't have any effect because at this point no events have been registered)
+          this._firstLayoutDone = true;
           isFirstLayout && this.onLayout(context, {
             centerX: center.x,
             centerY: center.y,
@@ -486,6 +492,7 @@
           this.setPositionByOrigin(newCenter, 'center', 'center');
           this.setCoords();
         }
+        this._firstLayoutDone = true;
         //  fire layout hook and event
         this.onLayout(context, result);
         this.fire('layout', {

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -463,37 +463,42 @@
         }
         var center = this.getRelativeCenterPoint();
         var result = this.getLayoutStrategyResult(this.layout, this._objects.concat(), context);
-        if (!result) {
-          //  fire hook on first layout  (firing layout event won't have any effect because at this point no events have been registered)
-          this._firstLayoutDone = true;
-          isFirstLayout && this.onLayout(context, {
+        if (result) {
+          //  handle positioning
+          var newCenter = new fabric.Point(result.centerX, result.centerY);
+          var vector = center.subtract(newCenter).add(new fabric.Point(result.correctionX || 0, result.correctionY || 0));
+          var diff = transformPoint(vector, invertTransform(this.calcOwnMatrix()), true);
+          //  set dimensions
+          this.set({ width: result.width, height: result.height });
+          //  adjust objects to account for new center
+          !context.objectsRelativeToGroup && this.forEachObject(function (object) {
+            this._adjustObjectPosition(object, diff);
+          }, this);
+          //  clip path as well
+          !isFirstLayout && this.layout !== 'clip-path' && this.clipPath && !this.clipPath.absolutePositioned
+            && this._adjustObjectPosition(this.clipPath, diff);
+          if (!newCenter.eq(center)) {
+            //  set position
+            this.setPositionByOrigin(newCenter, 'center', 'center');
+            this.setCoords();
+          }
+        }
+        else if (isFirstLayout) {
+          //  fill `result` with initial values for the layout hook
+          result = {
             centerX: center.x,
             centerY: center.y,
             width: this.width,
             height: this.height,
-          });
+          }
+        }
+        else {
+          //  no `result` so we return
           return;
         }
-        //  handle positioning
-        var newCenter = new fabric.Point(result.centerX, result.centerY);
-        var vector = center.subtract(newCenter).add(new fabric.Point(result.correctionX || 0, result.correctionY || 0));
-        var diff = transformPoint(vector, invertTransform(this.calcOwnMatrix()), true);
-        //  set dimensions
-        this.set({ width: result.width, height: result.height });
-        //  adjust objects to account for new center
-        !context.objectsRelativeToGroup && this.forEachObject(function (object) {
-          this._adjustObjectPosition(object, diff);
-        }, this);
-        //  clip path as well
-        !isFirstLayout && this.layout !== 'clip-path' && this.clipPath && !this.clipPath.absolutePositioned
-          && this._adjustObjectPosition(this.clipPath, diff);
-        if (!newCenter.eq(center)) {
-          //  set position
-          this.setPositionByOrigin(newCenter, 'center', 'center');
-          this.setCoords();
-        }
+        //  flag for next layouts
         this._firstLayoutDone = true;
-        //  fire layout hook and event
+        //  fire layout hook and event (event will fire only for layouts after initialization layout)
         this.onLayout(context, result);
         this.fire('layout', {
           context: context,
@@ -777,7 +782,7 @@
        * Complements `getLayoutStrategyResult`, which is called at the beginning of layout.
        * @public
        * @param {*} context layout context
-       * @param {Object} result layout result
+       * @param {Object|undefined} result layout result
        */
       onLayout: function (/* context, result */) {
         //  override by subclass


### PR DESCRIPTION
minor fix for v6! forcing initialization layout to be first
In case `layout` prop was set during init the `layout_change` event would fire before the initialization from within the `set` method