### PR TITLE
fix(itext): `set` during text editing

### DIFF
--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -592,6 +592,8 @@
         this.canvas.defaultCursor = this._savedProps.defaultCursor;
         this.canvas.moveCursor = this._savedProps.moveCursor;
       }
+
+      delete this._savedProps;
     },
 
     /**

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -187,6 +187,21 @@
     },
 
     /**
+     * While editing handle differently
+     * @private
+     * @param {string} key 
+     * @param {*} value 
+     */
+    _set: function (key, value) {
+      if (this.isEditing && this._savedProps && key in this._savedProps) {
+        this._savedProps[key] = value;
+      }
+      else {
+        this.callSuper('_set', key, value);
+      }
+    },
+
+    /**
      * Sets selection start (left boundary of a selection)
      * @param {Number} index Index to set selection start to
      */

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -299,10 +299,17 @@
       assert.deepEqual(_savedProps, iText._savedProps, 'iText saves a copy of important props');
       assert.equal(iText.selectable, false, 'selectable is set to false');
       assert.equal(iText.hasControls, false, 'hasControls is set to false');
+      assert.equal(iText.lockMovementX, true, 'lockMovementX is set to true');
+      assert.equal(iText._savedProps.lockMovementX, false, 'lockMovementX is set to false originally');
+      iText.set({ hasControls: true, lockMovementX: true });
+      assert.equal(iText.hasControls, false, 'hasControls is still set to false');
+      assert.equal(iText._savedProps.lockMovementX, true, 'lockMovementX should have been set to true');
       iText.exitEditing();
+      assert.ok(!iText._savedProps, 'removed ref');
       iText.abortCursorAnimation();
       assert.equal(iText.selectable, true, 'selectable is set back to true');
       assert.equal(iText.hasControls, true, 'hasControls is set back to true');
+      assert.equal(iText.lockMovementX, true, 'lockMovementX is set back to true, after changing saved props');
       iText.selectable = false;
       iText.enterEditing();
       iText.exitEditing();


### PR DESCRIPTION
### Motivation 
closes #7836 

Simple PR that assigns editing props to the saved object when in editing. This way once exiting is done the right props are restored and not stale ones.