### PR TITLE
using indexed property setter is not supported

### DIFF
--- a/src/util/dom_style.js
+++ b/src/util/dom_style.js
@@ -26,7 +26,7 @@
         var normalizedProperty = (property === 'float' || property === 'cssFloat')
           ? (typeof elementStyle.styleFloat === 'undefined' ? 'cssFloat' : 'styleFloat')
           : property;
-        elementStyle[normalizedProperty] = styles[property];
+        elementStyle.setProperty(normalizedProperty, styles[property]);
       }
     }
     return element;


### PR DESCRIPTION
When fabric is used on a canvas that is part of an angular app, you get the following error when the canvas is being disposed:
"Failed to set an indexed property on 'CSSStyleDeclaration': Indexed property setter is not supported."
This is because angular replaces some setters on the style object for binding.
Using the setProperty method fixes the problem and is supported in all browsers.

