### PR TITLE
refactor(object_interactivity): draw borders

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -172,7 +172,7 @@
             new fabric.Point(0, 0).scalarAddEquals(this.canvas.getZoom()) :
             new fabric.Point(options.scaleX, options.scaleY),
           stroke = strokeFactor.scalarMultiplyEquals(this.strokeWidth),
-          size = bbox.scalarAddEquals(stroke).scalarAddEquals(this.borderScaleFactor);
+          size = bbox.addEquals(stroke).scalarAddEquals(this.borderScaleFactor);
       this._drawBorders(ctx, size, styleOverride);
       return this;
     },

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -146,33 +146,24 @@
      * Requires public properties: width, height
      * Requires public options: padding, borderColor
      * @param {CanvasRenderingContext2D} ctx Context to draw on
-     * @param {Object} styleOverride object to override the object style
-     * @return {fabric.Object} thisArg
-     * @chainable
-     */
-    drawBorders: function (ctx, styleOverride) {
-      var size = this._calculateCurrentDimensions().scalarAddEquals(this.borderScaleFactor);
-      this._drawBorders(ctx, size, styleOverride);
-      return this;
-    },
-
-    /**
-     * Draws borders of an object's bounding box when it is inside a group.
-     * Requires public properties: width, height
-     * Requires public options: padding, borderColor
-     * @param {CanvasRenderingContext2D} ctx Context to draw on
      * @param {object} options object representing current object parameters
-     * @param {Object} styleOverride object to override the object style
+     * @param {Object} [styleOverride] object to override the object style
      * @return {fabric.Object} thisArg
      * @chainable
      */
-    drawBordersInGroup: function (ctx, options, styleOverride) {
-      var bbox = fabric.util.sizeAfterTransform(this.width, this.height, options),
+    drawBorders: function (ctx, options, styleOverride) {
+      var size;
+      if ((styleOverride && styleOverride.forActiveSelection) || this.group) {
+        var bbox = fabric.util.sizeAfterTransform(this.width, this.height, options),
           strokeFactor = this.strokeUniform ?
             new fabric.Point(0, 0).scalarAddEquals(this.canvas.getZoom()) :
             new fabric.Point(options.scaleX, options.scaleY),
-          stroke = strokeFactor.scalarMultiplyEquals(this.strokeWidth),
-          size = bbox.addEquals(stroke).scalarAddEquals(this.borderScaleFactor);
+          stroke = strokeFactor.scalarMultiplyEquals(this.strokeWidth);
+        size = bbox.addEquals(stroke).scalarAddEquals(this.borderScaleFactor);
+      }
+      else {
+        size = this._calculateCurrentDimensions().scalarAddEquals(this.borderScaleFactor);
+      }
       this._drawBorders(ctx, size, styleOverride);
       return this;
     },

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -108,9 +108,9 @@
     },
 
     /**
-     * @public override if necessary
-     * @param {CanvasRenderingContext2D} ctx
-     * @param {fabric.Point} size
+     * @public override this function in order to customize the drawing of the control box, e.g. rounded corners, different border style.
+     * @param {CanvasRenderingContext2D} ctx ctx is rotated and translated so that (0,0) is at object's center
+     * @param {fabric.Point} size the control box size used
      */
     strokeBorders: function (ctx, size) {
       ctx.strokeRect(

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -168,11 +168,11 @@
      */
     drawBordersInGroup: function (ctx, options, styleOverride) {
       var bbox = fabric.util.sizeAfterTransform(this.width, this.height, options),
-        strokeFactor = this.strokeUniform ?
-          new fabric.Point(0, 0).scalarAddEquals(this.canvas.getZoom()) :
-          new fabric.Point(options.scaleX, options.scaleY),
-        stroke = strokeFactor.scalarMultiplyEquals(this.strokeWidth),
-        size = bbox.scalarAddEquals(stroke).scalarAddEquals(this.borderScaleFactor);
+          strokeFactor = this.strokeUniform ?
+            new fabric.Point(0, 0).scalarAddEquals(this.canvas.getZoom()) :
+            new fabric.Point(options.scaleX, options.scaleY),
+          stroke = strokeFactor.scalarMultiplyEquals(this.strokeWidth),
+          size = bbox.scalarAddEquals(stroke).scalarAddEquals(this.borderScaleFactor);
       this._drawBorders(ctx, size, styleOverride);
       return this;
     },

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -155,10 +155,10 @@
       var size;
       if ((styleOverride && styleOverride.forActiveSelection) || this.group) {
         var bbox = fabric.util.sizeAfterTransform(this.width, this.height, options),
-          strokeFactor = this.strokeUniform ?
-            new fabric.Point(0, 0).scalarAddEquals(this.canvas.getZoom()) :
-            new fabric.Point(options.scaleX, options.scaleY),
-          stroke = strokeFactor.scalarMultiplyEquals(this.strokeWidth);
+            strokeFactor = this.strokeUniform ?
+              new fabric.Point(0, 0).scalarAddEquals(this.canvas.getZoom()) :
+              new fabric.Point(options.scaleX, options.scaleY),
+            stroke = strokeFactor.scalarMultiplyEquals(this.strokeWidth);
         size = bbox.addEquals(stroke).scalarAddEquals(this.borderScaleFactor);
       }
       else {

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -108,6 +108,40 @@
     },
 
     /**
+     * @public override if necessary
+     * @param {CanvasRenderingContext2D} ctx
+     * @param {fabric.Point} size
+     */
+    strokeBorders: function (ctx, size) {
+      ctx.strokeRect(
+        -size.x / 2,
+        -size.y / 2,
+        size.x,
+        size.y
+      );
+    },
+
+    /**
+     * @private
+     * @param {CanvasRenderingContext2D} ctx Context to draw on
+     * @param {fabric.Point} size
+     * @param {Object} styleOverride object to override the object style
+     */
+    _drawBorders: function (ctx, size, styleOverride) {
+      var options = Object.assign({
+        hasControls: this.hasControls,
+        borderColor: this.borderColor,
+        borderDashArray: this.borderDashArray
+      }, styleOverride || {});
+      ctx.save();
+      ctx.strokeStyle = options.borderColor;
+      this._setLineDash(ctx, options.borderDashArray);
+      this.strokeBorders(ctx, size);
+      options.hasControls && this.drawControlsConnectingLines(ctx, size);
+      ctx.restore();
+    },
+
+    /**
      * Draws borders of an object's bounding box.
      * Requires public properties: width, height
      * Requires public options: padding, borderColor
@@ -116,28 +150,9 @@
      * @return {fabric.Object} thisArg
      * @chainable
      */
-    drawBorders: function(ctx, styleOverride) {
-      styleOverride = styleOverride || {};
-      var wh = this._calculateCurrentDimensions(),
-          strokeWidth = this.borderScaleFactor,
-          width = wh.x + strokeWidth,
-          height = wh.y + strokeWidth,
-          hasControls = typeof styleOverride.hasControls !== 'undefined' ?
-            styleOverride.hasControls : this.hasControls;
-
-      ctx.save();
-      ctx.strokeStyle = styleOverride.borderColor || this.borderColor;
-      this._setLineDash(ctx, styleOverride.borderDashArray || this.borderDashArray);
-
-      ctx.strokeRect(
-        -width / 2,
-        -height / 2,
-        width,
-        height
-      );
-      hasControls && this.drawControlsConnectingLines(ctx, width, height);
-
-      ctx.restore();
+    drawBorders: function (ctx, styleOverride) {
+      var size = this._calculateCurrentDimensions().scalarAddEquals(this.borderScaleFactor);
+      this._drawBorders(ctx, size, styleOverride);
       return this;
     },
 
@@ -151,30 +166,14 @@
      * @return {fabric.Object} thisArg
      * @chainable
      */
-    drawBordersInGroup: function(ctx, options, styleOverride) {
-      styleOverride = styleOverride || {};
+    drawBordersInGroup: function (ctx, options, styleOverride) {
       var bbox = fabric.util.sizeAfterTransform(this.width, this.height, options),
-          strokeWidth = this.strokeWidth,
-          strokeUniform = this.strokeUniform,
-          borderScaleFactor = this.borderScaleFactor,
-          width =
-            bbox.x + strokeWidth * (strokeUniform ? this.canvas.getZoom() : options.scaleX) + borderScaleFactor,
-          height =
-            bbox.y + strokeWidth * (strokeUniform ? this.canvas.getZoom() : options.scaleY) + borderScaleFactor,
-          hasControls = typeof styleOverride.hasControls !== 'undefined' ?
-            styleOverride.hasControls : this.hasControls;
-      ctx.save();
-      this._setLineDash(ctx, styleOverride.borderDashArray || this.borderDashArray);
-      ctx.strokeStyle = styleOverride.borderColor || this.borderColor;
-      ctx.strokeRect(
-        -width / 2,
-        -height / 2,
-        width,
-        height
-      );
-      hasControls && this.drawControlsConnectingLines(ctx, width, height);
-
-      ctx.restore();
+        strokeFactor = this.strokeUniform ?
+          new fabric.Point(0, 0).scalarAddEquals(this.canvas.getZoom()) :
+          new fabric.Point(options.scaleX, options.scaleY),
+        stroke = strokeFactor.scalarMultiplyEquals(this.strokeWidth),
+        size = bbox.scalarAddEquals(stroke).scalarAddEquals(this.borderScaleFactor);
+      this._drawBorders(ctx, size, styleOverride);
       return this;
     },
 
@@ -188,7 +187,7 @@
      * @return {fabric.Object} thisArg
      * @chainable
      */
-    drawControlsConnectingLines: function (ctx, width, height) {
+    drawControlsConnectingLines: function (ctx, size) {
       var shouldStroke = false;
 
       ctx.beginPath();
@@ -198,10 +197,10 @@
         if (control.withConnection && control.getVisibility(fabricObject, key)) {
           // reset movement for each control
           shouldStroke = true;
-          ctx.moveTo(control.x * width, control.y * height);
+          ctx.moveTo(control.x * size.x, control.y * size.y);
           ctx.lineTo(
-            control.x * width + control.offsetX,
-            control.y * height + control.offsetY
+            control.x * size.x + control.offsetX,
+            control.y * size.y + control.offsetY
           );
         }
       });

--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1402,12 +1402,7 @@
         options.angle -= 180;
       }
       ctx.rotate(degreesToRadians(this.group ? options.angle : this.angle));
-      if (drawBorders && (styleOverride.forActiveSelection || this.group)) {
-        this.drawBordersInGroup(ctx, options, styleOverride);
-      }
-      else if (drawBorders) {
-        this.drawBorders(ctx, styleOverride);
-      }
+      drawBorders && this.drawBorders(ctx, options, styleOverride);
       drawControls && this.drawControls(ctx, styleOverride);
       ctx.restore();
     },

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -1154,10 +1154,7 @@
             }],
           transformMatrix = fabric.util.calcDimensionsMatrix(options),
           bbox = fabric.util.makeBoundingBoxFromPoints(points, transformMatrix);
-      return {
-        x: bbox.width,
-        y: bbox.height,
-      };
+      return new fabric.Point(bbox.width, bbox.height);
     },
 
     /**

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -1130,8 +1130,7 @@
      * @param {Number} options.scaleY
      * @param {Number} options.skewX
      * @param {Number} options.skewY
-     * @return {Object.x} width of containing
-     * @return {Object.y} height of containing
+     * @returns {fabric.Point} size
      */
     sizeAfterTransform: function(width, height, options) {
       var dimX = width / 2, dimY = height / 2,


### PR DESCRIPTION
This PR refactors logic to enable easier overriding + maintenance.

- exposes private `_drawBorders`
- exposes public `strokeBorders` for easier overriding

**BREAKING** d257c99:
- removed `drawBordersInGroup`
- changed `drawBroders` signature


