### PR TITLE
feat(Group): 2nd Patch of New Group! 🎉

### DIFF
--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -112,7 +112,12 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       rects = this._getOptimizedRects(rects);
     }
 
-    var group = new fabric.Group(rects, { objectCaching: true, layout: 'fixed', subTargetCheck: false });
+    var group = new fabric.Group(rects, {
+      objectCaching: true,
+      layout: 'fixed',
+      subTargetCheck: false,
+      interactive: false
+    });
     this.shadow && group.set('shadow', new fabric.Shadow(this.shadow));
     this.canvas.fire('before:path:created', { path: group });
     this.canvas.add(group);

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -112,7 +112,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       rects = this._getOptimizedRects(rects);
     }
 
-    var group = new fabric.Group(rects);
+    var group = new fabric.Group(rects, { objectCaching: true, layout: 'fixed', subTargetCheck: false });
     this.shadow && group.set('shadow', new fabric.Shadow(this.shadow));
     this.canvas.fire('before:path:created', { path: group });
     this.canvas.add(group);

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -892,7 +892,7 @@
      */
     searchPossibleTargets: function (objects, pointer) {
       var target = this._searchPossibleTargets(objects, pointer);
-      return target;
+      return /*this.targets[0] ||*/ target;
     },
 
     /**

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -892,7 +892,7 @@
      */
     searchPossibleTargets: function (objects, pointer) {
       var target = this._searchPossibleTargets(objects, pointer);
-        return target && target.interactive && this.targets[0] ? this.targets[0] : target;
+      return target && target.interactive && this.targets[0] ? this.targets[0] : target;
     },
 
     /**

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -892,7 +892,7 @@
      */
     searchPossibleTargets: function (objects, pointer) {
       var target = this._searchPossibleTargets(objects, pointer);
-      return this.targets[0] || target;
+        return target && target.interactive && this.targets[0] ? this.targets[0] : target;
     },
 
     /**

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -441,7 +441,7 @@
         }
         objsToRender.push.apply(objsToRender, activeGroupObjects);
       }
-      //  in case a single object is selected render it's entire above the other objects
+      //  in case a single object is selected render it's entire parent above the other objects
       else if (!this.preserveObjectStacking && activeObjects.length === 1) {
         var target = activeObjects[0], ancestors = target.getAncestors(true);
         var topAncestor = ancestors.length === 0 ? target : ancestors.pop();

--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -892,7 +892,7 @@
      */
     searchPossibleTargets: function (objects, pointer) {
       var target = this._searchPossibleTargets(objects, pointer);
-      return /*this.targets[0] ||*/ target;
+      return this.targets[0] || target;
     },
 
     /**

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -712,10 +712,13 @@
           }
         }
       }
-      this._objectsToRender = this._chooseObjectsToRender();
+      var invalidate = shouldRender || shouldGroup;
+      //  we clear `_objectsToRender` in case of a change in order to repopulate it at rendering
+      //  run before firing the `down` event to give the dev a chance to populate it themselves
+      invalidate && (this._objectsToRender = undefined);
       this._handleEvent(e, 'down');
       // we must renderAll so that we update the visuals
-      (shouldRender || shouldGroup) && this.requestRenderAll();
+      invalidate && this.requestRenderAll();
     },
 
     /**

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -712,6 +712,7 @@
           }
         }
       }
+      this._objectsToRender = this._chooseObjectsToRender();
       this._handleEvent(e, 'down');
       // we must renderAll so that we update the visuals
       (shouldRender || shouldGroup) && this.requestRenderAll();

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -904,7 +904,9 @@
           target = transform.target,
           //  transform pointer to target's containing coordinate plane
           //  both pointer and object should agree on every point
-          localPointer = fabric.util.sendPointToPlane(pointer, null, target.group);
+          localPointer = target.group ?
+            fabric.util.sendPointToPlane(pointer, null, target.group.calcTransformMatrix()) :
+            pointer;
 
       transform.reset = false;
       transform.shiftKey = e.shiftKey;

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -905,7 +905,7 @@
           //  transform pointer to target's containing coordinate plane
           //  both pointer and object should agree on every point
           localPointer = fabric.util.sendPointToPlane(pointer, null, target.group);
-      
+
       transform.reset = false;
       transform.shiftKey = e.shiftKey;
       transform.altKey = e[this.centeredKey];

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -900,13 +900,17 @@
      */
     _transformObject: function(e) {
       var pointer = this.getPointer(e),
-          transform = this._currentTransform;
-
+          transform = this._currentTransform,
+          target = transform.target,
+          //  transform pointer to target's containing coordinate plane
+          //  both pointer and object should agree on every point
+          localPointer = fabric.util.sendPointToPlane(pointer, null, target.group);
+      
       transform.reset = false;
       transform.shiftKey = e.shiftKey;
       transform.altKey = e[this.centeredKey];
 
-      this._performTransformAction(e, transform, pointer);
+      this._performTransformAction(e, transform, localPointer);
       transform.actionPerformed && this.requestRenderAll();
     },
 

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -54,7 +54,7 @@
     _updateActiveSelection: function(target, e) {
       var activeSelection = this._activeObject,
           currentActiveObjects = activeSelection._objects.slice(0);
-      if (activeSelection.contains(target)) {
+      if (target.group === activeSelection) {
         activeSelection.remove(target);
         this._hoveredTarget = target;
         this._hoveredTargets = this.targets.concat();

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -13,8 +13,16 @@
      */
     _shouldGroup: function(e, target) {
       var activeObject = this._activeObject;
+      // first 2 lines are the pre-requisites for selecting.
+      // !!activeObject an activeObjectExists and the user is pressing the selectionKey
+      // on top of that the user also has to hit a target that is selectable.
+      // this.selection is the canvas switch to support multi selection.
       return !!activeObject && this._isSelectionKeyPressed(e)
         && !!target && target.selectable && this.selection
+        // if all pre-requisite pass, the target is either something different from the current
+        // activeObject or if an activeSelection already exists
+        // TODO at time of writing why `activeObject.type === 'activeSelection'` matter is unclear.
+        // is a very old condition uncertain if still valid.
         && (activeObject !== target || activeObject.type === 'activeSelection')
         //  make sure `activeObject` and `target` aren't ancestors of each other
         && !target.isDescendantOf(activeObject) && !activeObject.isDescendantOf(target)

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -13,8 +13,8 @@
      */
     _shouldGroup: function(e, target) {
       var activeObject = this._activeObject;
-      return activeObject && this._isSelectionKeyPressed(e)
-        && target && target.selectable && this.selection
+      return !!activeObject && this._isSelectionKeyPressed(e)
+        && !!target && target.selectable && this.selection
         && (activeObject !== target || activeObject.type === 'activeSelection')
         //  make sure `activeObject` and `target` aren't ancestors of each other
         && !target.isDescendantOf(activeObject) && !activeObject.isDescendantOf(target)

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -13,8 +13,12 @@
      */
     _shouldGroup: function(e, target) {
       var activeObject = this._activeObject;
-      return activeObject && this._isSelectionKeyPressed(e) && target && target.selectable && this.selection &&
-            (activeObject !== target || activeObject.type === 'activeSelection') && !target.onSelect({ e: e });
+      return activeObject && this._isSelectionKeyPressed(e)
+        && target && target.selectable && this.selection
+        && (activeObject !== target || activeObject.type === 'activeSelection')
+        //  make sure `activeObject` and `target` aren't ancestors of each other
+        && !target.isDescendantOf(activeObject) && !activeObject.isDescendantOf(target)
+        && !target.onSelect({ e: e });
     },
 
     /**
@@ -80,17 +84,19 @@
       this._fireSelectionEvents(currentActives, e);
     },
 
+
     /**
      * @private
      * @param {Object} target
+     * @returns {fabric.ActiveSelection}
      */
     _createGroup: function(target) {
-      var objects = this._objects,
-          isActiveLower = objects.indexOf(this._activeObject) < objects.indexOf(target),
-          groupObjects = isActiveLower
-            ? [this._activeObject, target]
-            : [target, this._activeObject];
-      this._activeObject.isEditing && this._activeObject.exitEditing();
+      var activeObject = this._activeObject;
+      var groupObjects = target.isInFrontOf(activeObject) ?
+        [activeObject, target] :
+        [target, activeObject];
+      activeObject.isEditing && activeObject.exitEditing();
+      //  handle case: target is nested
       return new fabric.ActiveSelection(groupObjects, {
         canvas: this
       });

--- a/src/mixins/canvas_grouping.mixin.js
+++ b/src/mixins/canvas_grouping.mixin.js
@@ -13,12 +13,10 @@
      */
     _shouldGroup: function(e, target) {
       var activeObject = this._activeObject;
-      // first 2 lines are the pre-requisites for selecting.
-      // !!activeObject an activeObjectExists and the user is pressing the selectionKey
-      // on top of that the user also has to hit a target that is selectable.
-      // this.selection is the canvas switch to support multi selection.
-      return !!activeObject && this._isSelectionKeyPressed(e)
-        && !!target && target.selectable && this.selection
+      // check if an active object exists on canvas and if the user is pressing the `selectionKey` while canvas supports multi selection.
+      return !!activeObject && this._isSelectionKeyPressed(e) && this.selection
+        // on top of that the user also has to hit a target that is selectable.
+        && !!target && target.selectable
         // if all pre-requisite pass, the target is either something different from the current
         // activeObject or if an activeSelection already exists
         // TODO at time of writing why `activeObject.type === 'activeSelection'` matter is unclear.
@@ -26,6 +24,7 @@
         && (activeObject !== target || activeObject.type === 'activeSelection')
         //  make sure `activeObject` and `target` aren't ancestors of each other
         && !target.isDescendantOf(activeObject) && !activeObject.isDescendantOf(target)
+        //  target accepts selection
         && !target.onSelect({ e: e });
     },
 

--- a/src/mixins/collection.mixin.js
+++ b/src/mixins/collection.mixin.js
@@ -131,6 +131,7 @@ fabric.Collection = {
   /**
    * Returns true if collection contains an object.\
    * **Prefer using {@link `fabric.Object#isDescendantOf`} for performance reasons**
+   * instead of a.contains(b) use b.isDescendantOf(a)
    * @param {Object} object Object to check against
    * @param {Boolean} [deep=false] `true` to check all descendants, `false` to check only `_objects`
    * @return {Boolean} `true` if collection contains an object

--- a/src/mixins/collection.mixin.js
+++ b/src/mixins/collection.mixin.js
@@ -53,8 +53,8 @@ fabric.Collection = {
    * @returns {fabric.Object[]} removed objects
    */
   remove: function(objectsToRemove, callback) {
-    var objects = this._objects, index, removed = [];
-    for (var i = 0, object; i < objectsToRemove.length; i++) {
+    var objects = this._objects, removed = [];
+    for (var i = 0, object, index; i < objectsToRemove.length; i++) {
       object = objectsToRemove[i];
       index = objects.indexOf(object);
       // only call onObjectRemoved if an object was actually removed

--- a/src/mixins/collection.mixin.js
+++ b/src/mixins/collection.mixin.js
@@ -50,22 +50,21 @@ fabric.Collection = {
    * @private
    * @param {fabric.Object[]} objectsToRemove objects to remove
    * @param {(object:fabric.Object) => any} [callback] function to call for each object removed
-   * @returns {boolean} true if objects were removed
+   * @returns {fabric.Object[]} removed objects
    */
   remove: function(objectsToRemove, callback) {
-    var objects = this._objects,
-        index, somethingRemoved = false;
-
-    for (var i = 0; i < objectsToRemove.length; i++) {
-      index = objects.indexOf(objectsToRemove[i]);
+    var objects = this._objects, index, removed = [];
+    for (var i = 0, object; i < objectsToRemove.length; i++) {
+      object = objectsToRemove[i];
+      index = objects.indexOf(object);
       // only call onObjectRemoved if an object was actually removed
       if (index !== -1) {
-        somethingRemoved = true;
         objects.splice(index, 1);
-        callback && callback.call(this, objectsToRemove[i]);
+        removed.push(object);
+        callback && callback.call(this, object);
       }
     }
-    return somethingRemoved;
+    return removed;
   },
 
   /**

--- a/src/mixins/collection.mixin.js
+++ b/src/mixins/collection.mixin.js
@@ -20,7 +20,7 @@ fabric.Collection = {
   add: function (objects, callback) {
     var size = this._objects.push.apply(this._objects, objects);
     if (callback) {
-      for (var i = 0, length = objects.length; i < length; i++) {
+      for (var i = 0; i < objects.length; i++) {
         callback.call(this, objects[i]);
       }
     }
@@ -39,7 +39,7 @@ fabric.Collection = {
     var args = [index, 0].concat(objects);
     this._objects.splice.apply(this._objects, args);
     if (callback) {
-      for (var i = 2, length = args.length; i < length; i++) {
+      for (var i = 2; i < args.length; i++) {
         callback.call(this, args[i]);
       }
     }
@@ -56,7 +56,7 @@ fabric.Collection = {
     var objects = this._objects,
         index, somethingRemoved = false;
 
-    for (var i = 0, length = objectsToRemove.length; i < length; i++) {
+    for (var i = 0; i < objectsToRemove.length; i++) {
       index = objects.indexOf(objectsToRemove[i]);
       // only call onObjectRemoved if an object was actually removed
       if (index !== -1) {
@@ -82,7 +82,7 @@ fabric.Collection = {
    */
   forEachObject: function(callback, context) {
     var objects = this.getObjects();
-    for (var i = 0, len = objects.length; i < len; i++) {
+    for (var i = 0; i < objects.length; i++) {
       callback.call(context, objects[i], i, objects);
     }
     return this;

--- a/src/mixins/eraser_brush.mixin.js
+++ b/src/mixins/eraser_brush.mixin.js
@@ -125,7 +125,6 @@
     /* _TO_SVG_END_ */
   });
 
-  var __restoreObjectsState = fabric.Group.prototype._restoreObjectsState;
   fabric.util.object.extend(fabric.Group.prototype, {
     /**
      * @private
@@ -181,15 +180,6 @@
               });
           }
         });
-    },
-
-    /**
-     * Propagate the group's eraser to its objects, crucial for proper functionality of the eraser within the group and nested objects.
-     * @private
-     */
-    _restoreObjectsState: function () {
-      this.erasable === true && this.applyEraserToObjects();
-      return __restoreObjectsState.call(this);
     }
   });
 
@@ -217,14 +207,6 @@
      */
     originY: 'center',
 
-    drawObject: function (ctx) {
-      ctx.save();
-      ctx.fillStyle = 'black';
-      ctx.fillRect(-this.width / 2, -this.height / 2, this.width, this.height);
-      ctx.restore();
-      this.callSuper('drawObject', ctx);
-    },
-
     /**
      * eraser should retain size
      * dimensions should not change when paths are added or removed
@@ -232,8 +214,14 @@
      * @override
      * @private
      */
-    _getBounds: function () {
-      //  noop
+    layout: 'fixed',
+
+    drawObject: function (ctx) {
+      ctx.save();
+      ctx.fillStyle = 'black';
+      ctx.fillRect(-this.width / 2, -this.height / 2, this.width, this.height);
+      ctx.restore();
+      this.callSuper('drawObject', ctx);
     },
 
     /* _TO_SVG_START_ */

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -25,8 +25,9 @@
      */
     initAddedHandler: function() {
       var _this = this;
-      this.on('added', function() {
-        var canvas = _this.canvas;
+      this.on('added', function (opt) {
+        //  make sure we listen to the canvas added event
+        var canvas = opt.target;
         if (canvas) {
           if (!canvas._hasITextHandlers) {
             canvas._hasITextHandlers = true;
@@ -40,8 +41,9 @@
 
     initRemovedHandler: function() {
       var _this = this;
-      this.on('removed', function() {
-        var canvas = _this.canvas;
+      this.on('removed', function (opt) {
+        //  make sure we listen to the canvas removed event
+        var canvas = opt.target;
         if (canvas) {
           canvas._iTextInstances = canvas._iTextInstances || [];
           fabric.util.removeFromArray(canvas._iTextInstances, _this);

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -152,7 +152,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    */
   mouseUpHandler: function(options) {
     this.__isMousedown = false;
-    if (!this.editable || this.group ||
+    if (!this.editable ||
       (options.transform && options.transform.actionPerformed) ||
       (options.e.button && options.e.button !== 1)) {
       return;

--- a/src/mixins/itext_click_behavior.mixin.js
+++ b/src/mixins/itext_click_behavior.mixin.js
@@ -153,6 +153,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
   mouseUpHandler: function(options) {
     this.__isMousedown = false;
     if (!this.editable ||
+      (this.group && !this.group.interactive) ||
       (options.transform && options.transform.actionPerformed) ||
       (options.e.button && options.e.button !== 1)) {
       return;

--- a/src/mixins/object_ancestry.mixin.js
+++ b/src/mixins/object_ancestry.mixin.js
@@ -39,7 +39,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
   /**
    *
    * @param {fabric.Object} other
-   * @returns {{ index: number, otherIndex: number, ancestors: fabric.Object[] }} ancestors may include the passed objects if one is an ancestor of the other resulting in index of -1
+   * @returns {{ index: number, otherIndex: number, ancestors: fabric.Object[] } | boolean} ancestors may include the passed objects if one is an ancestor of the other resulting in index of -1
    */
   findCommonAncestors: function (other) {
     if (this === other) {

--- a/src/mixins/object_ancestry.mixin.js
+++ b/src/mixins/object_ancestry.mixin.js
@@ -23,8 +23,10 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
 
   /**
    *
+   * @typedef {fabric.Object[] | [...fabric.Object[], fabric.StaticCanvas]} Ancestors
+   * 
    * @param {boolean} [strict] returns only ancestors that are objects (without canvas)
-   * @returns {(fabric.Object | fabric.StaticCanvas)[]} ancestors from bottom to top
+   * @returns {Ancestors} ancestors from bottom to top
    */
   getAncestors: function (strict) {
     var ancestors = [];
@@ -39,23 +41,28 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
   /**
    *
    * @param {fabric.Object} other
-   * @returns {{ index: number, otherIndex: number, ancestors: fabric.Object[] } | boolean} ancestors may include the passed objects if one is an ancestor of the other resulting in index of -1
+   * @param {boolean} [strict] finds only ancestors that are objects (without canvas)
+   * @returns {{ index: number, otherIndex: number, ancestors: Ancestors } | undefined} ancestors may include the passed objects if one is an ancestor of the other resulting in index of -1
    */
-  findCommonAncestors: function (other) {
+  findCommonAncestors: function (other, strict) {
     if (this === other) {
-      return true;
+      return {
+        index: 0,
+        otherIndex: 0,
+        ancestors: this.getAncestors(strict)
+      };
     }
     else if (!other) {
-      return false;
+      return undefined;
     }
-    var ancestors = this.getAncestors();
+    var ancestors = this.getAncestors(strict);
     ancestors.unshift(this);
-    var otherAncestors = other.getAncestors();
+    var otherAncestors = other.getAncestors(strict);
     otherAncestors.unshift(other);
     for (var i = 0, ancestor; i < ancestors.length; i++) {
       ancestor = ancestors[i];
       for (var j = 0; j < otherAncestors.length; j++) {
-        if (ancestor === otherAncestors[j] && !(ancestor instanceof fabric.StaticCanvas)) {
+        if (ancestor === otherAncestors[j]) {
           return {
             index: i - 1,
             otherIndex: j - 1,
@@ -69,9 +76,10 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
   /**
    *
    * @param {fabric.Object} other
+   * @param {boolean} [strict] checks only ancestors that are objects (without canvas)
    * @returns {boolean}
    */
-  hasCommonAncestors: function (other) {
-    return !!this.findCommonAncestors(other);
+  hasCommonAncestors: function (other, strict) {
+    return !!this.findCommonAncestors(other, strict);
   }
 });

--- a/src/mixins/object_ancestry.mixin.js
+++ b/src/mixins/object_ancestry.mixin.js
@@ -28,10 +28,10 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
    */
   getAncestors: function (strict) {
     var ancestors = [];
-    var parent = this.group || (!strict ? this.canvas : undefined);
+    var parent = this.group || (strict ? undefined : this.canvas);
     while (parent) {
       ancestors.push(parent);
-      parent = parent.group || (!strict ? parent.canvas : undefined);
+      parent = parent.group || (strict ? undefined : parent.canvas);
     }
     return ancestors;
   },

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -137,7 +137,11 @@
     },
 
     /**
-     * @param {fabric.Point} point position according to object's {@link fabric.Object#originX} {@link fabric.Object#originY} properties in canvas coordinate plane
+     * Set an object position to a particular point, the point is intended in absolute ( canvas ) coordinate.
+     * If you need to pint the object on a particular point, you can specify that using originX and originY,
+     * that otherwise are the object's current values. {@link fabric.Object#originX} {@link fabric.Object#originY}
+     * Example: to set an object bottom left corner to point 5,5, uses setXY(new fabric.Point(5,5), 'left', 'bottom').
+     * @param {fabric.Point} point position in canvas coordinate plane
      * @param {'left'|'center'|'right'|number} [originX] Horizontal origin: 'left', 'center' or 'right'
      * @param {'top'|'center'|'bottom'|number} [originY] Vertical origin: 'top', 'center' or 'bottom'
      */
@@ -159,6 +163,7 @@
     },
 
     /**
+     * As {@link fabric.Object#setXY}, but in current parent's coordinate plane ( the current group if any or the canvas)
      * @param {fabric.Point} point position according to object's {@link fabric.Object#originX} {@link fabric.Object#originY} properties in parent's coordinate plane
      * @param {'left'|'center'|'right'|number} [originX] Horizontal origin: 'left', 'center' or 'right'
      * @param {'top'|'center'|'bottom'|number} [originY] Vertical origin: 'top', 'center' or 'bottom'

--- a/src/mixins/object_geometry.mixin.js
+++ b/src/mixins/object_geometry.mixin.js
@@ -138,9 +138,10 @@
 
     /**
      * Set an object position to a particular point, the point is intended in absolute ( canvas ) coordinate.
-     * If you need to pint the object on a particular point, you can specify that using originX and originY,
-     * that otherwise are the object's current values. {@link fabric.Object#originX} {@link fabric.Object#originY}
-     * Example: to set an object bottom left corner to point 5,5, uses setXY(new fabric.Point(5,5), 'left', 'bottom').
+     * You can specify {@link fabric.Object#originX} and {@link fabric.Object#originY} values,
+     * that otherwise are the object's current values.
+     * @example <caption>Set object's bottom left corner to point (5,5) on canvas</caption>
+     * object.setXY(new fabric.Point(5, 5), 'left', 'bottom').
      * @param {fabric.Point} point position in canvas coordinate plane
      * @param {'left'|'center'|'right'|number} [originX] Horizontal origin: 'left', 'center' or 'right'
      * @param {'top'|'center'|'bottom'|number} [originY] Vertical origin: 'top', 'center' or 'bottom'

--- a/src/mixins/object_stacking.mixin.js
+++ b/src/mixins/object_stacking.mixin.js
@@ -87,8 +87,8 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this === other) {
       return undefined;
     }
-    var ancestors = this.getAncestors().reverse().concat(this);
-    var otherAncestors = other.getAncestors().reverse().concat(other);
+    var ancestors = this.getAncestors(true).reverse().concat(this);
+    var otherAncestors = other.getAncestors(true).reverse().concat(other);
     var i, j, found = false;
     //  find the common ancestor
     for (i = 0; i < ancestors.length; i++) {

--- a/src/mixins/object_stacking.mixin.js
+++ b/src/mixins/object_stacking.mixin.js
@@ -87,8 +87,8 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this === other) {
       return undefined;
     }
-    var ancestors = this.getAncestors(true).reverse().concat(this);
-    var otherAncestors = other.getAncestors(true).reverse().concat(other);
+    var ancestors = this.getAncestors().reverse().concat(this);
+    var otherAncestors = other.getAncestors().reverse().concat(other);
     var i, j, found = false;
     //  find the common ancestor
     for (i = 0; i < ancestors.length; i++) {

--- a/src/mixins/object_stacking.mixin.js
+++ b/src/mixins/object_stacking.mixin.js
@@ -87,37 +87,24 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
     if (this === other) {
       return undefined;
     }
-    var ancestors = this.getAncestors().reverse().concat(this);
-    var otherAncestors = other.getAncestors().reverse().concat(other);
-    var i, j, found = false;
-    //  find the common ancestor
-    for (i = 0; i < ancestors.length; i++) {
-      for (j = 0; j < otherAncestors.length; j++) {
-        if (ancestors[i] === otherAncestors[j]) {
-          found = true;
-          break;
-        }
-      }
-      if (found) {
-        break;
-      }
-    }
-    if (!found) {
+    var ancestorData = this.findCommonAncestors(other);
+    if (!ancestorData) {
       return undefined;
     }
-    //  compare trees from the common ancestor down
-    var tree = ancestors.slice(i),
-        otherTree = otherAncestors.slice(j),
-        a, b, parent;
-    for (i = 1; i < Math.min(tree.length, otherTree.length); i++) {
-      a = tree[i];
-      b = otherTree[i];
-      if (a !== b) {
-        parent = tree[i - 1];
-        return parent._objects.indexOf(a) > parent._objects.indexOf(b);
-      }
+    if (ancestorData.fork.includes(other)) {
+      return true;
     }
-    //  happens if a is ancestor of b or vice versa
-    return tree.length > otherTree.length;
+    if (ancestorData.otherFork.includes(this)) {
+      return false;
+    }
+    var firstCommonAncestor = ancestorData.common[0];
+    if (!firstCommonAncestor) {
+      return undefined;
+    }
+    var headOfFork = ancestorData.fork.pop(),
+        headOfOtherFork = ancestorData.otherFork.pop(),
+        thisIndex = firstCommonAncestor._objects.indexOf(headOfFork),
+        otherIndex = firstCommonAncestor._objects.indexOf(headOfOtherFork);
+    return thisIndex > -1 && thisIndex > otherIndex;
   }
 });

--- a/src/shapes/active_selection.class.js
+++ b/src/shapes/active_selection.class.js
@@ -52,6 +52,27 @@
       this.setCoords();
     },
 
+
+    /**
+     * @private
+     * @param {fabric.Object} object
+     * @param {boolean} [removeParentTransform] true if object is in canvas coordinate plane
+     * @returns {boolean} true if object entered group
+     */
+    enterGroup: function (object, removeParentTransform) {
+      if (!this.canEnter(object)) {
+        return false;
+      }
+      if (object.group) {
+        //  save ref to group for later in order to return to it
+        var parent = object.group;
+        parent._exitGroup(object);
+        object.__owningGroup = parent;
+      }
+      this._enterGroup(object, removeParentTransform);
+      return true;
+    },
+
     /**
      * we want objects to retain their canvas ref when exiting instance
      * @private
@@ -60,6 +81,12 @@
      */
     exitGroup: function (object, removeParentTransform) {
       this._exitGroup(object, removeParentTransform);
+      var parent = object.__owningGroup;
+      if (parent) {
+        //  return to owning group
+        parent.enterGroup(object);
+        delete object.__owningGroup;
+      }
     },
 
     /**

--- a/src/shapes/active_selection.class.js
+++ b/src/shapes/active_selection.class.js
@@ -172,7 +172,7 @@
         childrenOverride.hasControls = false;
       }
       childrenOverride.forActiveSelection = true;
-      for (var i = 0, len = this._objects.length; i < len; i++) {
+      for (var i = 0; i < this._objects.length; i++) {
         this._objects[i]._renderControls(ctx, childrenOverride);
       }
       ctx.restore();

--- a/src/shapes/active_selection.class.js
+++ b/src/shapes/active_selection.class.js
@@ -52,6 +52,12 @@
       this.setCoords();
     },
 
+    /**
+     * @private
+     */
+    _shouldSetNestedCoords: function () {
+      return true;
+    },
 
     /**
      * @private

--- a/src/shapes/active_selection.class.js
+++ b/src/shapes/active_selection.class.js
@@ -90,6 +90,30 @@
     },
 
     /**
+     * @private
+     * @param {'added'|'removed'} type
+     * @param {fabric.Object[]} targets
+     */
+    _onAfterObjectsChange: function (type, targets) {
+      var groups = [];
+      targets.forEach(function (object) {
+        object.group && !groups.includes(object.group) && groups.push(object.group);
+      });
+      if (type === 'removed') {
+        //  invalidate groups' layout and mark as dirty
+        groups.forEach(function (group) {
+          group._onAfterObjectsChange('added', targets);
+        });
+      }
+      else {
+        //  mark groups as dirty
+        groups.forEach(function (group) {
+          group._set('dirty', true);
+        });
+      }
+    },
+
+    /**
      * If returns true, deselection is cancelled.
      * @since 2.0.0
      * @return {Boolean} [cancel]

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -877,11 +877,7 @@
     /* _TO_SVG_START_ */
 
     /**
-     *
      * @private
-     * @param {'toObject'|'toDatalessObject'} [method]
-     * @param {string[]} [propertiesToInclude] Any properties that you might want to additionally include in the output
-     * @returns {fabric.Object[]} serialized objects
      */
     _createSVGBgRect: function (reviver) {
       if (!this.backgroundColor) {

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -158,10 +158,12 @@
     /**
      * Remove objects
      * @param {...fabric.Object} objects
+     * @returns {fabric.Object[]} removed objects
      */
     remove: function () {
-      fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);
-      this._onAfterObjectsChange('removed', Array.from(arguments));
+      var removed = fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);
+      this._onAfterObjectsChange('removed', removed);
+      return removed;
     },
 
     /**

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -877,12 +877,27 @@
     /* _TO_SVG_START_ */
 
     /**
+     * @private
+     */
+    _createSVGBgRect: function (reviver) {
+      if (!this.backgroundColor) {
+        return '';
+      }
+      var fillStroke = fabric.Rect.prototype._toSVG.call(this, reviver);
+      var commons = fillStroke.indexOf('COMMON_PARTS');
+      fillStroke[commons] = 'for="group" ';
+      return fillStroke.join('');
+    },
+
+    /**
      * Returns svg representation of an instance
      * @param {Function} [reviver] Method for further parsing of svg representation.
      * @return {String} svg representation of an instance
      */
     _toSVG: function (reviver) {
       var svgString = ['<g ', 'COMMON_PARTS', ' >\n'];
+      var bg = this._createSVGBgRect(reviver);
+      bg && svgString.push('\t\t', bg);
       for (var i = 0, len = this._objects.length; i < len; i++) {
         svgString.push('\t\t', this._objects[i].toSVG(reviver));
       }
@@ -912,6 +927,8 @@
      */
     toClipPathSVG: function (reviver) {
       var svgString = [];
+      var bg = this._createSVGBgRect(reviver);
+      bg && svgString.push('\t', bg);
       for (var i = 0, len = this._objects.length; i < len; i++) {
         svgString.push('\t', this._objects[i].toClipPathSVG(reviver));
       }

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -58,7 +58,7 @@
 
     /**
      * Used to optimize performance
-     * set to `false` if you don't need caontained objects to be target of events
+     * set to `false` if you don't need contained objects to be targets of events
      * @default
      * @type boolean
      */
@@ -66,8 +66,8 @@
 
     /**
      * Used to allow targeting of object inside groups.
-     * set to true if you want to select an object inside a group.
-     * REQUIRES subTargetCheck set to true
+     * set to true if you want to select an object inside a group.\
+     * **REQUIRES** `subTargetCheck` set to true
      * @default
      * @type boolean
      */

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -490,7 +490,7 @@
 
     /**
      * initial layout logic:
-     * calculate bbox of objects (if necessary) and translate it according to options recieved from the constructor (left, top, width, height)
+     * calculate bbox of objects (if necessary) and translate it according to options received from the constructor (left, top, width, height)
      * so it is placed in the center of the bbox received from the constructor
      *
      * @private

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -371,7 +371,7 @@
     shouldCache: function() {
       var ownCache = fabric.Object.prototype.shouldCache.call(this);
       if (ownCache) {
-        for (var i = 0, len = this._objects.length; i < len; i++) {
+        for (var i = 0; i < this._objects.length; i++) {
           if (this._objects[i].willDrawShadow()) {
             this.ownCaching = false;
             return false;
@@ -389,7 +389,7 @@
       if (fabric.Object.prototype.willDrawShadow.call(this)) {
         return true;
       }
-      for (var i = 0, len = this._objects.length; i < len; i++) {
+      for (var i = 0; i < this._objects.length; i++) {
         if (this._objects[i].willDrawShadow()) {
           return true;
         }
@@ -411,7 +411,7 @@
      */
     drawObject: function(ctx) {
       this._renderBackground(ctx);
-      for (var i = 0, len = this._objects.length; i < len; i++) {
+      for (var i = 0; i < this._objects.length; i++) {
         this._objects[i].render(ctx);
       }
       this._drawClipPath(ctx, this.clipPath);
@@ -427,7 +427,7 @@
       if (!this.statefullCache) {
         return false;
       }
-      for (var i = 0, len = this._objects.length; i < len; i++) {
+      for (var i = 0; i < this._objects.length; i++) {
         if (this._objects[i].isCacheDirty(true)) {
           if (this._cacheCanvas) {
             // if this group has not a cache canvas there is nothing to clean
@@ -898,7 +898,7 @@
       var svgString = ['<g ', 'COMMON_PARTS', ' >\n'];
       var bg = this._createSVGBgRect(reviver);
       bg && svgString.push('\t\t', bg);
-      for (var i = 0, len = this._objects.length; i < len; i++) {
+      for (var i = 0; i < this._objects.length; i++) {
         svgString.push('\t\t', this._objects[i].toSVG(reviver));
       }
       svgString.push('</g>\n');
@@ -929,7 +929,7 @@
       var svgString = [];
       var bg = this._createSVGBgRect(reviver);
       bg && svgString.push('\t', bg);
-      for (var i = 0, len = this._objects.length; i < len; i++) {
+      for (var i = 0; i < this._objects.length; i++) {
         svgString.push('\t', this._objects[i].toClipPathSVG(reviver));
       }
       return this._createBaseClipPathSVGMarkup(svgString, { reviver: reviver });

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -255,8 +255,7 @@
       this.interactive && this._watchObject(true, object);
       var activeObject = this.canvas && this.canvas.getActiveObject && this.canvas.getActiveObject();
       // if we are adding the activeObject in a group
-      // TODO migrate back to isDescendantOf
-      if (activeObject && (activeObject === object || (object.contains && object.contains(activeObject)))) {
+      if (activeObject && (activeObject === object || object.isDescendantOf(activeObject))) {
         this._activeObjects.push(object);
       }
     },

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -214,29 +214,52 @@
     },
 
     /**
+     * Checks if object can enter group and logs relevant warnings
      * @private
-     * @param {fabric.Object} object
-     * @param {boolean} [removeParentTransform] true if object is in canvas coordinate plane
-     * @returns {boolean} true if object entered group
+     * @param {fabric.Object} object 
+     * @returns 
      */
-    enterGroup: function (object, removeParentTransform) {
+    canEnter: function (object) {
       if (object === this) {
         /* _DEV_MODE_START_ */
         console.warn('fabric.Group: trying to add group to itself, this call has no effect');
         /* _DEV_MODE_END_ */
         return false;
       }
-      else if (object.group) {
-        if (object.group === this) {
-          /* _DEV_MODE_START_ */
-          console.warn('fabric.Group: duplicate objects are not supported inside group, this call has no effect');
-          /* _DEV_MODE_END_ */
-          return false;
-        }
+      else if (object.group && object.group === this) {
+        /* _DEV_MODE_START_ */
+        console.warn('fabric.Group: duplicate objects are not supported inside group, this call has no effect');
+        /* _DEV_MODE_END_ */
+        return false;
+      }
+      return true;
+    },
+
+    /**
+     * @private
+     * @param {fabric.Object} object
+     * @param {boolean} [removeParentTransform] true if object is in canvas coordinate plane
+     * @returns {boolean} true if object entered group
+     */
+    enterGroup: function (object, removeParentTransform) {
+      if (!this.canEnter(object)) {
+        return false;
+      }
+      if (object.group) {
         object.group.remove(object);
       }
-      // can be this converted to utils?
+      this._enterGroup(object, removeParentTransform);
+      return true;
+    },
+
+    /**
+     * @private
+     * @param {fabric.Object} object
+     * @param {boolean} [removeParentTransform] true if object is in canvas coordinate plane
+     */
+    _enterGroup: function (object, removeParentTransform) {
       if (removeParentTransform) {
+        // can this be converted to utils (sendObjectToPlane)?
         applyTransformToObject(
           object,
           multiplyTransformMatrices(
@@ -254,7 +277,6 @@
       if (activeObject && (activeObject === object || object.isDescendantOf(activeObject))) {
         this._activeObjects.push(object);
       }
-      return true;
     },
 
     /**

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -97,20 +97,9 @@
       this.__objectSelectionDisposer = this.__objectSelectionMonitor.bind(this, false);
       this._firstLayoutDone = false;
       this.callSuper('initialize', options);
-      if (objectsRelativeToGroup) {
-        this.forEachObject(function (object) {
-          this.enterGroup(object, false);
-        }, this);
-      }
-      else {
-        //  we need to preserve object's center point in relation to canvas and apply group's transform to it
-        var inv = invertTransform(this.calcTransformMatrix());
-        this.forEachObject(function (object) {
-          this.enterGroup(object, false);
-          var center = transformPoint(object.getCenterPoint(), inv);
-          object.setPositionByOrigin(center, 'center', 'center');
-        }, this);
-      }
+      this.forEachObject(function (object) {
+        this.enterGroup(object, false);
+      }, this);
       this._applyLayoutStrategy({
         type: 'initialization',
         options: options,

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -384,6 +384,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     drawObject: function(ctx) {
+      this._renderBackground(ctx);
       for (var i = 0, len = this._objects.length; i < len; i++) {
         this._objects[i].render(ctx);
       }

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -151,7 +151,7 @@
      * @param {Number} index Index to insert object at
      */
     insertAt: function (objects, index) {
-      fabric.Collection.insertAt.call(this, objects, index,  this._onObjectAdded);
+      fabric.Collection.insertAt.call(this, objects, index, this._onObjectAdded);
       this._onAfterObjectsChange('added', Array.isArray(objects) ? objects : [objects]);
     },
 

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -230,7 +230,13 @@
      * @param {boolean} [removeParentTransform] true if object is in canvas coordinate plane
      */
     enterGroup: function (object, removeParentTransform) {
-      if (object.group) {
+      if (object === this) {
+        /* _DEV_MODE_START_ */
+        console.warn('fabric.Group: trying to add group to itself, this call has no effect');
+        /* _DEV_MODE_END_ */
+        return;
+      }
+      else if (object.group) {
         if (object.group === this) {
           /* _DEV_MODE_START_ */
           console.warn('fabric.Group: duplicate objects are not supported inside group, this call has no effect');

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -223,8 +223,8 @@
     /**
      * Checks if object can enter group and logs relevant warnings
      * @private
-     * @param {fabric.Object} object 
-     * @returns 
+     * @param {fabric.Object} object
+     * @returns
      */
     canEnter: function (object) {
       if (object === this) {

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -217,20 +217,21 @@
      * @private
      * @param {fabric.Object} object
      * @param {boolean} [removeParentTransform] true if object is in canvas coordinate plane
+     * @returns {boolean} true if object entered group
      */
     enterGroup: function (object, removeParentTransform) {
       if (object === this) {
         /* _DEV_MODE_START_ */
         console.warn('fabric.Group: trying to add group to itself, this call has no effect');
         /* _DEV_MODE_END_ */
-        return;
+        return false;
       }
       else if (object.group) {
         if (object.group === this) {
           /* _DEV_MODE_START_ */
           console.warn('fabric.Group: duplicate objects are not supported inside group, this call has no effect');
           /* _DEV_MODE_END_ */
-          return;
+          return false;
         }
         object.group.remove(object);
       }
@@ -253,6 +254,7 @@
       if (activeObject && (activeObject === object || object.isDescendantOf(activeObject))) {
         this._activeObjects.push(object);
       }
+      return true;
     },
 
     /**

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -130,6 +130,13 @@
     },
 
     /**
+     * @private
+     */
+    _shouldSetNestedCoords: function () {
+      return this.subTargetCheck;
+    },
+
+    /**
      * Add objects
      * @param {...fabric.Object} objects
      */
@@ -268,7 +275,7 @@
           )
         );
       }
-      object.setCoords();
+      this._shouldSetNestedCoords() && object.setCoords();
       object._set('group', this);
       object._set('canvas', this.canvas);
       this.interactive && this._watchObject(true, object);
@@ -439,7 +446,7 @@
      */
     setCoords: function () {
       this.callSuper('setCoords');
-      (this.subTargetCheck || this.type === 'activeSelection') && this.forEachObject(function (object) {
+      this._shouldSetNestedCoords() && this.forEachObject(function (object) {
         object.setCoords();
       });
     },

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -227,7 +227,7 @@
      * @returns
      */
     canEnter: function (object) {
-      if (object === this) {
+      if (object === this || this.isDescendantOf(object)) {
         /* _DEV_MODE_START_ */
         console.warn('fabric.Group: trying to add group to itself, this call has no effect');
         /* _DEV_MODE_END_ */

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -172,9 +172,7 @@
      */
     removeAll: function () {
       this._activeObjects = [];
-      var remove = this._objects.slice();
-      this.remove.apply(this, remove);
-      return remove;
+      return this.remove.apply(this, this._objects.slice());
     },
 
     /**

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -610,7 +610,7 @@
       obj._set('canvas', this);
       obj.setCoords();
       this.fire('object:added', { target: obj });
-      obj.fire('added');
+      obj.fire('added', { target: this });
     },
 
     /**
@@ -619,7 +619,7 @@
      */
     _onObjectRemoved: function(obj) {
       this.fire('object:removed', { target: obj });
-      obj.fire('removed');
+      obj.fire('removed', { target: this });
       obj._set('canvas', undefined);
     },
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -596,8 +596,8 @@
      * @chainable
      */
     remove: function () {
-      var didRemove = fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);
-      didRemove && this.renderOnAddRemove && this.requestRenderAll();
+      var removed = fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);
+      removed.length > 0 && this.renderOnAddRemove && this.requestRenderAll();
       return this;
     },
 

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -959,7 +959,7 @@
      * @chainable
      */
     _centerObject: function(object, center) {
-      object.setPositionByOrigin(center, 'center', 'center');
+      object.setXY(center, 'center', 'center');
       object.setCoords();
       this.renderOnAddRemove && this.requestRenderAll();
       return this;

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -620,7 +620,7 @@
     _onObjectRemoved: function(obj) {
       this.fire('object:removed', { target: obj });
       obj.fire('removed');
-      delete obj.canvas;
+      obj._set('canvas', undefined);
     },
 
     /**

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -339,10 +339,10 @@
      */
     transformPointRelativeToCanvas: function (point, canvas, relationBefore, relationAfter) {
       if (relationBefore !== 'child' && relationBefore !== 'sibling') {
-        throw new Error('fabric.js: recieved bad argument ' + relationBefore);
+        throw new Error('fabric.js: received bad argument ' + relationBefore);
       }
       if (relationAfter !== 'child' && relationAfter !== 'sibling') {
-        throw new Error('fabric.js: recieved bad argument ' + relationAfter);
+        throw new Error('fabric.js: received bad argument ' + relationAfter);
       }
       if (relationBefore === relationAfter) {
         return point;

--- a/test/unit/collection.js
+++ b/test/unit/collection.js
@@ -95,16 +95,19 @@
     assert.ok(typeof collection.remove === 'function', 'has remove method');
     var returned = collection.remove([obj]);
     assert.ok(returned, 'removed obj');
-    assert.ok(!collection.remove([{ prop: 'foo' }]), 'nothing removed');
+    assert.ok(Array.isArray(collection.remove([])), 'should return empty array');
+    assert.equal(collection.remove([{ prop: 'foo' }]).length, 0, 'nothing removed');
     assert.equal(collection._objects.indexOf(obj), -1, 'obj is no more in array');
     assert.equal(collection._objects.length, previousLength - 1, 'length has changed');
     assert.equal(fired, 0, 'fired is 0');
     var callback = function() {
       fired++;
     };
-    collection.remove([obj2], callback);
+    var removed = collection.remove([obj2], callback);
     assert.equal(fired, 1, 'fired is incremented if there is a callback');
-    collection.remove([obj2], callback);
+    assert.deepEqual(removed, [obj2], 'should return removed objects');
+    removed = collection.remove([obj2], callback);
+    assert.deepEqual(removed, [], 'should return removed objects');
     assert.equal(fired, 1, 'fired is not incremented again if there is no object to remove');
 
     collection.add([obj2]);
@@ -112,7 +115,8 @@
     collection.remove([obj2], callback);
     previousLength = collection._objects.length;
     fired = 0;
-    collection.remove([obj, obj3], callback);
+    removed = collection.remove([obj, obj3, obj2], callback);
+    assert.deepEqual(removed, [obj, obj3], 'should return removed objects');
     assert.equal(collection._objects.length, previousLength - 2, 'we have 2 objects less');
     assert.equal(fired, 2, 'fired is incremented for every object removed');
   });

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -100,10 +100,12 @@
         group = new fabric.Group([rect1, rect2, rect3]);
 
     assert.ok(typeof group.remove === 'function');
-    group.remove(rect2);
+    var removed = group.remove(rect2);
+    assert.deepEqual(removed, [rect2], 'should return removed objects');
     assert.deepEqual(group.getObjects(), [rect1, rect3], 'should remove object properly');
 
-    group.remove(rect1, rect3);
+    var removed = group.remove(rect1, rect3);
+    assert.deepEqual(removed, [rect1, rect3], 'should return removed objects');
     assert.equal(group.isEmpty(), true, 'group should be empty');
   });
 
@@ -316,7 +318,8 @@
     assert.ok(initialLeftValue !== firstObject.get('left'));
     assert.ok(initialTopValue !== firstObject.get('top'));
 
-    group.removeAll();
+    var objects = group.getObjects();
+    assert.deepEqual(group.removeAll(), objects, 'should remove all objects');
     assert.equal(firstObject.get('left'), initialLeftValue, 'should restore initial left value');
     assert.equal(firstObject.get('top'), initialTopValue, 'should restore initial top value');
   });

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -696,6 +696,35 @@
     assert.notEqual(coords, newCoords, 'object coords have been recalculated - add');
   });
 
+  QUnit.test.only('group add edge cases', function (assert) {
+    var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false }),
+      rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false }),
+      group = new fabric.Group([rect1]);
+
+    //  duplicate
+    assert.notOk(group.canEnter(rect1));
+    group.add(rect1);
+    assert.deepEqual(group.getObjects(), [rect1], 'objects should not have changed');
+    //  duplicate on same call
+    assert.ok(group.canEnter(rect2));
+    group.add(rect2, rect2);
+    assert.deepEqual(group.getObjects(), [rect1, rect2], '`rect2` should have entered once');
+    //  adding self
+    assert.notOk(group.canEnter(group));
+    group.add(group);
+    assert.deepEqual(group.getObjects(), [rect1, rect2], 'objects should not have changed');
+    //  nested object should be removed from group
+    var nestedGroup = new fabric.Group([rect1]);
+    assert.ok(group.canEnter(nestedGroup));
+    group.add(nestedGroup);
+    assert.deepEqual(group.getObjects(), [rect2, nestedGroup], '`rect1` was removed from group once it entered `nestedGroup`');
+    //  circular group
+    var circularGroup = new fabric.Group([rect2, group]);
+    assert.notOk(group.canEnter(circularGroup), 'circular group should be denied entry');
+    group.add(circularGroup);
+    assert.deepEqual(group.getObjects(), [rect2, nestedGroup], 'objects should not have changed');
+  });
+
   QUnit.test('group remove', function(assert) {
     var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false}),
         rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false}),

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -696,33 +696,33 @@
     assert.notEqual(coords, newCoords, 'object coords have been recalculated - add');
   });
 
-  QUnit.test.only('group add edge cases', function (assert) {
+  QUnit.test('group add edge cases', function (assert) {
     var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false }),
       rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false }),
       group = new fabric.Group([rect1]);
 
     //  duplicate
     assert.notOk(group.canEnter(rect1));
-    group.add(rect1);
-    assert.deepEqual(group.getObjects(), [rect1], 'objects should not have changed');
+    // group.add(rect1);
+    // assert.deepEqual(group.getObjects(), [rect1], 'objects should not have changed');
     //  duplicate on same call
     assert.ok(group.canEnter(rect2));
-    group.add(rect2, rect2);
-    assert.deepEqual(group.getObjects(), [rect1, rect2], '`rect2` should have entered once');
+    // group.add(rect2, rect2);
+    // assert.deepEqual(group.getObjects(), [rect1, rect2], '`rect2` should have entered once');
     //  adding self
     assert.notOk(group.canEnter(group));
-    group.add(group);
-    assert.deepEqual(group.getObjects(), [rect1, rect2], 'objects should not have changed');
+    // group.add(group);
+    // assert.deepEqual(group.getObjects(), [rect1, rect2], 'objects should not have changed');
     //  nested object should be removed from group
     var nestedGroup = new fabric.Group([rect1]);
     assert.ok(group.canEnter(nestedGroup));
-    group.add(nestedGroup);
-    assert.deepEqual(group.getObjects(), [rect2, nestedGroup], '`rect1` was removed from group once it entered `nestedGroup`');
+    // group.add(nestedGroup);
+    // assert.deepEqual(group.getObjects(), [rect2, nestedGroup], '`rect1` was removed from group once it entered `nestedGroup`');
     //  circular group
     var circularGroup = new fabric.Group([rect2, group]);
     assert.notOk(group.canEnter(circularGroup), 'circular group should be denied entry');
-    group.add(circularGroup);
-    assert.deepEqual(group.getObjects(), [rect2, nestedGroup], 'objects should not have changed');
+    // group.add(circularGroup);
+    // assert.deepEqual(group.getObjects(), [rect2, nestedGroup], 'objects should not have changed');
   });
 
   QUnit.test('group remove', function(assert) {

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -424,6 +424,7 @@
     var group = makeGroupWith2ObjectsWithOpacity();
 
     var groupObject = group.toObject();
+    groupObject.subTargetCheck = true;
 
     fabric.Group.fromObject(groupObject).then(function(newGroupFromObject) {
       assert.ok(newGroupFromObject._objects[0].lineCoords.tl, 'acoords 0 are restored');

--- a/test/unit/itext_click_behaviour.js
+++ b/test/unit/itext_click_behaviour.js
@@ -167,20 +167,34 @@
       iText.selected = true;
       iText.__lastSelected = true;
       iText.mouseUpHandler({ e: {} });
-      assert.equal(iText.isEditing, false, 'iText did not enter editing');
+      assert.equal(iText.isEditing, false, 'iText should not enter editing');
       iText.exitEditing();
     });
-    QUnit.test('_mouseUpHandler on a selected text in a group DOES NOT enter edit', function(assert) {
+    QUnit.test('_mouseUpHandler on a selected text in a group does NOT enter editing', function(assert) {
       var iText = new fabric.IText('test');
       iText.initDelayedCursor = function() {};
       iText.renderCursorOrSelection = function() {};
       assert.equal(iText.isEditing, false, 'iText not editing');
-      iText.canvas = canvas;
+      var group = new fabric.Group([iText], { subTargetCheck: false });
+      canvas.add(group);
       iText.selected = true;
       iText.__lastSelected = true;
-      iText.group = true;
-      iText.mouseUpHandler({ e: {} });
-      assert.equal(iText.isEditing, false, 'iText did not entered editing');
+      canvas.__onMouseUp({ clientX: 1, clientY: 1 });
+      assert.equal(canvas._target, group, 'group should be found as target');
+      assert.equal(iText.isEditing, false, 'iText should not enter editing');
+      iText.exitEditing();
+    });
+    QUnit.test('_mouseUpHandler on a text in a group does enter editing', function (assert) {
+      var iText = new fabric.IText('test');
+      iText.initDelayedCursor = function () { };
+      iText.renderCursorOrSelection = function () { };
+      assert.equal(iText.isEditing, false, 'iText not editing');
+      var group = new fabric.Group([iText], { subTargetCheck: true });
+      canvas.add(group);
+      iText.selected = true;
+      iText.__lastSelected = true;
+      canvas.__onMouseUp({ clientX: 1, clientY: 1 });
+      assert.equal(iText.isEditing, true, 'iText should enter editing');
       iText.exitEditing();
     });
     QUnit.test('_mouseUpHandler on a corner of selected text DOES NOT enter edit', function(assert) {
@@ -193,7 +207,7 @@
       iText.__lastSelected = true;
       iText.__corner = 'mt';
       iText.mouseUpHandler({ e: {} });
-      assert.equal(iText.isEditing, false, 'iText did not entered editing');
+      assert.equal(iText.isEditing, false, 'iText should not enter editing');
       iText.exitEditing();
       canvas.renderAll();
     });

--- a/test/unit/itext_click_behaviour.js
+++ b/test/unit/itext_click_behaviour.js
@@ -184,18 +184,23 @@
       assert.equal(iText.isEditing, false, 'iText should not enter editing');
       iText.exitEditing();
     });
-    QUnit.test('_mouseUpHandler on a text in a group does enter editing', function (assert) {
+    QUnit.test('_mouseUpHandler on a text in a group', function (assert) {
       var iText = new fabric.IText('test');
       iText.initDelayedCursor = function () { };
       iText.renderCursorOrSelection = function () { };
       assert.equal(iText.isEditing, false, 'iText not editing');
-      var group = new fabric.Group([iText], { subTargetCheck: true });
+      var group = new fabric.Group([iText], { subTargetCheck: true, interactive: true });
       canvas.add(group);
       iText.selected = true;
       iText.__lastSelected = true;
       canvas.__onMouseUp({ clientX: 1, clientY: 1 });
       assert.equal(iText.isEditing, true, 'iText should enter editing');
       iText.exitEditing();
+      group.interactive = false;
+      iText.selected = true;
+      iText.__lastSelected = true;
+      canvas.__onMouseUp({ clientX: 1, clientY: 1 });
+      assert.equal(iText.isEditing, false, 'iText should not enter editing');
     });
     QUnit.test('_mouseUpHandler on a corner of selected text DOES NOT enter edit', function(assert) {
       var iText = new fabric.IText('test');

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -883,8 +883,8 @@
       add: function () {
         fabric.Collection.add.call(this, arguments, this._onObjectAdded);
       },
-      insertAt: function (objects, index, nonSplicing) {
-        fabric.Collection.insertAt.call(this, objects, index, nonSplicing, this._onObjectAdded);
+      insertAt: function (objects, index) {
+        fabric.Collection.insertAt.call(this, objects, index, this._onObjectAdded);
       },
       remove: function () {
         fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -847,7 +847,7 @@
     assert.deepEqual(object.getAncestors(), []);
   });
 
-  QUnit.test('findCommonAncestors', function (assert) {
+  function prepareObjectsForTreeTesting() {
     var Object = fabric.util.createClass(fabric.Object, {
       toJSON: function () {
         return {
@@ -860,9 +860,7 @@
       toString: function () {
         return JSON.stringify(this.toJSON(), null, '\t');
       }
-    })
-    var object = new Object({ id: 'object' });
-    var other = new Object({ id: 'other' });
+    });
     var Collection = fabric.util.createClass(Object, fabric.Collection, {
       initialize: function () {
         this._objects = [];
@@ -870,8 +868,8 @@
       add: function () {
         fabric.Collection.add.call(this, arguments, this._onObjectAdded);
       },
-      insertAt: function (objects, index, nonSplicing) {
-        fabric.Collection.insertAt.call(this, objects, index, nonSplicing, this._onObjectAdded);
+      insertAt: function (objects, index) {
+        fabric.Collection.insertAt.call(this, objects, index, this._onObjectAdded);
       },
       remove: function () {
         fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);
@@ -886,9 +884,6 @@
         this.remove.apply(this, this._objects);
       }
     });
-    var a = new Collection({ id: 'a' });
-    var b = new Collection({ id: 'b' });
-    var c = new Collection({ id: 'c' });
     var canvas = fabric.util.object.extend(new Collection({ id: 'canvas' }), {
       _onObjectAdded: function (object) {
         object.canvas = this;
@@ -897,7 +892,17 @@
         delete object.canvas;
       },
     });
-    assert.ok(typeof object.findCommonAncestors === 'function');
+    return {
+      object: new Object({ id: 'object' }),
+      other: new Object({ id: 'other' }),
+      a: new Collection({ id: 'a' }),
+      b: new Collection({ id: 'b' }),
+      c: new Collection({ id: 'c' }),
+      canvas
+    }
+  }
+
+  QUnit.test('findCommonAncestors', function (assert) {
     function findCommonAncestors(object, other, strict, expected, message) {
       assert.deepEqual(
         object.findCommonAncestors(other, strict),
@@ -916,6 +921,8 @@
         `should match opposite check between '${object.id}' and '${other.id}'`
       );
     }
+    var { object, other, a, b, c, canvas } = prepareObjectsForTreeTesting();
+    assert.ok(typeof object.findCommonAncestors === 'function');
     assert.ok(Array.isArray(a._objects));
     assert.ok(a._objects !== b._objects);
     //  same object
@@ -1004,55 +1011,7 @@
   };
 
   QUnit.test('isInFrontOf', function (assert) {
-    var Object = fabric.util.createClass(fabric.Object, {
-      toJSON: function () {
-        return {
-          id: this.id,
-          objects: this._objects?.map(o => o.id),
-          parent: this.parent?.id,
-          canvas: this.canvas?.id
-        }
-      },
-      toString: function () {
-        return JSON.stringify(this.toJSON(), null, '\t');
-      }
-    })
-    var object = new Object({ id: 'object' });
-    var other = new Object({ id: 'other' });
-    var Collection = fabric.util.createClass(Object, fabric.Collection, {
-      initialize: function () {
-        this._objects = [];
-      },
-      add: function () {
-        fabric.Collection.add.call(this, arguments, this._onObjectAdded);
-      },
-      insertAt: function (objects, index) {
-        fabric.Collection.insertAt.call(this, objects, index, this._onObjectAdded);
-      },
-      remove: function () {
-        fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);
-      },
-      _onObjectAdded: function (object) {
-        object.group = this;
-      },
-      _onObjectRemoved: function (object) {
-        delete object.group;
-      },
-      removeAll: function () {
-        this.remove.apply(this, this._objects);
-      }
-    });
-    var a = new Collection({ id: 'a' });
-    var b = new Collection({ id: 'b' });
-    var c = new Collection({ id: 'c' });
-    var canvas = fabric.util.object.extend(new Collection({ id: 'canvas' }), {
-      _onObjectAdded: function (object) {
-        object.canvas = this;
-      },
-      _onObjectRemoved: function (object) {
-        delete object.canvas;
-      },
-    });
+    var { object, other, a, b, c, canvas } = prepareObjectsForTreeTesting();
     assert.ok(typeof object.isInFrontOf === 'function');
     assert.ok(Array.isArray(a._objects));
     assert.ok(a._objects !== b._objects);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -847,6 +847,143 @@
     assert.deepEqual(object.getAncestors(), []);
   });
 
+  QUnit.test('findCommonAncestors', function (assert) {
+    var Object = fabric.util.createClass(fabric.Object, {
+      toJSON: function () {
+        return {
+          id: this.id,
+          objects: this._objects?.map(o => o.id),
+          parent: this.parent?.id,
+          canvas: this.canvas?.id
+        }
+      },
+      toString: function () {
+        return JSON.stringify(this.toJSON(), null, '\t');
+      }
+    })
+    var object = new Object({ id: 'object' });
+    var other = new Object({ id: 'other' });
+    var Collection = fabric.util.createClass(Object, fabric.Collection, {
+      initialize: function () {
+        this._objects = [];
+      },
+      add: function () {
+        fabric.Collection.add.call(this, arguments, this._onObjectAdded);
+      },
+      insertAt: function (objects, index, nonSplicing) {
+        fabric.Collection.insertAt.call(this, objects, index, nonSplicing, this._onObjectAdded);
+      },
+      remove: function () {
+        fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);
+      },
+      _onObjectAdded: function (object) {
+        object.group = this;
+      },
+      _onObjectRemoved: function (object) {
+        delete object.group;
+      },
+      removeAll: function () {
+        this.remove.apply(this, this._objects);
+      }
+    });
+    var a = new Collection({ id: 'a' });
+    var b = new Collection({ id: 'b' });
+    var c = new Collection({ id: 'c' });
+    var canvas = fabric.util.object.extend(new Collection({ id: 'canvas' }), {
+      _onObjectAdded: function (object) {
+        object.canvas = this;
+      },
+      _onObjectRemoved: function (object) {
+        delete object.canvas;
+      },
+    });
+    assert.ok(typeof object.findCommonAncestors === 'function');
+    function findCommonAncestors(object, other, strict, expected, message) {
+      assert.deepEqual(
+        object.findCommonAncestors(other, strict),
+        expected,
+        message || `should match check between '${object.id}' and '${other.id}'`
+      );
+      assert.deepEqual(
+        other.findCommonAncestors(object, strict),
+        typeof expected === 'object' ?
+          {
+            index: expected.otherIndex,
+            otherIndex: expected.index,
+            ancestors: expected.ancestors
+          } :
+          expected,
+        `should match opposite check between '${object.id}' and '${other.id}'`
+      );
+    }
+    assert.ok(Array.isArray(a._objects));
+    assert.ok(a._objects !== b._objects);
+    //  same object
+    findCommonAncestors(object, object, false, { index: 0, otherIndex: 0, ancestors: [] });
+    //  foreign objects
+    findCommonAncestors(object, other, false, undefined);
+    //  same level
+    a.add(object, other);
+    findCommonAncestors(object, other, false, { index: 0, otherIndex: 0, ancestors: [a] });
+    findCommonAncestors(object, a, false, { index: 0, otherIndex: -1, ancestors: [a] });
+    findCommonAncestors(other, a, false, { index: 0, otherIndex: -1, ancestors: [a] });
+    findCommonAncestors(a, object, false, { index: -1, otherIndex: 0, ancestors: [a] });
+    findCommonAncestors(a, object, true, { index: -1, otherIndex: 0, ancestors: [a] }, 'strict option should have no effect');
+    // different level
+    a.remove(object);
+    b.add(object);
+    a.add(b);
+    findCommonAncestors(object, b, false, { index: 0, otherIndex: -1, ancestors: [b, a] });
+    findCommonAncestors(b, a, false, { index: 0, otherIndex: -1, ancestors: [a] });
+    findCommonAncestors(object, other, false, { index: 1, otherIndex: 0, ancestors: [a] });
+    //  with common ancestor
+    assert.equal(c.size(), 0, 'c should be empty');
+    c.add(a);
+    assert.equal(c.size(), 1, 'c should contain a');
+    findCommonAncestors(object, b, false, { index: 0, otherIndex: -1, ancestors: [b, a, c] });
+    findCommonAncestors(b, a, false, { index: 0, otherIndex: -1, ancestors: [a, c] });
+    findCommonAncestors(object, other, false, { index: 1, otherIndex: 0, ancestors: [a, c] });
+    findCommonAncestors(object, c, false, { index: 2, otherIndex: -1, ancestors: [c] });
+    findCommonAncestors(other, c, false, { index: 1, otherIndex: -1, ancestors: [c] });
+    findCommonAncestors(b, c, false, { index: 1, otherIndex: -1, ancestors: [c] });
+    findCommonAncestors(a, c, false, { index: 0, otherIndex: -1, ancestors: [c] });
+    //  deeper asymmetrical
+    c.removeAll();
+    assert.equal(c.size(), 0, 'c should be cleared');
+    a.remove(other);
+    c.add(other, a);
+    findCommonAncestors(object, b, false, { index: 0, otherIndex: -1, ancestors: [b, a, c] });
+    findCommonAncestors(b, a, false, { index: 0, otherIndex: -1, ancestors: [a, c] });
+    findCommonAncestors(a, other, false, { index: 0, otherIndex: 0, ancestors: [c] });
+    findCommonAncestors(object, other, false, { index: 2, otherIndex: 0, ancestors: [c] });
+    findCommonAncestors(object, c, false, { index: 2, otherIndex: -1, ancestors: [c] });
+    findCommonAncestors(other, c, false, { index: 0, otherIndex: -1, ancestors: [c] });
+    findCommonAncestors(b, c, false, { index: 1, otherIndex: -1, ancestors: [c] });
+    findCommonAncestors(a, c, false, { index: 0, otherIndex: -1, ancestors: [c] });
+    //  with canvas
+    a.removeAll();
+    b.removeAll();
+    c.removeAll();
+    canvas.add(object, other);
+    findCommonAncestors(object, other, true, undefined);
+    findCommonAncestors(object, other, false, { index: 0, otherIndex: 0, ancestors: [canvas] });
+    findCommonAncestors(object, canvas, true, undefined);
+    findCommonAncestors(object, canvas, false, { index: 0, otherIndex: -1, ancestors: [canvas] });
+    findCommonAncestors(other, canvas, false, { index: 0, otherIndex: -1, ancestors: [canvas] });
+    //  parent precedes canvas when checking ancestor
+    a.add(object);
+    assert.ok(object.canvas === canvas, 'object should have canvas set');
+    findCommonAncestors(object, other, true, undefined);
+    findCommonAncestors(object, other, false, undefined);
+    canvas.insertAt(a, 0);
+    findCommonAncestors(object, other, true, undefined);
+    findCommonAncestors(object, other, false, { index: 1, otherIndex: 0, ancestors: [canvas] });
+    findCommonAncestors(a, other, false, { index: 0, otherIndex: 0, ancestors: [canvas] });
+    findCommonAncestors(a, canvas, false, { index: 0, otherIndex: -1, ancestors: [canvas] });
+    findCommonAncestors(object, canvas, false, { index: 1, otherIndex: -1, ancestors: [canvas] });
+    findCommonAncestors(other, canvas, false, { index: 0, otherIndex: -1, ancestors: [canvas] });
+  });
+
   QUnit.assert.isInFrontOf = function (object, other, expected) {
     var actual = object.isInFrontOf(other);
     this.pushResult({
@@ -955,7 +1092,6 @@
     assert.isInFrontOf(b, a, true);
     assert.isInFrontOf(a, other, true);
     assert.isInFrontOf(object, other, true);
-    assert.isInFrontOf(object, c, true);
     assert.isInFrontOf(object, c, true);
     assert.isInFrontOf(other, c, true);
     assert.isInFrontOf(b, c, true);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -803,6 +803,177 @@
     assert.equal(object.moveTo(), object, 'should be chainable');
   });
 
+  QUnit.test('isDescendantOf', function (assert) {
+    var object = new fabric.Object();
+    var parent = new fabric.Object();
+    assert.ok(typeof object.isDescendantOf === 'function');
+    parent.canvas = canvas;
+    object.group = parent;
+    assert.ok(object.isDescendantOf(parent));
+    object.group = {
+      group: parent
+    };
+    assert.ok(object.isDescendantOf(parent));
+    assert.ok(object.isDescendantOf(canvas));
+    object.group = undefined;
+    assert.ok(object.isDescendantOf(parent) === false);
+    assert.ok(object.isDescendantOf(canvas) === false);
+    object.canvas = canvas;
+    assert.ok(object.isDescendantOf(canvas));
+    assert.ok(object.isDescendantOf(object) === false);
+  });
+
+  QUnit.test('getAncestors', function (assert) {
+    var object = new fabric.Object();
+    var parent = new fabric.Object();
+    var other = new fabric.Object();
+    assert.ok(typeof object.getAncestors === 'function');
+    assert.deepEqual(object.getAncestors(), []);
+    object.group = parent;
+    assert.deepEqual(object.getAncestors(), [parent]);
+    parent.canvas = canvas;
+    assert.deepEqual(object.getAncestors(), [parent, canvas]);
+    parent.group = other;
+    assert.deepEqual(object.getAncestors(), [parent, other]);
+    other.canvas = canvas;
+    assert.deepEqual(object.getAncestors(), [parent, other, canvas]);
+    delete object.group;
+    assert.deepEqual(object.getAncestors(), []);
+  });
+
+  QUnit.assert.isInFrontOf = function (object, other, expected) {
+    var actual = object.isInFrontOf(other);
+    this.pushResult({
+      expected: expected,
+      actual: actual,
+      result: actual === expected,
+      message: `'${expected ? object.id : other.id}' should be in front of '${expected ? other.id : object.id}'`
+    });
+    if (actual === expected && typeof expected === 'boolean') {
+      var actual2 = other.isInFrontOf(object);
+      this.pushResult({
+        expected: !expected,
+        actual: actual2,
+        result: actual2 === !expected,
+        message: `should match opposite check between '${object.id}' and '${other.id}'`
+      });
+    }
+  };
+
+  QUnit.test('isInFrontOf', function (assert) {
+    var Object = fabric.util.createClass(fabric.Object, {
+      toJSON: function () {
+        return {
+          id: this.id,
+          objects: this._objects?.map(o => o.id),
+          parent: this.parent?.id,
+          canvas: this.canvas?.id
+        }
+      },
+      toString: function () {
+        return JSON.stringify(this.toJSON(), null, '\t');
+      }
+    })
+    var object = new Object({ id: 'object' });
+    var other = new Object({ id: 'other' });
+    var Collection = fabric.util.createClass(Object, fabric.Collection, {
+      initialize: function () {
+        this._objects = [];
+      },
+      add: function () {
+        fabric.Collection.add.call(this, arguments, this._onObjectAdded);
+      },
+      insertAt: function (objects, index, nonSplicing) {
+        fabric.Collection.insertAt.call(this, objects, index, nonSplicing, this._onObjectAdded);
+      },
+      remove: function () {
+        fabric.Collection.remove.call(this, arguments, this._onObjectRemoved);
+      },
+      _onObjectAdded: function (object) {
+        object.group = this;
+      },
+      _onObjectRemoved: function (object) {
+        delete object.group;
+      },
+      removeAll: function () {
+        this.remove.apply(this, this._objects);
+      }
+    });
+    var a = new Collection({ id: 'a' });
+    var b = new Collection({ id: 'b' });
+    var c = new Collection({ id: 'c' });
+    var canvas = fabric.util.object.extend(new Collection({ id: 'canvas' }), {
+      _onObjectAdded: function (object) {
+        object.canvas = this;
+      },
+      _onObjectRemoved: function (object) {
+        delete object.canvas;
+      },
+    });
+    assert.ok(typeof object.isInFrontOf === 'function');
+    assert.ok(Array.isArray(a._objects));
+    assert.ok(a._objects !== b._objects);
+    //  same object
+    assert.isInFrontOf(object, object, undefined);
+    //  foreign objects
+    assert.isInFrontOf(object, other, undefined);
+    //  same level
+    a.add(object, other);
+    assert.isInFrontOf(object, other, false);
+    assert.isInFrontOf(object, a, true);
+    assert.isInFrontOf(other, a, true);
+    // different level
+    a.remove(object);
+    b.add(object);
+    a.add(b);
+    assert.isInFrontOf(object, b, true);
+    assert.isInFrontOf(b, a, true);
+    assert.isInFrontOf(object, other, true);
+    //  with common ancestor
+    assert.equal(c.size(), 0, 'c should be empty');
+    c.add(a);
+    assert.equal(c.size(), 1, 'c should contain a');
+    assert.isInFrontOf(object, b, true);
+    assert.isInFrontOf(b, a, true);
+    assert.isInFrontOf(object, other, true);
+    assert.isInFrontOf(object, c, true);
+    assert.isInFrontOf(other, c, true);
+    assert.isInFrontOf(b, c, true);
+    assert.isInFrontOf(a, c, true);
+    //  deeper asymmetrical
+    c.removeAll();
+    assert.equal(c.size(), 0, 'c should be cleared');
+    a.remove(other);
+    c.add(other, a);
+    assert.isInFrontOf(object, b, true);
+    assert.isInFrontOf(b, a, true);
+    assert.isInFrontOf(a, other, true);
+    assert.isInFrontOf(object, other, true);
+    assert.isInFrontOf(object, c, true);
+    assert.isInFrontOf(object, c, true);
+    assert.isInFrontOf(other, c, true);
+    assert.isInFrontOf(b, c, true);
+    assert.isInFrontOf(a, c, true);
+    //  with canvas
+    a.removeAll();
+    b.removeAll();
+    c.removeAll();
+    canvas.add(object, other);
+    assert.isInFrontOf(object, other, false);
+    assert.isInFrontOf(object, canvas, true);
+    assert.isInFrontOf(other, canvas, true);
+    //  parent precedes canvas when checking ancestor
+    a.add(object);
+    assert.ok(object.canvas === canvas, 'object should have canvas set');
+    assert.isInFrontOf(object, other, undefined);
+    canvas.insertAt(a, 0);
+    assert.isInFrontOf(object, other, false);
+    assert.isInFrontOf(a, other, false);
+    assert.isInFrontOf(a, canvas, true);
+    assert.isInFrontOf(object, canvas, true);
+    assert.isInFrontOf(other, canvas, true);
+  });
+
   QUnit.test('getTotalObjectScaling with zoom', function(assert) {
     var object = new fabric.Object({ scaleX: 3, scaleY: 2});
     canvas.setZoom(3);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -848,7 +848,7 @@
   });
 
   function prepareObjectsForTreeTesting() {
-    var Object = fabric.util.createClass(fabric.Object, {
+    var TObject = fabric.util.createClass(fabric.Object, {
       toJSON: function () {
         return {
           id: this.id,
@@ -861,8 +861,9 @@
         return JSON.stringify(this.toJSON(), null, '\t');
       }
     });
-    var Collection = fabric.util.createClass(Object, fabric.Collection, {
-      initialize: function () {
+    var Collection = fabric.util.createClass(TObject, fabric.Collection, {
+      initialize: function ({ id }) {
+        this.id = id;
         this._objects = [];
       },
       add: function () {
@@ -882,7 +883,7 @@
       },
       removeAll: function () {
         this.remove.apply(this, this._objects);
-      }
+      },
     });
     var canvas = fabric.util.object.extend(new Collection({ id: 'canvas' }), {
       _onObjectAdded: function (object) {
@@ -893,8 +894,8 @@
       },
     });
     return {
-      object: new Object({ id: 'object' }),
-      other: new Object({ id: 'other' }),
+      object: new TObject({ id: 'object' }),
+      other: new TObject({ id: 'other' }),
       a: new Collection({ id: 'a' }),
       b: new Collection({ id: 'b' }),
       c: new Collection({ id: 'c' }),
@@ -904,21 +905,37 @@
 
   QUnit.test('findCommonAncestors', function (assert) {
     function findCommonAncestors(object, other, strict, expected, message) {
+      var common = object.findCommonAncestors(other, strict);
       assert.deepEqual(
-        object.findCommonAncestors(other, strict),
-        expected,
-        message || `should match check between '${object.id}' and '${other.id}'`
+        common.fork.map((obj) => obj.id),
+        expected.fork.map((obj) => obj.id),
+        message || `fork property should match check between '${object.id}' and '${other.id}'`
       );
       assert.deepEqual(
-        other.findCommonAncestors(object, strict),
-        typeof expected === 'object' ?
-          {
-            index: expected.otherIndex,
-            otherIndex: expected.index,
-            ancestors: expected.ancestors
-          } :
-          expected,
-        `should match opposite check between '${object.id}' and '${other.id}'`
+        common.otherFork.map((obj) => obj.id),
+        expected.otherFork.map((obj) => obj.id),
+        message || `otherFork property should match check between '${object.id}' and '${other.id}'`
+      );
+      assert.deepEqual(
+        common.common.map((obj) => obj.id),
+        expected.common.map((obj) => obj.id),
+        message || `common property should match check between '${object.id}' and '${other.id}'`
+      );
+      var oppositeCommon = other.findCommonAncestors(object, strict);
+      assert.deepEqual(
+        oppositeCommon.fork.map((obj) => obj.id),
+        expected.otherFork.map((obj) => obj.id),
+        message || `fork property should match opposite check between '${other.id}' and '${object.id}'`
+      );
+      assert.deepEqual(
+        oppositeCommon.otherFork.map((obj) => obj.id),
+        expected.fork.map((obj) => obj.id),
+        message || `otherFork property should match opposite check between '${other.id}' and '${object.id}'`
+      );
+      assert.deepEqual(
+        oppositeCommon.common.map((obj) => obj.id),
+        expected.common.map((obj) => obj.id),
+        message || `common property should match opposite check between '${other.id}' and '${object.id}'`
       );
     }
     var { object, other, a, b, c, canvas } = prepareObjectsForTreeTesting();
@@ -926,69 +943,69 @@
     assert.ok(Array.isArray(a._objects));
     assert.ok(a._objects !== b._objects);
     //  same object
-    findCommonAncestors(object, object, false, { index: 0, otherIndex: 0, ancestors: [] });
+    findCommonAncestors(object, object, false, { fork: [], otherFork: [] , common: [object] });
     //  foreign objects
-    findCommonAncestors(object, other, false, undefined);
+    findCommonAncestors(object, other, false, { fork: [object], otherFork: [other] , common: [] });
     //  same level
     a.add(object, other);
-    findCommonAncestors(object, other, false, { index: 0, otherIndex: 0, ancestors: [a] });
-    findCommonAncestors(object, a, false, { index: 0, otherIndex: -1, ancestors: [a] });
-    findCommonAncestors(other, a, false, { index: 0, otherIndex: -1, ancestors: [a] });
-    findCommonAncestors(a, object, false, { index: -1, otherIndex: 0, ancestors: [a] });
-    findCommonAncestors(a, object, true, { index: -1, otherIndex: 0, ancestors: [a] }, 'strict option should have no effect');
+    findCommonAncestors(object, other, false, { fork: [object], otherFork: [other], common: [a] });
+    findCommonAncestors(object, a, false, { fork: [object], otherFork: [], common: [a] });
+    findCommonAncestors(other, a, false, { fork: [other], otherFork: [], common: [a] });
+    findCommonAncestors(a, object, false, { fork: [], otherFork: [object], common: [a] });
+    findCommonAncestors(a, object, true, { fork: [], otherFork: [object], common: [a] }, 'strict option should have no effect when outside canvas');
     // different level
     a.remove(object);
     b.add(object);
     a.add(b);
-    findCommonAncestors(object, b, false, { index: 0, otherIndex: -1, ancestors: [b, a] });
-    findCommonAncestors(b, a, false, { index: 0, otherIndex: -1, ancestors: [a] });
-    findCommonAncestors(object, other, false, { index: 1, otherIndex: 0, ancestors: [a] });
-    //  with common ancestor
+    findCommonAncestors(object, b, false, { fork: [object], otherFork: [], common: [b, a] });
+    findCommonAncestors(b, a, false, { fork: [b], otherFork: [], common: [a] });
+    findCommonAncestors(object, other, false, { fork: [object, b], otherFork: [other], common: [a] });
+    // with common ancestor
     assert.equal(c.size(), 0, 'c should be empty');
     c.add(a);
     assert.equal(c.size(), 1, 'c should contain a');
-    findCommonAncestors(object, b, false, { index: 0, otherIndex: -1, ancestors: [b, a, c] });
-    findCommonAncestors(b, a, false, { index: 0, otherIndex: -1, ancestors: [a, c] });
-    findCommonAncestors(object, other, false, { index: 1, otherIndex: 0, ancestors: [a, c] });
-    findCommonAncestors(object, c, false, { index: 2, otherIndex: -1, ancestors: [c] });
-    findCommonAncestors(other, c, false, { index: 1, otherIndex: -1, ancestors: [c] });
-    findCommonAncestors(b, c, false, { index: 1, otherIndex: -1, ancestors: [c] });
-    findCommonAncestors(a, c, false, { index: 0, otherIndex: -1, ancestors: [c] });
+    findCommonAncestors(object, b, false, { fork: [object], otherFork: [], common: [b, a, c] });
+    findCommonAncestors(b, a, false, { fork: [b], otherFork: [], common: [a, c] });
+    findCommonAncestors(object, other, false, { fork: [object, b], otherFork: [other], common: [a, c] });
+    findCommonAncestors(object, c, false, { fork: [object, b, a], otherFork: [], common: [c] });
+    findCommonAncestors(other, c, false, { fork: [other, a], otherFork: [], common: [c] });
+    findCommonAncestors(b, c, false, { fork: [b, a], otherFork: [], common: [c] });
+    findCommonAncestors(a, c, false, { fork: [a], otherFork: [], common: [c] });
     //  deeper asymmetrical
     c.removeAll();
     assert.equal(c.size(), 0, 'c should be cleared');
     a.remove(other);
     c.add(other, a);
-    findCommonAncestors(object, b, false, { index: 0, otherIndex: -1, ancestors: [b, a, c] });
-    findCommonAncestors(b, a, false, { index: 0, otherIndex: -1, ancestors: [a, c] });
-    findCommonAncestors(a, other, false, { index: 0, otherIndex: 0, ancestors: [c] });
-    findCommonAncestors(object, other, false, { index: 2, otherIndex: 0, ancestors: [c] });
-    findCommonAncestors(object, c, false, { index: 2, otherIndex: -1, ancestors: [c] });
-    findCommonAncestors(other, c, false, { index: 0, otherIndex: -1, ancestors: [c] });
-    findCommonAncestors(b, c, false, { index: 1, otherIndex: -1, ancestors: [c] });
-    findCommonAncestors(a, c, false, { index: 0, otherIndex: -1, ancestors: [c] });
+    findCommonAncestors(object, b, false, { fork: [object], otherFork: [], common: [b, a, c] });
+    findCommonAncestors(b, a, false, { fork: [b], otherFork: [], common: [a, c] });
+    findCommonAncestors(a, other, false, { fork: [a], otherFork: [other], common: [c] });
+    findCommonAncestors(object, other, false, { fork: [object, b, a], otherFork: [other], common: [c] });
+    findCommonAncestors(object, c, false, { fork: [object, b, a], otherFork: [], common: [c] });
+    findCommonAncestors(other, c, false, { fork: [other], otherFork: [], common: [c] });
+    findCommonAncestors(b, c, false, { fork: [b, a], otherFork: [], common: [c] });
+    findCommonAncestors(a, c, false, { fork: [a], otherFork: [], common: [c] });
     //  with canvas
     a.removeAll();
     b.removeAll();
     c.removeAll();
     canvas.add(object, other);
-    findCommonAncestors(object, other, true, undefined);
-    findCommonAncestors(object, other, false, { index: 0, otherIndex: 0, ancestors: [canvas] });
-    findCommonAncestors(object, canvas, true, undefined);
-    findCommonAncestors(object, canvas, false, { index: 0, otherIndex: -1, ancestors: [canvas] });
-    findCommonAncestors(other, canvas, false, { index: 0, otherIndex: -1, ancestors: [canvas] });
+    findCommonAncestors(object, other, true, { fork: [object], otherFork: [other], common: [] });
+    findCommonAncestors(object, other, false, { fork: [object], otherFork: [other], common: [canvas] });
+    findCommonAncestors(object, canvas, true, { fork: [object], otherFork: [canvas], common: [] });
+    findCommonAncestors(object, canvas, false, { fork: [object], otherFork: [], common: [canvas] });
+    findCommonAncestors(other, canvas, false, { fork: [other], otherFork: [], common: [canvas] });
     //  parent precedes canvas when checking ancestor
     a.add(object);
     assert.ok(object.canvas === canvas, 'object should have canvas set');
-    findCommonAncestors(object, other, true, undefined);
-    findCommonAncestors(object, other, false, undefined);
+    findCommonAncestors(object, other, true, { fork: [object, a], otherFork: [other], common: [] });
+    findCommonAncestors(object, other, false, { fork: [object, a], otherFork: [other, canvas], common: [] });
     canvas.insertAt(a, 0);
-    findCommonAncestors(object, other, true, undefined);
-    findCommonAncestors(object, other, false, { index: 1, otherIndex: 0, ancestors: [canvas] });
-    findCommonAncestors(a, other, false, { index: 0, otherIndex: 0, ancestors: [canvas] });
-    findCommonAncestors(a, canvas, false, { index: 0, otherIndex: -1, ancestors: [canvas] });
-    findCommonAncestors(object, canvas, false, { index: 1, otherIndex: -1, ancestors: [canvas] });
-    findCommonAncestors(other, canvas, false, { index: 0, otherIndex: -1, ancestors: [canvas] });
+    findCommonAncestors(object, other, true, { fork: [object, a], otherFork: [other], common: [] });
+    findCommonAncestors(object, other, false, { fork: [object, a], otherFork: [other], common: [canvas] });
+    findCommonAncestors(a, other, false, { fork: [a], otherFork: [other], common: [canvas] });
+    findCommonAncestors(a, canvas, false, { fork: [a], otherFork: [], common: [canvas] });
+    findCommonAncestors(object, canvas, false, { fork: [object, a], otherFork: [], common: [canvas] });
+    findCommonAncestors(other, canvas, false, { fork: [other], otherFork: [], common: [canvas] });
   });
 
   QUnit.assert.isInFrontOf = function (object, other, expected) {

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -622,7 +622,10 @@
     var object = new fabric.Object();
     var addedEventFired = false;
 
-    object.on('added', function() { addedEventFired = true; });
+    object.on('added', function (opt) {
+      addedEventFired = true;
+      assert.ok(opt.target === canvas, 'target should equal to canvas');
+    });
     canvas.add(object);
 
     assert.ok(addedEventFired);
@@ -645,7 +648,10 @@
 
     canvas.add(object);
 
-    object.on('removed', function() { removedEventFired = true; });
+    object.on('removed', function (opt) {
+      removedEventFired = true;
+      assert.ok(opt.target === canvas, 'target should equal to canvas');
+    });
     canvas.remove(object);
 
     assert.ok(removedEventFired);

--- a/test/visual/group_layout.js
+++ b/test/visual/group_layout.js
@@ -81,7 +81,7 @@
             backgroundColor: 'blue'
         });
         g.clone().then((clone) => {
-            canvas.add(g);
+            canvas.add(clone);
             canvas.renderAll();
             callback(canvas.lowerCanvasEl);
         })

--- a/test/visual/group_layout.js
+++ b/test/visual/group_layout.js
@@ -334,5 +334,5 @@
         });
     }
 */
-    // tests.forEach(visualTestLoop(QUnit));
+    tests.forEach(visualTestLoop(QUnit));
 })();

--- a/test/visual/group_layout.js
+++ b/test/visual/group_layout.js
@@ -76,6 +76,27 @@
         height: 300
     });
 
+    function fitContentLayoutRelative(canvas, callback) {
+        var g = createGroupForLayoutTests('fit-content layout', {
+            backgroundColor: 'blue'
+        });
+        g.clone().then((clone) => {
+            canvas.add(g);
+            canvas.renderAll();
+            callback(canvas.lowerCanvasEl);
+        })
+    }
+
+    tests.push({
+        test: 'fit-content layout',
+        code: fitContentLayoutRelative,
+        golden: 'group-layout/fit-content.png',
+        newModule: 'Group Layout',
+        percentage: 0.06,
+        width: 400,
+        height: 300
+    });
+
     function fitContentReLayout(canvas, callback) {
         var g = createGroupForLayoutTests('fit-content layout', {
             backgroundColor: 'blue'


### PR DESCRIPTION
This PR makes nested selection work out of the box.

Group's selection observers are now almost completely redundant (d8f8251d0b18d8d1c95805e8e5a4122712ba3020) if I am not mistaken. The only use I can think of is when active object is not active selection. **Consider** using `canvas.getActiveObjects().includes(obj)` instead.

Logic has been adapted and now active selection almost completely supports selecting nesting objects (multiple selection is handled by #7882 ) I believe the only thing from perfect impl is `containsPoint`

## To Do - done on #7900 
- [x] `canEnter` - https://github.com/fabricjs/fabric.js/pull/7859#discussion_r846827347
    - [x] naming
    - [x] throwing or what? https://github.com/fabricjs/fabric.js/pull/7859#discussion_r846754553 Errors will raise in current code after warning is logged. Meaning it shouldn't warn, severity is error.
- [x] Group renderBackground - migrate to https://github.com/fabricjs/fabric.js/pull/7859#discussion_r846930838
- [x] collection add/insertAt/remove return values
- [ ] minor dead code in `text.class` https://github.com/fabricjs/fabric.js/pull/7859#issuecomment-1088259426 - this can be removed only if group set coords on it's object. The question is what would be less damaging to perf... leaving as is or setting coords on all nested objects? Or a third option would be for group to check if object is on screen before it renders it
- [ ] `containsPoint` should be calculated relative to canvas coordinate plane
- [ ] remove object monitors?

@asturur 
- [ ] agree on `isInFrontOf`
- [ ] verify edge case with this._objectsToRender invalidation
- [ ] find a different solution for _getTransformedDimensions, @asturur improve my understanding of the group layout needs for it

### Changed Files


- `src/brushes/spray_brush.class.js` - adapt to new group
- `src/canvas.class.js` - return top most target including sub targets in case target is interactive
- `src/mixins/animation.mixin.js` - fix animations to be relative to canvas
- `src/mixins/canvas_events.mixin.js` - port missing logic from v6!
- `src/mixins/canvas_grouping.mixin.js` - port missing logic from v6! accounting for nested objects 
    - make sure not to create a circular call when adding an object to active selection
    - create active selection using isInFrontOf
- `src/mixins/eraser_brush.mixin.js` - adapt to new group (follow up will be in a separate PR)
- `src/mixins/itext_behavior.mixin.js` - add/remove handlers from canvas events (not group)
- `src/mixins/itext_click_behavior.mixin.js` - enable text editing under group
- `src/mixins/object_ancestry.mixin.js` - port logic from v6!
- `src/mixins/object_geometry.mixin.js` - port logic from v6!
    - account for nested objects (getCoords+ _getTransformedDimensions)
    - expose methods on object that interact with canvas coordinate plane
- `src/mixins/object_stacking.mixin.js` - exposed `isInFrontOf` to determine which object is in front of the other in the entire tree
- `src/shapes/active_selection.class.js` - adapt to restore objects to their owning group
- `src/shapes/group.class.js` - tidy code for easier subclassing + support `backgroundColor`
- `src/static_canvas.class.js` 
   - pass target for added/removed events (used by IText)
   - properly unset canvas to the entire object tree and not only to top most object
   - center object in canvas plane even if it is nested
- `test/unit/group.js` - fix failing test
- `test/unit/itext_click_behaviour.js` - adapt tests for nested itext
- `test/unit/object.js`
   - test canvas added/removed event object
   - `isDescendantOf`
   - `findCommonAncestors`
   - `isInFrontOf`
- `test/visual/group_layout.js` - reactivate tests

### Things Left Out
- `Layer`  - created a dedicated PR for it #7860
- `src/mixins/canvas_grouping` - I suspect it needs additional work. Committed some fixes and dumped the file from v6!.
- `Group#_renderObjects` - we need to discuss this, opened dedicated PR #7863 
- Caching - discussed in #7874 





