### PR TITLE
perf(SprayBrush): enhance perf using new Group

### DIFF
--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -130,7 +130,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     if (this._tempBuffer) {
       //  add last buffer to main buffer
       this._layoutBufferingGroup(this._tempBuffer);
-      group.addRelativeToGroup(this._tempBuffer);
+      group.addRelative(this._tempBuffer);
     }
     this._layoutBufferingGroup(group);
     this.shadow && group.set('shadow', new fabric.Shadow(this.shadow));
@@ -238,14 +238,14 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
       });
       if (this._tempBuffer && this._tempBuffer.size() > this.bufferThreshold) {
         this._layoutBufferingGroup(this._tempBuffer);
-        this._buffer.addRelativeToGroup(this._tempBuffer);
+        this._buffer.addRelative(this._tempBuffer);
         this._tempBuffer.renderCache();
         this._tempBuffer = undefined;
       }
       if (!this._tempBuffer) {
         this._tempBuffer = this._createBufferingGroup();
       }
-      this._tempBuffer.addRelativeToGroup(rect);
+      this._tempBuffer.addRelative(rect);
     }
 
     this.sprayChunks.push(sprayChunkPoints);

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -45,6 +45,13 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    * @default
    */
   optimizeOverlapping:  true,
+  
+  /**
+   * Performance enhancement
+   * Threshold of dots before creating a new buffering group
+   * @type number
+   */
+  bufferThreshold: 500,
 
   /**
    * Constructor
@@ -54,6 +61,36 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   initialize: function(canvas) {
     this.canvas = canvas;
     this.sprayChunks = [];
+    this.memo = {};
+  },
+
+  /**
+   * create a group to contain some of the spray chunks, acting as a buffer
+   * position group center at canvas 0,0 so we can add objects relative to group, reducing calculations to a minimum
+   * @private
+   * @returns {fabric.Group}
+   */
+  _createBufferingGroup: function () {
+    return new fabric.Group([], {
+      objectCaching: true,
+      layout: 'none',
+      subTargetCheck: false,
+      originX: 'center',
+      originY: 'center',
+      width: this.canvas.width,
+      height: this.canvas.height,
+      canvas: this.canvas
+    });
+  },
+
+  /**
+   * layout once and disable future layouting by setting to `fixed`
+   * @private
+   * @param {fabric.Group} group 
+   */
+  _layoutBufferingGroup: function (group) {
+    group.triggerLayout({ layout: 'fit-content' });
+    group.triggerLayout({ layout: 'fixed' });
   },
 
   /**
@@ -61,12 +98,14 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    * @param {Object} pointer
    */
   onMouseDown: function(pointer) {
-    this.sprayChunks.length = 0;
+    this.sprayChunks = [];
+    this.memo = {};
+    this._buffer = this._createBufferingGroup();
     this.canvas.clearContext(this.canvas.contextTop);
     this._setShadow();
 
-    this.addSprayChunk(pointer);
-    this.render(this.sprayChunkPoints);
+    var chunk = this.addSprayChunk(pointer);
+    this.renderChunk(chunk);
   },
 
   /**
@@ -77,8 +116,8 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     if (this.limitedToCanvasSize === true && this._isOutSideCanvas(pointer)) {
       return;
     }
-    this.addSprayChunk(pointer);
-    this.render(this.sprayChunkPoints);
+    var chunk = this.addSprayChunk(pointer);
+    this.renderChunk(chunk);
   },
 
   /**
@@ -87,70 +126,33 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   onMouseUp: function() {
     var originalRenderOnAddRemove = this.canvas.renderOnAddRemove;
     this.canvas.renderOnAddRemove = false;
-
-    var rects = [];
-
-    for (var i = 0, ilen = this.sprayChunks.length; i < ilen; i++) {
-      var sprayChunk = this.sprayChunks[i];
-
-      for (var j = 0, jlen = sprayChunk.length; j < jlen; j++) {
-
-        var rect = new fabric.Rect({
-          width: sprayChunk[j].width,
-          height: sprayChunk[j].width,
-          left: sprayChunk[j].x + 1,
-          top: sprayChunk[j].y + 1,
-          originX: 'center',
-          originY: 'center',
-          fill: this.color
-        });
-        rects.push(rect);
-      }
+    var group = this._buffer;
+    if (this._tempBuffer) {
+      //  add last buffer to main buffer
+      this._layoutBufferingGroup(this._tempBuffer);
+      group.addRelativeToGroup(this._tempBuffer);
     }
-
-    if (this.optimizeOverlapping) {
-      rects = this._getOptimizedRects(rects);
-    }
-
-    var group = new fabric.Group(rects);
+    this._layoutBufferingGroup(group);
     this.shadow && group.set('shadow', new fabric.Shadow(this.shadow));
+    // fire events and add
     this.canvas.fire('before:path:created', { path: group });
     this.canvas.add(group);
     this.canvas.fire('path:created', { path: group });
-
+    //  render
     this.canvas.clearContext(this.canvas.contextTop);
     this._resetShadow();
     this.canvas.renderOnAddRemove = originalRenderOnAddRemove;
     this.canvas.requestRenderAll();
-  },
-
-  /**
-   * @private
-   * @param {Array} rects
-   */
-  _getOptimizedRects: function(rects) {
-
-    // avoid creating duplicate rects at the same coordinates
-    var uniqueRects = { }, key, i, len;
-
-    for (i = 0, len = rects.length; i < len; i++) {
-      key = rects[i].left + '' + rects[i].top;
-      if (!uniqueRects[key]) {
-        uniqueRects[key] = rects[i];
-      }
-    }
-    var uniqueRectsArray = [];
-    for (key in uniqueRects) {
-      uniqueRectsArray.push(uniqueRects[key]);
-    }
-
-    return uniqueRectsArray;
+    //  deallocate
+    this._buffer = undefined;
+    this._tempBuffer = undefined;
+    this.memo = {};
   },
 
   /**
    * Render new chunk of spray brush
    */
-  render: function(sprayChunk) {
+  renderChunk: function(sprayChunk) {
     var ctx = this.canvas.contextTop, i, len;
     ctx.fillStyle = this.color;
 
@@ -176,7 +178,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
     this._saveAndTransform(ctx);
 
     for (i = 0, ilen = this.sprayChunks.length; i < ilen; i++) {
-      this.render(this.sprayChunks[i]);
+      this.renderChunk(this.sprayChunks[i]);
     }
     ctx.restore();
   },
@@ -185,9 +187,8 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    * @param {Object} pointer
    */
   addSprayChunk: function(pointer) {
-    this.sprayChunkPoints = [];
-
-    var x, y, width, radius = this.width / 2, i;
+    var sprayChunkPoints = [];
+    var i, x, y, key, width, radius = this.width / 2, r;
 
     for (i = 0; i < this.density; i++) {
 
@@ -204,6 +205,17 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
         width = this.dotWidth;
       }
 
+      if (this.optimizeOverlapping) {
+        // avoid creating duplicate rects at the same coordinates
+        key = x + ',' + y;
+        if (this.memo[key]) {
+          continue;
+        }
+        else {
+          this.memo[key] = true;
+        }
+      }
+
       var point = new fabric.Point(x, y);
       point.width = width;
 
@@ -211,9 +223,32 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
         point.opacity = fabric.util.getRandomInt(0, 100) / 100;
       }
 
-      this.sprayChunkPoints.push(point);
+      sprayChunkPoints.push(point);
+      r = point.width / 2;
+      var rect = new fabric.Rect({
+        width: point.width,
+        height: point.width,
+        left: point.x + r,
+        top: point.y + r,
+        originX: 'center',
+        originY: 'center',
+        fill: this.color,
+        objectCaching: false,
+        canvas: this.canvas
+      });
+      if (this._tempBuffer && this._tempBuffer.size() > this.bufferThreshold) {
+        this._layoutBufferingGroup(this._tempBuffer);
+        this._buffer.addRelativeToGroup(this._tempBuffer);
+        this._tempBuffer.renderCache();
+        this._tempBuffer = undefined;
+      }
+      if (!this._tempBuffer) {
+        this._tempBuffer = this._createBufferingGroup();
+      }
+      this._tempBuffer.addRelativeToGroup(rect);
     }
 
-    this.sprayChunks.push(this.sprayChunkPoints);
+    this.sprayChunks.push(sprayChunkPoints);
+    return sprayChunkPoints;
   }
 });

--- a/src/brushes/spray_brush.class.js
+++ b/src/brushes/spray_brush.class.js
@@ -45,7 +45,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
    * @default
    */
   optimizeOverlapping:  true,
-  
+
   /**
    * Performance enhancement
    * Threshold of dots before creating a new buffering group
@@ -86,7 +86,7 @@ fabric.SprayBrush = fabric.util.createClass( fabric.BaseBrush, /** @lends fabric
   /**
    * layout once and disable future layouting by setting to `fixed`
    * @private
-   * @param {fabric.Group} group 
+   * @param {fabric.Group} group
    */
   _layoutBufferingGroup: function (group) {
     group.triggerLayout({ layout: 'fit-content' });

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -150,6 +150,15 @@
     },
 
     /**
+     * Add objects
+     * @param {...fabric.Object} objects
+     */
+    addRelative: function () {
+      fabric.Collection.add.call(this, arguments, this._onRelativeObjectAdded);
+      this._onAfterObjectsChange('added', Array.from(arguments));
+    },
+
+    /**
      * Inserts an object into collection at specified index
      * @param {fabric.Object} objects Object to insert
      * @param {Number} index Index to insert object at


### PR DESCRIPTION
This PR is an excellent demonstration of the power of the new Group and what can be unlocked using it
[control](https://codesandbox.io/s/fabric-app-forked-nq1t4)
[perf](https://codesandbox.io/s/fabric-app-forked-ewex1q)

Basically it reduces computation cost by iterating only once over the spray dots instead of a number of times.
It split up the dots into a number of groups that act as buffers to cut down iterations.
I need to get these buffers to render cache once they're maxed out and then performance will rise even more (splitting the rendering of the entire spray into smaller chunks and then at mouseup the create path is a group of groups that have already been cached so overhead will be minimal)

Will merge once v6! stabilizes

The buffering approach can/should be used by canvas for perf

If we wrap the result of the spray brush with another group we enhance perf even more in case it is used with clip path or in other cases that invalidate cache.



## In action
You'll see that the dots double every second or so. That's the buffering group.
Notice that normally there is a massive frame drop on mouse up and here, even though the spray is huge there is no visible drop.

**Zoom in on mouse up**

https://user-images.githubusercontent.com/34343793/155074016-e5d1c1f0-1f5e-49e3-858a-0a9fb6766749.mp4


