### PR TITLE
chore(canvas): minor cleanup

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1326,7 +1326,7 @@
       var originalProperties = this._realizeGroupTransformOnObject(instance),
           object = this.callSuper('_toObject', instance, methodName, propertiesToInclude);
       //Undo the damage we did by changing all of its properties
-      this._unwindGroupTransformOnObject(instance, originalProperties);
+      originalProperties && instance.set(originalValues);
       return object;
     },
 
@@ -1353,18 +1353,6 @@
     },
 
     /**
-     * Restores the changed properties of instance
-     * @private
-     * @param {fabric.Object} [instance] the object to un-transform (gets mutated)
-     * @param {Object} [originalValues] the original values of instance, as returned by _realizeGroupTransformOnObject
-     */
-    _unwindGroupTransformOnObject: function(instance, originalValues) {
-      if (originalValues) {
-        instance.set(originalValues);
-      }
-    },
-
-    /**
      * @private
      */
     _setSVGObject: function(markup, instance, reviver) {
@@ -1372,7 +1360,7 @@
       //object when the group is deselected
       var originalProperties = this._realizeGroupTransformOnObject(instance);
       this.callSuper('_setSVGObject', markup, instance, reviver);
-      this._unwindGroupTransformOnObject(instance, originalProperties);
+      originalProperties && instance.set(originalValues);
     },
 
     setViewportTransform: function (vpt) {

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -41,7 +41,7 @@
    * @fires drop
    * @fires after:render at the end of the render process, receives the context in the callback
    * @fires before:render at start the render process, receives the context in the callback
-   * 
+   *
    * @fires contextmenu:before
    * @fires contextmenu
    * @example
@@ -1326,7 +1326,7 @@
       var originalProperties = this._realizeGroupTransformOnObject(instance),
           object = this.callSuper('_toObject', instance, methodName, propertiesToInclude);
       //Undo the damage we did by changing all of its properties
-      originalProperties && instance.set(originalValues);
+      originalProperties && instance.set(originalProperties);
       return object;
     },
 
@@ -1360,7 +1360,7 @@
       //object when the group is deselected
       var originalProperties = this._realizeGroupTransformOnObject(instance);
       this.callSuper('_setSVGObject', markup, instance, reviver);
-      originalProperties && instance.set(originalValues);
+      originalProperties && instance.set(originalProperties);
     },
 
     setViewportTransform: function (vpt) {

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -397,7 +397,7 @@
 
       /**
        * Prepare the pattern for the erasing brush
-       * This pattern will be drawn on the top context after clipping the main context, 
+       * This pattern will be drawn on the top context after clipping the main context,
        * achieving a visual effect of erasing only erasable objects
        * @private
        */

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -189,8 +189,8 @@
     /**
      * While editing handle differently
      * @private
-     * @param {string} key 
-     * @param {*} value 
+     * @param {string} key
+     * @param {*} value
      */
     _set: function (key, value) {
       if (this.isEditing && this._savedProps && key in this._savedProps) {

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -883,14 +883,14 @@
      * Measure and return the info of a single grapheme.
      * needs the the info of previous graphemes already filled
      * Override to customize measuring
-     * 
+     *
      * @typedef {object} GraphemeBBox
      * @property {number} width
      * @property {number} height
      * @property {number} kernedWidth
      * @property {number} left
      * @property {number} deltaY
-     * 
+     *
      * @param {String} grapheme to be measured
      * @param {Number} lineIndex index of the line where the char is
      * @param {Number} charIndex position in the line

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -282,7 +282,7 @@
      * It gets called when charBounds are not available yet.
      * Override if necessary
      * Use with {@link fabric.Textbox#wordSplit}
-     * 
+     *
      * @param {CanvasRenderingContext2D} ctx
      * @param {String} text
      * @param {number} lineIndex
@@ -350,7 +350,7 @@
         return { word: word, width: width };
       }.bind(this));
       var maxWidth = Math.max(desiredWidth, largestWordWidth, this.dynamicMinWidth);
-      // layout words 
+      // layout words
       offset = 0;
       for (var i = 0; i < words.length; i++) {
         word = data[i].word;


### PR DESCRIPTION
1. remove `_unwindGroupTransformOnObject`, an unnecessary method.
2. lint artifacts