### PR TITLE
fix(): assigning canvas to collections

### DIFF
--- a/src/shapes/object.class.js
+++ b/src/shapes/object.class.js
@@ -1231,7 +1231,7 @@
       // needed to setup a couple of variables
       // path canvas gets overridden with this one.
       // TODO find a better solution?
-      clipPath.canvas = this.canvas;
+      clipPath._set('canvas', this.canvas);
       clipPath.shouldCache();
       clipPath._transformDone = true;
       clipPath.renderCache({ forClipping: true });

--- a/src/static_canvas.class.js
+++ b/src/static_canvas.class.js
@@ -761,7 +761,7 @@
         this.drawControls(ctx);
       }
       if (path) {
-        path.canvas = this;
+        path._set('canvas', this);
         // needed to setup a couple of variables
         path.shouldCache();
         path._transformDone = true;


### PR DESCRIPTION
Collections could be used as clip paths.
This PR fixes canvas assignment in such a case.
Because Group assigns canvas only if the property changed this should not affect performance.