### PR TITLE
fix(ci): CLI `debug` and `recreate` options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ To customize the dev server take a look at [`./scripts`](./scripts).
 You can symlink `fabric.js` and test your changes in a separate project.
 1. From `fabric.js` folder run `npm link` **OR** `yarn link`.
 1. From your project's folder run `npm link fabric` **OR** `yarn link fabric`.
-See [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link) **OR** [yarn link](https://yarnpkg.com/cli/link).
+
+See [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link) **OR** [yarn link](https://yarnpkg.com/cli/link).\
 Don't forget to unlink the package once you're done.
 
 ### Working on `fabricjs.com`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,15 @@ If you are working on windows, check out [`jekyll` docs](https://jekyllrb.com/do
 Take a look at an existing [demo file](https://github.com/fabricjs/fabricjs.com/blob/gh-pages/posts/demos/_posts/2020-2-15-custom-control-render.md).
 Create a new file in the same directory (`posts/demos/_posts`) and you're good to go.
 
+### Tests
+Fabric has 2 test suites: 
+- `unit` testing logic and state
+- `visual` testing visual outcome against image refs
+
+#### Running Tests
+- **Node.js**: run `npm test -- -a -d` to run all tests in debug mode (pass `--help` to see more options).
+- **Browser**: start `fabricjs.com` (`npm start`) and navigate to the `tests` tab where you will find the test interface.
+
 ### Pull request guidelines
 
 Here are a few notes you should take into account:
@@ -79,7 +88,7 @@ Here are a few notes you should take into account:
 
 - **Distribution files:** Do your changes only in the [source files](https://github.com/fabricjs/fabric.js/tree/master/src). Don't include the [distribution files](https://github.com/fabricjs/fabric.js/tree/master/dist) in your commit.
 
-- **Add tests**: Tests are always a great addition - invest a little time and expand the [unit tests suite](https://github.com/fabricjs/fabric.js/tree/master/test/unit). More informations about [QUnit](http://qunitjs.com/) tests can be found in the [wiki](https://github.com/fabricjs/fabric.js/wiki/How-to-contribute-to-Fabric#testing-fabric).
+- **Add tests**: Tests are vital - invest a little time and expand the [unit tests suite](https://github.com/fabricjs/fabric.js/tree/master/test/unit). More information about [QUnit](http://qunitjs.com/) tests can be found in the [wiki](https://github.com/fabricjs/fabric.js/wiki/How-to-contribute-to-Fabric#testing-fabric).
 
 - **Add documentation:** Fabric uses [JSDoc 3] for documentation. The generated documentation can be found at [fabricjs.com](http://fabricjs.com/docs).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Fabric has 2 test suites:
 - `visual` testing visual outcome against image refs
 
 #### Running Tests
-- **Node.js**: run `npm test -- -a -d` to run all tests in debug mode (pass `--help` to see more options).
+- **Node.js**: run `npm test -- -a -d` to run **a**ll tests in **d**ebug mode (pass `--help` to see more options).
 - **Browser**: start `fabricjs.com` (`npm start`) and navigate to the `tests` tab where you will find the test interface.
 
 ### Pull request guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,10 @@ To customize the dev server take a look at [`./scripts`](./scripts).
 
 #### symlinking
 You can symlink `fabric.js` and test your changes in a separate project.
-1. From `fabric.js` folder run `npm link`.
-1. From your project's folder run `npm link fabric`.
-See [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link).
+1. From `fabric.js` folder run `npm link` **OR** `yarn link`.
+1. From your project's folder run `npm link fabric` **OR** `yarn link fabric`.
+See [npm link](https://docs.npmjs.com/cli/v8/commands/npm-link) **OR** [yarn link](https://yarnpkg.com/cli/link).
+Don't forget to unlink the package once you're done.
 
 ### Working on `fabricjs.com`
 
@@ -95,7 +96,7 @@ Here are a few notes you should take into account:
 
 - **Distribution files:** Do your changes only in the [source files](https://github.com/fabricjs/fabric.js/tree/master/src). Don't include the [distribution files](https://github.com/fabricjs/fabric.js/tree/master/dist) in your commit.
 
-- **Add tests**: Tests are vital - invest a little time and expand the [unit tests suite](https://github.com/fabricjs/fabric.js/tree/master/test/unit). More information about [QUnit](http://qunitjs.com/) tests can be found in the [wiki](https://github.com/fabricjs/fabric.js/wiki/How-to-contribute-to-Fabric#testing-fabric).
+- **Add tests**: Tests are vital - invest time to extend the [tests suites](https://github.com/fabricjs/fabric.js/tree/master/test). More information about [QUnit](http://qunitjs.com/) tests can be found in the [wiki](https://github.com/fabricjs/fabric.js/wiki/How-to-contribute-to-Fabric#testing-fabric).
 
 - **Add documentation:** Fabric uses [JSDoc 3] for documentation. The generated documentation can be found at [fabricjs.com](http://fabricjs.com/docs).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,21 +18,28 @@ If you are sure that it's a bug in Fabric.js or a suggestion, open a new [issue]
 
 ### Issue tracker guidelines
 
-- **Search:** Before opening a new issue please [search](https://github.com/fabricjs/fabric.js/search?q=&ref=cmdform&type=Issues) Fabric's existing issues.
+If you think you found a bug in Fabric file an [issue](https://github.com/fabricjs/fabric.js/issues).
+
+- **Gotchas**: Make sure you didn't fall into a known [fabric-gotcha](http://fabricjs.com/fabric-gotchas)
+
+- **Search:** Before opening a new issue please take the time to [search](https://github.com/fabricjs/fabric.js/search?q=&ref=cmdform&type=Issues) Fabric's existing issues. This is vital to prevent spamming and to keep the community in a good state.
 
 - **Title:** Choose an informative title.
 
 - **Description:** Use the questions above to describe the issue. Add logs, screenshots or videos if that makes sense.
 
-- **Test case:** Please post code to replicate the bug - best on [jsfiddle](http://jsfiddle.net). Ideally a failing test would be
-perfect, but even a simple script demonstrating the error would suffice. You could use [this jsfiddle template](http://jsfiddle.net/fabricjs/Da7SP/) as a
-starting point.
+- **Test case:** Make sure you create a minimal and immediate test case, demonstrating the bug, with relevant explanations. It should be extremely **easy** and **fast** for someone to understand your bug and reproduce it. Bug templates can be found within a [bug report](https://github.com/fabricjs/fabric.js/issues/new?assignees=&labels=&template=bug_report.md)
 
-- **Fabric.js version:** Make sure to specify which version of Fabric.js you are using. The version can be found in [fabric.js file](https://github.com/fabricjs/fabric.js/blob/master/dist/fabric.js#L5) or just by executing `fabric.version` in the browser console.
+- **Fabric.js version:** Make sure to specify which version of Fabric.js you are using. The version can be found in [fabric.js file](https://github.com/fabricjs/fabric.js/blob/master/dist/fabric.js#L5) or just by executing `fabric.version` in the browser console. It is advised you upgrade to the latest version before proceeding.
+
+**Without these requirements issues shall be closed.**
+
+If you're unsure about something that is not a bug, it's best to start a [discussion](https://github.com/fabricjs/fabric.js/discussions) or create a post on [Fabric's google group](groups.google.com/forum/?fromgroups#!forum/fabricjs) where someone might clarify some of the things.
 
 ## Pull requests
 
 We are very grateful for your pull requests! This is your chance to improve Fabric for everyone else.
+Before you begin read this through and take a look at [fabric-gotchas](http://fabricjs.com/fabric-gotchas)
 
 ### Online one-click setup for making PRs
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -149,7 +149,11 @@ function test(tests, options) {
     const args = ['qunit', 'test/node_test_setup.js', 'test/lib'].concat(tests);
     process.env.QUNIT_DEBUG_VISUAL_TESTS = options.debug;
     process.env.QUNIT_RECREATE_VISUAL_REFS = options.recreate;
-    cp.execSync(args.join(' '), { stdio: 'inherit', cwd: wd, env: process.env });
+    try {
+        cp.execSync(args.join(' '), { stdio: 'inherit', cwd: wd, env: process.env });
+    } catch (error) {
+
+    }
 }
 
 /**

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -122,7 +122,7 @@ function exportTestsToWebsite() {
 }
 
 function exportToWebsite(options) {
-    if (!options.include  || options.include .length === 0) {
+    if (!options.include  || options.include.length === 0) {
         options.include  = ['build', 'tests'];
     }
     options.include .forEach(x => {
@@ -165,7 +165,6 @@ function listTestFiles(type) {
 }
 
 function writeCLIFile(tests) {
-    fs.removeSync
     fs.writeFileSync(CLI_CACHE, JSON.stringify(tests, null, '\t'));
 }
 
@@ -262,10 +261,13 @@ program
     .command('build')
     .description('build dist')
     .option('-f, --fast')
+    .option('-w, --watch')
     .option('-x, --exclude [exclude...]')
     .option('-m, --modules [modules...]')
     .action((options) => {
-        build(options);
+        const { watch: w, ...rest } = options || {};
+        build(rest);
+        w && watch(path.resolve(wd, 'src'), () => build(rest));
     });
 
 program

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -140,8 +140,9 @@ function exportToWebsite(options) {
 }
 
 function test(tests, debug) {
-    const args = ['qunit', 'test/node_test_setup.js', 'test/lib'].concat(tests).concat(debug ? '--debug' : '');
-    cp.execSync(args.join(' '), { stdio: 'inherit', cwd: wd });
+    const args = ['qunit', 'test/node_test_setup.js', 'test/lib'].concat(tests);
+    process.env.QUNIT_DEBUG_VISUAL_TESTS = debug;
+    cp.execSync(args.join(' '), { stdio: 'inherit', cwd: wd, env: process.env });
 }
 
 /**
@@ -262,7 +263,7 @@ program
     .addOption(new commander.Option('-s, --suite [suite...]', 'test suite to run').choices(['unit', 'visual']))
     .option('-f, --file [file]', 'run a specific test file')
     .option('-a, --all', 'run all tests', false)
-    .option('-d, --debug', 'display some debugging', false)
+    .option('-d, --debug', 'debug visual tests by overriding golden images', false)
     .option('-cc, --clear-cache', 'clear CLI test cache', false)
     .action((options) => {
         if (options.clearCache) {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -229,7 +229,11 @@ async function runIntreactiveTestSuite(debug) {
         acc[curr.type].push(`test/${curr.type}/${curr.file}`);
         return acc;
     }, { unit: [], visual: [] });
-    _.forEach(tests, files => files.length > 0 && test(files, debug));
+    _.forEach(tests, files => {
+        if (files.length > 0) {
+            test(files, debug);
+        }
+    });
 }
 
 program

--- a/test/lib/visualTestLoop.js
+++ b/test/lib/visualTestLoop.js
@@ -160,7 +160,9 @@
             if (!isOK) {
               var stringa = imageDataToChalk(output);
               console.log(stringa);
-              QUnit.debugVisual && generateGolden(getGoldeName(golden), renderedCanvas);
+            }
+            if ((!isOK && QUnit.debugVisual) || QUnit.recreateVisualRefs) {
+              generateGolden(getGoldeName(golden), renderedCanvas);
             }
             fabricCanvas.dispose();
             done();

--- a/test/lib/visualTestLoop.js
+++ b/test/lib/visualTestLoop.js
@@ -61,13 +61,20 @@
     return fabric.isLikelyNode ? localPath('/..', finalName) : getAbsolutePath('/test' + finalName);
   }
 
+  function generateGolden(filename, original) {
+    if (fabric.isLikelyNode && original) {
+      var plainFileName = filename.replace('file://', '');
+      var dataUrl = original.toDataURL().split(',')[1];
+      console.log('creating original for ', filename);
+      fs.writeFileSync(plainFileName, dataUrl, { encoding: 'base64' });
+    }
+  }
+
   function getImage(filename, original, callback) {
     if (fabric.isLikelyNode && original) {
       var plainFileName = filename.replace('file://', '');
-      if (!fs.existsSync(plainFileName) || QUnit.debug) {
-        var dataUrl = original.toDataURL().split(',')[1];
-        console.log('creating original for ', filename);
-        fs.writeFileSync(plainFileName, dataUrl, { encoding: 'base64' });
+      if (!fs.existsSync(plainFileName)) {
+        generateGolden(filename, original);
       }
     }
     var img = fabric.document.createElement('img');
@@ -153,9 +160,10 @@
             if (!isOK) {
               var stringa = imageDataToChalk(output);
               console.log(stringa);
+              QUnit.debugVisual && generateGolden(getGoldeName(golden), renderedCanvas);
             }
-            done();
             fabricCanvas.dispose();
+            done();
           });
         });
       });

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -4,8 +4,12 @@ var diff = require('deep-object-diff').diff;
 var commander = require('commander');
 
 commander.program.option('-d, --debug', 'write golden file in case of difference in visual test').action(options => {
-  QUnit.debug = options.debug;
+  QUnit.debug = QUnit.debugVisual = options.debug;
 }).parse(process.argv);
+//  for now accept an env variable because qunit doesn't allow passing unknown options
+if (process.env.QUNIT_DEBUG_VISUAL_TESTS === 'true') {
+  QUnit.debugVisual = true;
+}
 
 global.fabric = require('../dist/fabric').fabric;
 global.pixelmatch = require('pixelmatch');

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -3,12 +3,19 @@ var chalk = require('chalk');
 var diff = require('deep-object-diff').diff;
 var commander = require('commander');
 
-commander.program.option('-d, --debug', 'write golden file in case of difference in visual test').action(options => {
-  QUnit.debug = QUnit.debugVisual = options.debug;
-}).parse(process.argv);
+commander.program
+  .option('-d, --debug', 'debug visual tests by overriding refs (golden images) in case of visual changes', false)
+  .option('-r, --recreate', 'recreate visual refs (golden images)', false)
+  .action(options => {
+    QUnit.debug = QUnit.debugVisual = options.debug;
+    QUnit.recreateVisualRefs = options.recreate;
+  }).parse(process.argv);
 //  for now accept an env variable because qunit doesn't allow passing unknown options
 if (process.env.QUNIT_DEBUG_VISUAL_TESTS === 'true') {
   QUnit.debugVisual = true;
+}
+if (process.env.QUNIT_RECREATE_VISUAL_REFS === 'true') {
+  QUnit.recreateVisualRefs = true;
 }
 
 global.fabric = require('../dist/fabric').fabric;


### PR DESCRIPTION
Finalizes #7825 

> Excellent.
> The only think I'm thinking of is this:
> > Added a debug flag for visual tests to recreate a golden file for the dev to compare changes (this means we need to relay of a https://github.com/qunitjs/qunit/pull/1681 or simply use my branch)

> I can simply add a env var instead of waiting for quint to allow other flags

_Originally posted by @ShaMan123 in https://github.com/fabricjs/fabric.js/issues/7825#issuecomment-1079698430_

**DONE**