### PR TITLE
fix(Textbox): flipped `changeWidth` control behavior

### DIFF
--- a/src/controls.actions.js
+++ b/src/controls.actions.js
@@ -688,7 +688,6 @@
   function changeWidth(eventData, transform, x, y) {
     var localPoint = getLocalPoint(transform, transform.originX, transform.originY, x, y);
     //  make sure the control changes width ONLY from it's side of target
-    console.log(transform.corner)
     if ((transform.corner === 'ml' && localPoint.x < 0) || (transform.corner === 'mr' && localPoint.x > 0)) {
       var target = transform.target,
         strokePadding = target.strokeWidth / (target.strokeUniform ? target.scaleX : 1),

--- a/src/controls.actions.js
+++ b/src/controls.actions.js
@@ -690,10 +690,10 @@
     //  make sure the control changes width ONLY from it's side of target
     if ((transform.originX === 'right' && localPoint.x < 0) || (transform.originX === 'left' && localPoint.x > 0)) {
       var target = transform.target,
-        strokePadding = target.strokeWidth / (target.strokeUniform ? target.scaleX : 1),
-        multiplier = isTransformCentered(transform) ? 2 : 1,
-        oldWidth = target.width,
-        newWidth = Math.ceil(Math.abs(localPoint.x * multiplier / target.scaleX) - strokePadding);
+          strokePadding = target.strokeWidth / (target.strokeUniform ? target.scaleX : 1),
+          multiplier = isTransformCentered(transform) ? 2 : 1,
+          oldWidth = target.width,
+          newWidth = Math.ceil(Math.abs(localPoint.x * multiplier / target.scaleX) - strokePadding);
       target.set('width', Math.max(newWidth, 0));
       //  check against actual target width in case `newWidth` was rejected
       return oldWidth !== target.width;

--- a/src/controls.actions.js
+++ b/src/controls.actions.js
@@ -688,7 +688,9 @@
   function changeWidth(eventData, transform, x, y) {
     var localPoint = getLocalPoint(transform, transform.originX, transform.originY, x, y);
     //  make sure the control changes width ONLY from it's side of target
-    if ((transform.originX === 'right' && localPoint.x < 0) || (transform.originX === 'left' && localPoint.x > 0)) {
+    if (transform.originX === 'center' ||
+      (transform.originX === 'right' && localPoint.x < 0) ||
+      (transform.originX === 'left' && localPoint.x > 0)) {
       var target = transform.target,
           strokePadding = target.strokeWidth / (target.strokeUniform ? target.scaleX : 1),
           multiplier = isTransformCentered(transform) ? 2 : 1,

--- a/src/controls.actions.js
+++ b/src/controls.actions.js
@@ -688,7 +688,7 @@
   function changeWidth(eventData, transform, x, y) {
     var localPoint = getLocalPoint(transform, transform.originX, transform.originY, x, y);
     //  make sure the control changes width ONLY from it's side of target
-    if ((transform.corner === 'ml' && localPoint.x < 0) || (transform.corner === 'mr' && localPoint.x > 0)) {
+    if ((transform.originX === 'right' && localPoint.x < 0) || (transform.originX === 'left' && localPoint.x > 0)) {
       var target = transform.target,
         strokePadding = target.strokeWidth / (target.strokeUniform ? target.scaleX : 1),
         multiplier = isTransformCentered(transform) ? 2 : 1,

--- a/src/controls.actions.js
+++ b/src/controls.actions.js
@@ -686,7 +686,12 @@
    * @return {Boolean} true if some change happened
    */
   function changeWidth(eventData, transform, x, y) {
-    var target = transform.target, localPoint = getLocalPoint(transform, transform.originX, transform.originY, x, y),
+    var localPoint = getLocalPoint(transform, transform.originX, transform.originY, x, y);
+    //  make sure the control changes width ONLY from it's side of target
+    if ((transform.corner === 'ml' && localPoint.x > 0) || (transform.corner === 'mr' && localPoint.x < 0)) {
+      return false;
+    }
+    var target = transform.target,
         strokePadding = target.strokeWidth / (target.strokeUniform ? target.scaleX : 1),
         multiplier = isTransformCentered(transform) ? 2 : 1,
         oldWidth = target.width,

--- a/src/controls.actions.js
+++ b/src/controls.actions.js
@@ -688,17 +688,18 @@
   function changeWidth(eventData, transform, x, y) {
     var localPoint = getLocalPoint(transform, transform.originX, transform.originY, x, y);
     //  make sure the control changes width ONLY from it's side of target
-    if ((transform.corner === 'ml' && localPoint.x > 0) || (transform.corner === 'mr' && localPoint.x < 0)) {
-      return false;
-    }
-    var target = transform.target,
+    console.log(transform.corner)
+    if ((transform.corner === 'ml' && localPoint.x < 0) || (transform.corner === 'mr' && localPoint.x > 0)) {
+      var target = transform.target,
         strokePadding = target.strokeWidth / (target.strokeUniform ? target.scaleX : 1),
         multiplier = isTransformCentered(transform) ? 2 : 1,
         oldWidth = target.width,
         newWidth = Math.ceil(Math.abs(localPoint.x * multiplier / target.scaleX) - strokePadding);
-    target.set('width', Math.max(newWidth, 0));
-    //  check against actual target width in case `newWidth` was rejected
-    return oldWidth !== target.width;
+      target.set('width', Math.max(newWidth, 0));
+      //  check against actual target width in case `newWidth` was rejected
+      return oldWidth !== target.width;
+    }
+    return false;
   }
 
   /**

--- a/test/unit/controls_handlers.js
+++ b/test/unit/controls_handlers.js
@@ -5,20 +5,23 @@
     hooks.beforeEach(function() {
       var target = new fabric.Rect({ width: 100, height: 100 });
       canvas.add(target);
-      eventData = {
-      };
-      transform = {
-        originX: 'left',
-        originY: 'top',
-        target: target,
-        corner: 'mr',
-        signX: 1,
-        signY: 1,
-      };
+      eventData = {};
+      transform = prepareTransform(target, 'mr');
     });
     hooks.afterEach(function() {
       canvas.clear();
     });
+    function prepareTransform(target, corner) {
+      var origin = canvas._getOriginFromCorner(target, corner);
+      return {
+        target,
+        corner,
+        originX: origin.x,
+        originY: origin.y,
+        signX: 1,
+        signY: 1,
+      };
+    }
     QUnit.test('changeWidth changes the width', function(assert) {
       assert.equal(transform.target.width, 100);
       var changed = fabric.controlsUtils.changeWidth(eventData, transform, 200, 300);
@@ -39,10 +42,10 @@
     });
     QUnit.test('changeWidth does not change the width of target\'s other side', function (assert) {
       assert.equal(transform.target.width, 100);
-      var changed = fabric.controlsUtils.changeWidth(eventData, Object.assign({}, transform, { corner: 'ml' }), 200, 300);
+      var changed = fabric.controlsUtils.changeWidth(eventData, prepareTransform(transform.target, 'ml'), 200, 300);
       assert.ok(!changed, 'control should not have changed target');
       assert.equal(transform.target.width, 100);
-      changed = fabric.controlsUtils.changeWidth(eventData, Object.assign({}, transform, { corner: 'mr' }), -200, 300);
+      changed = fabric.controlsUtils.changeWidth(eventData, prepareTransform(transform.target, 'mr'), -200, 300);
       assert.ok(!changed, 'control should not have changed target');
       assert.equal(transform.target.width, 100);
       assert.equal(transform.target.left, 0);

--- a/test/unit/controls_handlers.js
+++ b/test/unit/controls_handlers.js
@@ -37,6 +37,17 @@
       assert.equal(target.left, 0);
       assert.equal(target.top, 0);
     });
+    QUnit.test('changeWidth does not change the width of target\'s other side', function (assert) {
+      assert.equal(transform.target.width, 100);
+      var changed = fabric.controlsUtils.changeWidth(eventData, Object.assign({}, transform, { corner: 'ml' }), 200, 300);
+      assert.ok(!changed, 'control should not have changed target');
+      assert.equal(transform.target.width, 100);
+      changed = fabric.controlsUtils.changeWidth(eventData, Object.assign({}, transform, { corner: 'mr' }), -200, 300);
+      assert.ok(!changed, 'control should not have changed target');
+      assert.equal(transform.target.width, 100);
+      assert.equal(transform.target.left, 0);
+      assert.equal(transform.target.top, 0);
+    });
     QUnit.test('changeWidth changes the width with centered transform', function(assert) {
       transform.originX = 'center';
       transform.originY = 'center';


### PR DESCRIPTION
This PR fixes the change width control.
It used to change width as if it were flipped.
Now it doesn't.
~~Should I adapt the logic to enable more corners?~~

## Before

https://user-images.githubusercontent.com/34343793/171060617-ab11c64a-be82-4d57-b7f2-1b22ad68ad68.mp4


## After

https://user-images.githubusercontent.com/34343793/171060636-b5da5d9c-9df7-44cf-94a6-81f162faf691.mp4


