### PR TITLE
ci(): fix build script option `exclude`

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -53,7 +53,7 @@ class ICheckbox extends Checkbox {
 inquirer.registerPrompt('test-selection', ICheckbox);
 
 function build(options = {}) {
-    _.defaultsDeep(options, { exclude: ['gestures', 'accessors', 'erasing'] });
+    _.defaults(options, { exclude: ['gestures', 'accessors', 'erasing'] });
     const args = [
         `node`,
         `build.js`,


### PR DESCRIPTION
passing `--exclude` now overrides default value