### PR TITLE
fix(IText): behaviour of move cursor down after select word

### DIFF
--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -478,18 +478,13 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
   },
 
   /**
-   * Moves cursor up without shift
+   * Moves cursor up / down without shift
    * @param {Number} offset
    */
   moveCursorWithoutShift: function(offset) {
-    if (offset < 0) {
-      this.selectionStart += offset;
-      this.selectionEnd = this.selectionStart;
-    }
-    else {
-      this.selectionEnd += offset;
-      this.selectionStart = this.selectionEnd;
-    }
+    // moves cursor down / up both start from selectionStart
+    this.selectionStart += offset;
+    this.selectionEnd = this.selectionStart;
     return offset !== 0;
   },
 

--- a/test/unit/itext_key_behaviour.js
+++ b/test/unit/itext_key_behaviour.js
@@ -114,8 +114,8 @@
     iText.selectionEnd = 4;
     iText.moveCursorDown({ shiftKey: false });
     assert.equal(selection, 1, 'should fire');
-    assert.equal(iText.selectionStart, 24, 'should move to down line');
-    assert.equal(iText.selectionEnd, 24, 'should move to down line');
+    assert.equal(iText.selectionStart, 21, 'should move to down line');
+    assert.equal(iText.selectionEnd, 21, 'should move to down line');
     selection = 0;
 
     iText.selectionStart = 28;


### PR DESCRIPTION
Hi, there

I found a problem on IText and tried to fix it

When the user selects a word and presses down key, the cursor does not move to the right position, unlike <textarea>

if it is not the last line, the cursor will move down and close to the right side, but this is not a problem, it's design to be like this
![case_1](https://user-images.githubusercontent.com/29225360/158021631-84e74032-ec98-42dc-9dc2-143dcb28ef0d.gif)
In the same case, <textarea> will move the cursor to the left
![textarea_1](https://user-images.githubusercontent.com/29225360/158022491-713497ca-e0cc-4458-a117-49e84052f927.gif)

What's worse, when the same case happen in the last line, the cursor will not move to the end of text, and the right key doesn’t work after that
![case_2](https://user-images.githubusercontent.com/29225360/158022505-893daf6e-f2a0-4857-8cfc-2d6676464e4a.gif)

It is not difficult to fixed this problem, and I change the test unit of this case

Hope I can help 🦆