### PR TITLE
fix(Polyline): safegurad `_setPositionDimensions`

### DIFF
--- a/src/shapes/polyline.class.js
+++ b/src/shapes/polyline.class.js
@@ -83,6 +83,7 @@
     },
 
     _setPositionDimensions: function(options) {
+      options || (options = {});
       var calcDim = this._calcDimensions(options), correctLeftTop,
           correctSize = this.exactBoundingBox ? this.strokeWidth : 0;
       this.width = calcDim.width - correctSize;


### PR DESCRIPTION

before
```js
poly._setPositionDimensions() //throws error
poly._setPositionDimensions({}) //ok
```

now both are ok