### PR TITLE
fix(canvas export): regression caused by safegurading

### DIFF
--- a/src/mixins/canvas_dataurl_exporter.mixin.js
+++ b/src/mixins/canvas_dataurl_exporter.mixin.js
@@ -61,7 +61,6 @@
      * @param {Number} [options.top] Cropping top offset.
      * @param {Number} [options.width] Cropping width.
      * @param {Number} [options.height] Cropping height.
-     * @param {fabric.Object[]} [options.objects] objects to render, overrides `filter`
      * @param {(object: fabric.Object) => boolean} [options.filter] Function to filter objects.
      */
     toCanvasElement: function (multiplier, options) {
@@ -81,7 +80,7 @@
           originalRetina = this.enableRetinaScaling,
           canvasEl = fabric.util.createCanvasElement(),
           originalContextTop = this.contextTop,
-          objectsToRender = options.objects || (options.filter ? this._objects.filter(options.filter) : this._objects);
+          objectsToRender = options.filter ? this._objects.filter(options.filter) : this._objects;
       canvasEl.width = scaledWidth;
       canvasEl.height = scaledHeight;
       this.contextTop = null;

--- a/src/mixins/canvas_dataurl_exporter.mixin.js
+++ b/src/mixins/canvas_dataurl_exporter.mixin.js
@@ -61,6 +61,7 @@
      * @param {Number} [options.top] Cropping top offset.
      * @param {Number} [options.width] Cropping width.
      * @param {Number} [options.height] Cropping height.
+     * @param {fabric.Object[]} [options.objects] objects to render, overrides `filter`
      * @param {(object: fabric.Object) => boolean} [options.filter] Function to filter objects.
      */
     toCanvasElement: function (multiplier, options) {
@@ -80,7 +81,7 @@
           originalRetina = this.enableRetinaScaling,
           canvasEl = fabric.util.createCanvasElement(),
           originalContextTop = this.contextTop,
-          objectsToRender = options.filter ? this._objects.filter(options.filter) : this._objects;
+          objectsToRender = options.objects || (options.filter ? this._objects.filter(options.filter) : this._objects);
       canvasEl.width = scaledWidth;
       canvasEl.height = scaledHeight;
       this.contextTop = null;

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1738,7 +1738,7 @@
       if (originalGroup) {
         this.group = originalGroup;
       }
-      this.set(origParams).setCoords();
+      this.set(origParams);
       // canvas.dispose will call image.dispose that will nullify the elements
       // since this canvas is a simple element for the process, we remove references
       // to objects in this way in order to avoid object trashing.

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1729,12 +1729,8 @@
         canvas.backgroundColor = '#fff';
       }
       this.setPositionByOrigin(new fabric.Point(canvas.width / 2, canvas.height / 2), 'center', 'center');
-
-      var originalCanvas = this.canvas;
-      canvas.add(this);
-      var canvasEl = canvas.toCanvasElement(multiplier || 1, options);
+      var canvasEl = canvas.toCanvasElement(multiplier || 1, Object.assign(options, { objects: [this] }));
       this.shadow = originalShadow;
-      this.set('canvas', originalCanvas);
       if (originalGroup) {
         this.group = originalGroup;
       }

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1729,7 +1729,10 @@
         canvas.backgroundColor = '#fff';
       }
       this.setPositionByOrigin(new fabric.Point(canvas.width / 2, canvas.height / 2), 'center', 'center');
+      var originalCanvas = this.canvas;
+      this.set('canvas', canvas);
       var canvasEl = canvas.toCanvasElement(multiplier || 1, Object.assign(options, { objects: [this] }));
+      this.set('canvas', originalCanvas);
       this.shadow = originalShadow;
       if (originalGroup) {
         this.group = originalGroup;

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1732,6 +1732,7 @@
       var originalCanvas = this.canvas;
       canvas._objects = [this];
       this.set('canvas', canvas);
+      this.setCoords();
       var canvasEl = canvas.toCanvasElement(multiplier || 1, options);
       this.set('canvas', originalCanvas);
       this.shadow = originalShadow;
@@ -1739,6 +1740,7 @@
         this.group = originalGroup;
       }
       this.set(origParams);
+      this.setCoords();
       // canvas.dispose will call image.dispose that will nullify the elements
       // since this canvas is a simple element for the process, we remove references
       // to objects in this way in order to avoid object trashing.

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1730,8 +1730,9 @@
       }
       this.setPositionByOrigin(new fabric.Point(canvas.width / 2, canvas.height / 2), 'center', 'center');
       var originalCanvas = this.canvas;
+      canvas._objects = [this];
       this.set('canvas', canvas);
-      var canvasEl = canvas.toCanvasElement(multiplier || 1, Object.assign(options, { objects: [this] }));
+      var canvasEl = canvas.toCanvasElement(multiplier || 1, options);
       this.set('canvas', originalCanvas);
       this.shadow = originalShadow;
       if (originalGroup) {

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -396,7 +396,7 @@
 
   QUnit.test('toCanvasElement', function(assert) {
     var cObj = new fabric.Rect({
-      width: 100, height: 100, fill: 'red', strokeWidth: 0
+      width: 100, height: 100, fill: 'red', strokeWidth: 0, canvas: canvas
     });
 
     assert.ok(typeof cObj.toCanvasElement === 'function');
@@ -404,6 +404,7 @@
     var canvasEl = cObj.toCanvasElement();
 
     assert.ok(typeof canvasEl.getContext === 'function', 'the element returned is a canvas');
+    assert.ok(cObj.canvas === canvas, 'canvas ref should remain unchanged');
   });
 
   QUnit.test('toCanvasElement activeSelection', function(assert) {


### PR DESCRIPTION
#7866 exposed a regression when using `toCanvasElement`
This commit fixes it by working around `canvas.add` and fixes another issue:
`object.toCanvasElement()` would fire an added event which is absolutely undesired