### PR TITLE
Cleanup README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,50 @@
-## Fabric.js
+# Fabric.js
+
+<a href="http://fabricjs.com/kitchensink" target="_blank"><img align="right" src="https://github.com/kangax/fabric.js/raw/master/lib/screenshot.png" style="width:400px"></a>
+
+<a href="http://fabricjs.com">FabricJS.com</a> is a **simple and powerful Javascript HTML5 canvas library**. It is also an **SVG-to-canvas parser**.
+
 
 <!-- build/coverage status, climate -->
-
 [![Build Status](https://secure.travis-ci.org/fabricjs/fabric.js.svg?branch=master)](http://travis-ci.org/#!/kangax/fabric.js)
 [![Code Climate](https://d3s6mut3hikguw.cloudfront.net/github/kangax/fabric.js/badges/gpa.svg)](https://codeclimate.com/github/kangax/fabric.js)
-[![Coverage Status](https://coveralls.io/repos/fabricjs/fabric.js/badge.png?branch=master)](https://coveralls.io/r/kangax/fabric.js?branch=master)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/fabricjs/fabric.js)
 
 <!-- npm, bower, CDNJS versions, downloads -->
-
-[![Bower version](https://badge.fury.io/bo/fabric.svg)](http://badge.fury.io/bo/fabric)
+[![CDNJS version](https://img.shields.io/cdnjs/v/fabric.js.svg)](https://cdnjs.com/libraries/fabric.js)
 [![NPM version](https://badge.fury.io/js/fabric.svg)](http://badge.fury.io/js/fabric)
 [![Downloads per month](https://img.shields.io/npm/dm/fabric.svg)](https://www.npmjs.org/package/fabric)
-[![CDNJS version](https://img.shields.io/cdnjs/v/fabric.js.svg)](https://cdnjs.com/libraries/fabric.js)
+[![Bower version](https://badge.fury.io/bo/fabric.svg)](http://badge.fury.io/bo/fabric)
 
-<!-- bounties, tips -->
-
-[![Bountysource](https://api.bountysource.com/badge/tracker?tracker_id=23217)](https://www.bountysource.com/trackers/23217-fabric-js?utm_source=23217&utm_medium=shield&utm_campaign=TRACKER_BADGE)
-[![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=kangax&url=http://github.com/kangax/fabric.js&title=Fabric.js&language=&tags=github&category=software)
-
-**Fabric.js** is a framework that makes it easy to work with HTML5 canvas element. It is an **interactive object model** on top of canvas element. It is also an **SVG-to-canvas parser**.
-
-<a href="http://fabricjs.com/kitchensink" target="_blank"><img src="https://github.com/kangax/fabric.js/raw/master/lib/screenshot.png" style="width:300px;box-shadow:rgba(0,0,0,0.3) 0 0 5px"></a>
-
-Using Fabric.js, you can create and populate objects on canvas; objects like simple geometrical shapes — rectangles, circles, ellipses, polygons, or more complex shapes consisting of hundreds or thousands of simple paths. You can then scale, move, and rotate these objects with the mouse; modify their properties — color, transparency, z-index, etc. You can also manipulate these objects altogether — grouping them with a simple mouse selection.
-
-### Non-Technical Introduction to Fabric
-
-Fabric.js allows you to easily create simple shapes like rectangles, circles, triangles and other polygons or more complex shapes made up of many paths, onto the HTML `<canvas>` element on a webpage using JavaScript.  Fabric.js will then allow you to manipulate the size, position and rotation of these objects with a mouse.  It’s also possible to change some of the attributes of these objects such as their color, transparency, depth position on the webpage or selecting groups of these objects using the Fabric.js library. Fabric.js will also allow you to convert an SVG image into JavaScript data that can be used for putting it onto the `<canvas>` element.
+<br/>
 
 
-[Contributions](https://github.com/kangax/fabric.js/wiki/Love-Fabric%3F-Help-us-by...) are very much welcome!
+Using Fabric.js, you can create and populate objects on canvas; objects like simple geometrical shapes — rectangles, circles, ellipses, polygons, or more complex shapes consisting of hundreds or thousands of simple paths. You can then scale, move, and rotate these objects with the mouse; modify their properties — color, transparency, z-index, etc. You can also manipulate these objects altogether — grouping them with a simple mouse selection. Fabric.js will also allow you to convert an SVG image into JavaScript data that can be used for putting it onto the `<canvas>` element.
 
-### Goals
+<br />
 
-- Unit tested (1150+ tests at the moment, 79%+ coverage)
-- Modular (~60 small ["classes", modules, mixins](http://fabricjs.com/docs/))
-- Cross-browser
-- [Fast](https://github.com/kangax/fabric.js/wiki/Focus-on-speed)
-- Encapsulated in one object
-- No browser sniffing for critical functionality
-- Runs under ES5 strict mode
-- Runs on a server under [Node.js](http://nodejs.org/) (active stable releases and latest of current) (see [Node.js limitations](https://github.com/kangax/fabric.js/wiki/Fabric-limitations-in-node.js))
-- Follows [Semantic Versioning](http://semver.org/)
+<a href="http://fabricjs.com/fabric-intro-part-1">Introduction</a>
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+<a href="http://fabricjs.com/docs/">Docs</a>
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+<a href="http://fabricjs.com/demos/">Demos</a>
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+<a href="http://fabricjs.com/kitchensink/">Kitchensink</a>
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+<a href="http://fabricjs.com/benchmarks/">Benchmarks</a>
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+<a href="https://github.com/fabricjs/fabric.js/wiki">Contribution</a>
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+<a href="#sponsor">Sponsor authors</a>
+<br />
 
-### Supported browsers
+<hr />
 
-- Firefox 4+
-- Safari 5+
-- Opera 9.64+
-- Chrome (all versions)
-- Edge (chromium based, all versions)
-- IE11 and Edge legacy, not supported. Fabric up to 5.0 is written with ES5 in mind, but no specific tests are run for those browsers.
+<h3 id="npm-install">Quick Start</h3>
 
-You can [run automated unit tests](http://fabricjs.com/test/unit/) right in the browser.
-
-### History
-
-Fabric.js started as a foundation for design editor on [printio.ru](http://printio.ru) — interactive online store with ability to create your own designs. The idea was to create [Javascript-based editor](http://printio.ru/ringer_man_tees/new), which would make it easy to manipulate vector shapes and images on T-Shirts. Since performance was one of the most critical requirements, we chose canvas over SVG. While SVG is excellent with static shapes, it's not as performant as canvas when it comes to dynamic manipulation of objects (movement, scaling, rotation, etc.). Fabric.js was heavily inspired by [Ernest Delgado's canvas experiment](http://www.ernestdelgado.com/public-tests/canvasphoto/demo/canvas.html). In fact, code from Ernest's experiment was the foundation of an entire framework. Later, Fabric.js grew into a collection of distinct object types and got an SVG-to-canvas parser.
-
-### Installation Instructions
-
-<h3 id="bower-install">Install with bower</h3>
-
-    $ bower install fabric
-
-<h3 id="npm-install">Install with npm</h3>
-
-Note: If you are using Fabric.js in a Node.js script, you will depend from [node-canvas](https://github.com/Automattic/node-canvas).`node-canvas` is an html canvas replacement that works on top of native libraries.
-Please follow the instructions located [here](https://github.com/Automattic/node-canvas#compiling) in order to get it up and running.
-
-
-    $ npm install fabric --save
-
+```
+$ npm install fabric --save
+```
 
 After this, you can import fabric like so:
 
@@ -86,19 +58,73 @@ Or you can use this instead if your build pipeline supports ES6 imports:
 import { fabric } from "fabric";
 ```
 
+NOTE: If you are using Fabric.js in a Node.js script, you will depend from [node-canvas](https://github.com/Automattic/node-canvas).`node-canvas` is an HTML canvas replacement that works on top of native libraries. Please [follow the instructions](https://github.com/Automattic/node-canvas#compiling) to get it up and running.
+
 NOTE: es6 imports won't work in browser or with bundlers which expect es6 module like vite. Use commonjs syntax instead.
 
-See [the example section](#examples-of-use) for usage examples.
+### Usage
+
+#### Plain HTML
+
+```html
+<canvas id="canvas" width="300" height="300"></canvas>
+
+<!-- Get latest version: https://cdnjs.com/libraries/fabric.js -->
+<script src="lib/fabric.js"></script> 
+<script>
+    var canvas = new fabric.Canvas('canvas');
+
+    var rect = new fabric.Rect({
+        top : 100,
+        left : 100,
+        width : 60,
+        height : 70,
+        fill : 'red'
+    });
+    canvas.add(rect);
+</script>
+```
+
+#### ReactJS
+
+```tsx
+import React, {useEffect, useRef} from 'react'
+import {fabric} from 'fabric'
+
+const FabricJSCanvas = () => {
+  const canvasEl = useRef(null)
+  useEffect(() => {
+    const canvas = new fabric.Canvas(canvasEl.current);
+    const rect = new fabric.Rect({
+            top : 100,
+            left : 100,
+            width : 60,
+            height : 70,
+            fill : 'red'
+    });
+    
+    canvas.add(rect);
+    return () => {
+      canvas.dispose()
+    }
+  }, []);
+  
+  return (<canvas width="300" height="300" ref={canvasEl}/>)
+});
+
+export default FabricJSCanvas;
+```
+
+NOTE: Fabric.js requires a `window` object.
+
 
 <h3 id="fabric-building">Building</h3>
 
-1. [Install Node.js](https://github.com/joyent/node/wiki/Installation)
+1. Build distribution file  **[~77K minified, ~20K gzipped]**
 
-2. Build distribution file  **[~77K minified, ~20K gzipped]**
+         $ node build.js
 
-        $ node build.js
-
-    2.1 Or build a custom distribution file, by passing (comma separated) module names to be included.
+    1.1 Or build a custom distribution file, by passing (comma separated) module names to be included.
 
           $ node build.js modules=text,serialization,parser
           // or
@@ -115,15 +141,15 @@ See [the example section](#examples-of-use) for usage examples.
 
           $ node build.js modules=interaction
 
-    2.2 You can also include all modules like so:
+    1.2 You can also include all modules like so:
 
           $ node build.js modules=ALL
 
-    2.3 You can exclude a few modules like so:
+    1.3 You can exclude a few modules like so:
 
           $ node build.js modules=ALL exclude=gestures,image_filters
 
-3. Create a minified distribution file
+2. Create a minified distribution file
 
         # Using YUICompressor (default option)
         $ node build.js modules=... minifier=yui
@@ -131,11 +157,11 @@ See [the example section](#examples-of-use) for usage examples.
         # or Google Closure Compiler
         $ node build.js modules=... minifier=closure
 
-4. Enable AMD support via require.js (requires uglify)
+3. Enable AMD support via require.js (requires uglify)
 
         $ node build.js requirejs modules=...
 
-5. Create source map file for better productive debugging (requires uglify or google closure compiler).<br>More information about [source maps](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/).
+4. Create source map file for better productive debugging (requires uglify or google closure compiler).<br>More information about [source maps](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/).
 
         $ node build.js sourcemap modules=...
 
@@ -143,45 +169,31 @@ See [the example section](#examples-of-use) for usage examples.
 
         //# sourceMappingURL=fabric.min.js.map
 
-6. Ensure code guidelines are met (prerequisite: `npm -g install eslint`)
+5. Ensure code guidelines are met (prerequisite: `npm -g install eslint`)
 
         $ npm run lint && npm run lint_tests
 
 <h3 id="fabric-building">Testing</h3>
 
-1. [Install Node.js](https://github.com/joyent/node/wiki/Installation)
+#### 1. Install NPM packages
 
-2. [Install NPM, if necessary](https://github.com/npm/npm#super-easy-install)
+```
+$ npm install
+```
 
-3. Install NPM packages
+#### 2. Install testem
 
-        $ npm install
+```
+$ npm install -g testem
+```
 
-4. Run test suite
+#### 3. Run tests Chrome and Node (by default):
 
-Make sure testem is installed
-
-        $ npm install -g testem
-
-Run tests Chrome and Node (by default):
-
-        $ testem
+```
+$ testem
+```
 
 See testem docs for more info: https://github.com/testem/testem
-
-### Demos
-
-- [Demos](http://fabricjs.com/demos/)
-- [Kitchensink demo](http://fabricjs.com/kitchensink)
-- [Benchmarks](http://fabricjs.com/benchmarks/)
-
-[Who's using Fabric?](http://trends.builtwith.com/javascript/FabricJS)
-
-### Documentation
-
-Documentation is always available at [http://fabricjs.com/docs/](http://fabricjs.com/docs/).
-
-Also see [official 4-part intro series](http://fabricjs.com/articles), [presentation from BK.js](http://www.slideshare.net/kangax/fabricjs-building-acanvaslibrarybk) and [presentation from Falsy Values](http://www.slideshare.net/kangax/fabric-falsy-values-8067834) for an overview of fabric.js, how it works, and its features.
 
 ### Optional modules
 
@@ -212,65 +224,62 @@ For example:
 
     node build.js modules=ALL exclude=json no-strict no-svg-export
 
-### Examples of use
 
-#### Adding red rectangle to canvas
+### Goals
 
-```html
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body>
-    <canvas id="canvas" width="300" height="300"></canvas>
+- Unit tested (1150+ tests at the moment, 79%+ coverage)
+- Modular (~60 small ["classes", modules, mixins](http://fabricjs.com/docs/))
+- Cross-browser
+- [Fast](https://github.com/kangax/fabric.js/wiki/Focus-on-speed)
+- Encapsulated in one object
+- No browser sniffing for critical functionality
+- Runs under ES5 strict mode
+- Runs on a server under [Node.js](http://nodejs.org/) (active stable releases and latest of current) (see [Node.js limitations](https://github.com/kangax/fabric.js/wiki/Fabric-limitations-in-node.js))
+- Follows [Semantic Versioning](http://semver.org/)
 
-    <script src="lib/fabric.js"></script>
-    <script>
-        var canvas = new fabric.Canvas('canvas');
+### Supported browsers
 
-        var rect = new fabric.Rect({
-            top : 100,
-            left : 100,
-            width : 60,
-            height : 70,
-            fill : 'red'
-        });
+- Firefox 4+
+- Safari 5+
+- Opera 9.64+
+- Chrome (all versions)
+- Edge (chromium based, all versions)
+- IE11 and Edge legacy, not supported. Fabric up to 5.0 is written with ES5 in mind, but no specific tests are run for those browsers.
 
-        canvas.add(rect);
-    </script>
-</body>
-</html>
-```
+You can [run automated unit tests](http://fabricjs.com/test/unit/) right in the browser.
 
-### Helping Fabric
 
-- [Fabric on Bountysource](https://www.bountysource.com/trackers/23217-fabric-js)
-- [Fabric on CodeTriage](http://www.codetriage.com/kangax/fabric.js)
-- [Contributing](./CONTRIBUTING.md)
+### More resources
 
-### Staying in touch
+- [Fabric.js on Twitter](https://twitter.com/fabricjs)
+- [Fabric.js on Google Groups](https://groups.google.com/group/fabricjs)
+- [Fabric.js on CodeTriage](https://www.codetriage.com/kangax/fabric.js)
+- [Fabric.js on Bountysource](https://www.bountysource.com/trackers/23217-fabric-js)
+- [Fabric.js on Stackoverflow](https://stackoverflow.com/questions/tagged/fabricjs)
+- [Fabric.js on jsfiddle](https://jsfiddle.net/user/fabricjs/fiddles/)
+- [Fabric.js on Codepen.io](https://codepen.io/tag/fabricjs)
+- [Presentation from BK.js](http://www.slideshare.net/kangax/fabricjs-building-acanvaslibrarybk)
+- [Presentation from Falsy Values](http://www.slideshare.net/kangax/fabric-falsy-values-8067834)
 
-Follow [@fabric.js](http://twitter.com/fabricjs), [@kangax](http://twitter.com/kangax) or [@AndreaBogazzi](http://twitter.com/AndreaBogazzi) on twitter.
-
-Questions, suggestions — [fabric.js on Google Groups](http://groups.google.com/group/fabricjs).
-
-See [Fabric questions on Stackoverflow](http://stackoverflow.com/questions/tagged/fabricjs),
-Fabric snippets on [jsfiddle](http://jsfiddle.net/user/fabricjs/fiddles/)
-or [codepen.io](http://codepen.io/tag/fabricjs).
-
-Fabric on [LibKnot](http://libknot.ohmztech.com/).
-
-Get help in Fabric's IRC channel — irc://irc.freenode.net/#fabric.js
 
 ### Credits
 
+- [@kangax](https://twitter.com/kangax)
 - [Andrea Bogazzi](https://twitter.com/AndreaBogazzi) for help with bugs, new features, documentation, GitHub issues
 - Ernest Delgado for the original idea of [manipulating images on canvas](http://www.ernestdelgado.com/archive/canvas/)
 - [Maxim "hakunin" Chernyak](http://twitter.com/hakunin) for ideas, and help with various parts of the library throughout its life
 - [Sergey Nisnevich](http://nisnya.com) for help with geometry logic
 - [Stefan Kienzle](https://twitter.com/kienzle_s) for help with bugs, features, documentation, GitHub issues
-- [Shutterstock](http://www.shutterstock.com/jobs) for the time and resources invested in using and improving fabric.js
+- [Shutterstock](http://www.shutterstock.com/jobs) for the time and resources invested in using and improving Fabric.js
 - [And all the other GitHub contributors](https://github.com/kangax/fabric.js/graphs/contributors)
+
+
+<h3 id="sponsor">Sponsor authors</h3>
+
+- https://flattr.com/@kangax
+- https://github.com/sponsors/asturur
+- https://www.patreon.com/fabricJS
+
 
 ### MIT License
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@
 [![Downloads per month](https://img.shields.io/npm/dm/fabric.svg)](https://www.npmjs.org/package/fabric)
 [![Bower version](https://badge.fury.io/bo/fabric.svg)](http://badge.fury.io/bo/fabric)
 
-<br/>
-
-
-Using Fabric.js, you can create and populate objects on canvas; objects like simple geometrical shapes — rectangles, circles, ellipses, polygons, or more complex shapes consisting of hundreds or thousands of simple paths. You can then scale, move, and rotate these objects with the mouse; modify their properties — color, transparency, z-index, etc. You can also manipulate these objects altogether — grouping them with a simple mouse selection. Fabric.js will also allow you to convert an SVG image into JavaScript data that can be used for putting it onto the `<canvas>` element.
+## Features 
+- drag-n-drop objects on canvas,
+- scale, move, rotate and group objects with mouse,
+- use predefined shapes or create custom objects,
+- works super-fast with many objects,
+- supports JPG, PNG, JSON and SVG formats,
+- ready-to-use image filters,
+- create animations,
+- and much more!
 
 <br />
 
@@ -34,13 +39,11 @@ Using Fabric.js, you can create and populate objects on canvas; objects like sim
 <a href="http://fabricjs.com/benchmarks/">Benchmarks</a>
 <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
 <a href="https://github.com/fabricjs/fabric.js/wiki">Contribution</a>
-<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-<a href="#sponsor">Sponsor authors</a>
 <br />
 
 <hr />
 
-<h3 id="npm-install">Quick Start</h3>
+## Quick Start
 
 ```
 $ npm install fabric --save
@@ -62,9 +65,9 @@ NOTE: If you are using Fabric.js in a Node.js script, you will depend on [node-c
 
 NOTE: es6 imports won't work in browser or with bundlers which expect es6 module like vite. Use commonjs syntax instead.
 
-### Usage
+## Usage
 
-#### Plain HTML
+### Plain HTML
 
 ```html
 <canvas id="canvas" width="300" height="300"></canvas>
@@ -85,7 +88,7 @@ NOTE: es6 imports won't work in browser or with bundlers which expect es6 module
 </script>
 ```
 
-#### ReactJS
+### ReactJS
 
 ```tsx
 import React, {useEffect, useRef} from 'react'
@@ -94,31 +97,25 @@ import {fabric} from 'fabric'
 const FabricJSCanvas = () => {
   const canvasEl = useRef(null)
   useEffect(() => {
-    const canvas = new fabric.Canvas(canvasEl.current);
-    const rect = new fabric.Rect({
-            top : 100,
-            left : 100,
-            width : 60,
-            height : 70,
-            fill : 'red'
-    });
-    
-    canvas.add(rect);
+    const options = { ... };
+    const canvas = new fabric.Canvas(canvasEl.current, options);
+    // make the fabric.Canvas instance available to your app
+    updateCanvasContext(canvas);
     return () => {
+      updateCanvasContext(null);
       canvas.dispose()
     }
   }, []);
   
   return (<canvas width="300" height="300" ref={canvasEl}/>)
 });
-
 export default FabricJSCanvas;
 ```
 
 NOTE: Fabric.js requires a `window` object.
 
 
-<h3 id="fabric-building">Building</h3>
+## Building
 
 1. Build distribution file  **[~77K minified, ~20K gzipped]**
 
@@ -173,21 +170,15 @@ NOTE: Fabric.js requires a `window` object.
 
         $ npm run lint && npm run lint_tests
 
-<h3 id="fabric-building">Testing</h3>
+## Testing
 
-#### 1. Install NPM packages
+### 1. Install NPM packages
 
 ```
 $ npm install
 ```
 
-#### 2. Install testem
-
-```
-$ npm install -g testem
-```
-
-#### 3. Run tests Chrome and Node (by default):
+### 2. Run tests Chrome and Node (by default):
 
 ```
 $ testem
@@ -195,7 +186,7 @@ $ testem
 
 See testem docs for more info: https://github.com/testem/testem
 
-### Optional modules
+## Optional modules
 
 These are the optional modules that could be specified for inclusion, when building custom version of fabric:
 
@@ -225,7 +216,7 @@ For example:
     node build.js modules=ALL exclude=json no-strict no-svg-export
 
 
-### Goals
+## Goals
 
 - Unit tested (1150+ tests at the moment, 79%+ coverage)
 - Modular (~60 small ["classes", modules, mixins](http://fabricjs.com/docs/))
@@ -237,7 +228,7 @@ For example:
 - Runs on a server under [Node.js](http://nodejs.org/) (active stable releases and latest of current) (see [Node.js limitations](https://github.com/kangax/fabric.js/wiki/Fabric-limitations-in-node.js))
 - Follows [Semantic Versioning](http://semver.org/)
 
-### Supported browsers
+## Supported browsers
 
 - Firefox 4+
 - Safari 5+
@@ -249,12 +240,10 @@ For example:
 You can [run automated unit tests](http://fabricjs.com/test/unit/) right in the browser.
 
 
-### More resources
+## More resources
 
 - [Fabric.js on Twitter](https://twitter.com/fabricjs)
-- [Fabric.js on Google Groups](https://groups.google.com/group/fabricjs)
 - [Fabric.js on CodeTriage](https://www.codetriage.com/kangax/fabric.js)
-- [Fabric.js on Bountysource](https://www.bountysource.com/trackers/23217-fabric-js)
 - [Fabric.js on Stackoverflow](https://stackoverflow.com/questions/tagged/fabricjs)
 - [Fabric.js on jsfiddle](https://jsfiddle.net/user/fabricjs/fiddles/)
 - [Fabric.js on Codepen.io](https://codepen.io/tag/fabricjs)
@@ -262,7 +251,7 @@ You can [run automated unit tests](http://fabricjs.com/test/unit/) right in the 
 - [Presentation from Falsy Values](http://www.slideshare.net/kangax/fabric-falsy-values-8067834)
 
 
-### Credits
+## Credits
 
 - [@kangax](https://twitter.com/kangax)
 - [Andrea Bogazzi](https://twitter.com/AndreaBogazzi) for help with bugs, new features, documentation, GitHub issues
@@ -274,14 +263,17 @@ You can [run automated unit tests](http://fabricjs.com/test/unit/) right in the 
 - [And all the other GitHub contributors](https://github.com/kangax/fabric.js/graphs/contributors)
 
 
-<h3 id="sponsor">Sponsor authors</h3>
+## Sponsor authors
 
 - https://flattr.com/@kangax
 - https://github.com/sponsors/asturur
 - https://www.patreon.com/fabricJS
 
+## History
 
-### MIT License
+Fabric.js started as a foundation for design editor on [printio.ru](http://printio.ru) — interactive online store with ability to create your own designs. The idea was to create [Javascript-based editor](http://printio.ru/ringer_man_tees/new), which would make it easy to manipulate vector shapes and images on T-Shirts. Since performance was one of the most critical requirements, we chose canvas over SVG. While SVG is excellent with static shapes, it's not as performant as canvas when it comes to dynamic manipulation of objects (movement, scaling, rotation, etc.). Fabric.js was heavily inspired by [Ernest Delgado's canvas experiment](http://www.ernestdelgado.com/public-tests/canvasphoto/demo/canvas.html). In fact, code from Ernest's experiment was the foundation of an entire framework. Later, Fabric.js grew into a collection of distinct object types and got an SVG-to-canvas parser.
+
+## MIT License
 
 Copyright (c) 2008-2015 Printio (Juriy Zaytsev, Maxim Chernyak)
 

--- a/README.md
+++ b/README.md
@@ -255,12 +255,14 @@ You can [run automated unit tests](http://fabricjs.com/test/unit/) right in the 
 
 - [@kangax](https://twitter.com/kangax)
 - [Andrea Bogazzi](https://twitter.com/AndreaBogazzi) for help with bugs, new features, documentation, GitHub issues
+- [melchiar](https://github.com/melchiar)
+- [ShaMan123](https://github.com/ShaMan123)
 - Ernest Delgado for the original idea of [manipulating images on canvas](http://www.ernestdelgado.com/archive/canvas/)
 - [Maxim "hakunin" Chernyak](http://twitter.com/hakunin) for ideas, and help with various parts of the library throughout its life
 - [Sergey Nisnevich](http://nisnya.com) for help with geometry logic
 - [Stefan Kienzle](https://twitter.com/kienzle_s) for help with bugs, features, documentation, GitHub issues
 - [Shutterstock](http://www.shutterstock.com/jobs) for the time and resources invested in using and improving Fabric.js
-- [And all the other GitHub contributors](https://github.com/kangax/fabric.js/graphs/contributors)
+- [and all the other GitHub contributors](https://github.com/kangax/fabric.js/graphs/contributors)
 
 
 ## Sponsor authors
@@ -268,10 +270,6 @@ You can [run automated unit tests](http://fabricjs.com/test/unit/) right in the 
 - https://flattr.com/@kangax
 - https://github.com/sponsors/asturur
 - https://www.patreon.com/fabricJS
-
-## History
-
-Fabric.js started as a foundation for design editor on [printio.ru](http://printio.ru) — interactive online store with ability to create your own designs. The idea was to create [Javascript-based editor](http://printio.ru/ringer_man_tees/new), which would make it easy to manipulate vector shapes and images on T-Shirts. Since performance was one of the most critical requirements, we chose canvas over SVG. While SVG is excellent with static shapes, it's not as performant as canvas when it comes to dynamic manipulation of objects (movement, scaling, rotation, etc.). Fabric.js was heavily inspired by [Ernest Delgado's canvas experiment](http://www.ernestdelgado.com/public-tests/canvasphoto/demo/canvas.html). In fact, code from Ernest's experiment was the foundation of an entire framework. Later, Fabric.js grew into a collection of distinct object types and got an SVG-to-canvas parser.
 
 ## MIT License
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Or you can use this instead if your build pipeline supports ES6 imports:
 import { fabric } from "fabric";
 ```
 
-NOTE: If you are using Fabric.js in a Node.js script, you will depend from [node-canvas](https://github.com/Automattic/node-canvas).`node-canvas` is an HTML canvas replacement that works on top of native libraries. Please [follow the instructions](https://github.com/Automattic/node-canvas#compiling) to get it up and running.
+NOTE: If you are using Fabric.js in a Node.js script, you will depend on [node-canvas](https://github.com/Automattic/node-canvas). `node-canvas` is an HTML canvas replacement that works on top of native libraries. Please [follow the instructions](https://github.com/Automattic/node-canvas#compiling) to get it up and running.
 
 NOTE: es6 imports won't work in browser or with bundlers which expect es6 module like vite. Use commonjs syntax instead.
 


### PR DESCRIPTION
I rearranged a lot of content, making it a bit more modern. I focused on showing new users HOW TO USE it instead feeding them with the FabricJS history 😉

# Changes:
- Removed not working links
- Made a sponsorship section
- Removed duplicated links to resources
- Created a README header with the most important links
- Added a Quick Start section
- Added ReactJS example code
- Removed Bower installation instruction (I left a badge)
- Simplified sample HTML code

# EDIT

I didn't want to delete too much, because I'm fairly new in FabricJS. I would love to keep the docs and README.md page clean and simple. My intention was to remove duplicated and old/useless content, it's easy to get lost in all those resources and links.