### PR TITLE
fix(Point): safeguard initialization

### DIFF
--- a/src/point.class.js
+++ b/src/point.class.js
@@ -23,8 +23,8 @@
    * @return {fabric.Point} thisArg
    */
   function Point(x, y) {
-    this.x = x;
-    this.y = y;
+    this.x = x || 0;
+    this.y = y || 0;
   }
 
   Point.prototype = /** @lends fabric.Point.prototype */ {

--- a/test/unit/point.js
+++ b/test/unit/point.js
@@ -18,7 +18,7 @@
     var x = 5, y = 6;
     point = new fabric.Point(x, y);
     assert.equal(point.x, x, 'constructor pass x value');
-    assert.equal(point.y, y, 'constructor pass y value');   
+    assert.equal(point.y, y, 'constructor pass y value');
   });
 
   QUnit.test('point add', function(assert) {

--- a/test/unit/point.js
+++ b/test/unit/point.js
@@ -12,17 +12,13 @@
     assert.ok(point.constructor === fabric.Point);
     assert.ok(typeof point.constructor === 'function');
     assert.equal(point.type, 'point');
-    assert.equal(point.x, undefined, 'no default values for x');
-    assert.equal(point.y, undefined, 'no default values for y');
+    assert.strictEqual(point.x, 0, 'constructor assign x value');
+    assert.strictEqual(point.y, 0, 'constructor assign y value');
 
     var x = 5, y = 6;
     point = new fabric.Point(x, y);
     assert.equal(point.x, x, 'constructor pass x value');
-    assert.equal(point.y, y, 'constructor pass y value');
-
-    point = new fabric.Point();
-    assert.strictEqual(point.x, 0, 'constructor assign x value');
-    assert.strictEqual(point.y, 0, 'constructor assign y value');
+    assert.equal(point.y, y, 'constructor pass y value');   
   });
 
   QUnit.test('point add', function(assert) {

--- a/test/unit/point.js
+++ b/test/unit/point.js
@@ -19,6 +19,10 @@
     point = new fabric.Point(x, y);
     assert.equal(point.x, x, 'constructor pass x value');
     assert.equal(point.y, y, 'constructor pass y value');
+
+    point = new fabric.Point();
+    assert.strictEqual(point.x, 0, 'constructor assign x value');
+    assert.strictEqual(point.y, 0, 'constructor assign y value');
   });
 
   QUnit.test('point add', function(assert) {


### PR DESCRIPTION
This PR fixes Point so that the following
```js
new fabric.Point().scalarAdd(5)
```

will result in Point(5, 5) instead of Nan
