### PR TITLE
feat(observable): BREAKING return disposer instead of context for chaining

### DIFF
--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -579,29 +579,16 @@
     }, 1000);
   });
 
-  QUnit.test('on off fire are chainable', function(assert) {
-    var object = new fabric.Object({ left: 20, top: 30, width: 40, height: 50, angle: 43 });
-    var ret;
-    ret = object.fire('');
-    assert.equal(ret, object, 'fire is chainable when no events are registered at all');
-    ret = object.on('hi', function() {});
-    assert.equal(ret, object, 'on is chainable');
-    ret = object.fire('bye');
-    assert.equal(ret, object, 'fire is chainable when firing a non registerd event');
-    ret = object.fire('hi');
-    assert.equal(ret, object, 'fire is chainable when firing a registerd event');
-    ret = object.off('hi');
-    assert.equal(ret, object, 'off is chainable');
-  });
-
   QUnit.test('observable', function(assert) {
     var object = new fabric.Object({ left: 20, top: 30, width: 40, height: 50, angle: 43 });
 
     var fooFired = false,
         barFired = false;
 
-    object.on('foo', function() { fooFired = true; });
-    object.on('bar', function() { barFired = true; });
+    var fooDisposer = object.on('foo', function() { fooFired = true; });
+    var barDisposer = object.on('bar', function () { barFired = true; });
+    assert.ok(typeof fooDisposer === 'function', 'should return disposer');
+    assert.ok(typeof barDisposer === 'function', 'should return disposer');
 
     object.fire('foo');
     assert.ok(fooFired);

--- a/test/unit/observable.js
+++ b/test/unit/observable.js
@@ -354,7 +354,7 @@ QUnit.test('disposing', function(assert) {
       })
     ];
   }
-  var disposers;
+  var disposers = [];
   var fireAll = function () {
     fired.forEach(function (__, index) {
       foo.fire(getEventName(index));
@@ -368,9 +368,7 @@ QUnit.test('disposing', function(assert) {
 
   //  dispose before firing
   disposers = attach();
-  disposers.forEach(function (disposer) {
-    disposer();
-  });
+  dispose();
   fireAll();
   assert.deepEqual(fired, new Array(fired.length).fill(false));
 

--- a/test/unit/observable.js
+++ b/test/unit/observable.js
@@ -326,30 +326,61 @@ QUnit.test('adding events', function(assert) {
 });
 
 
-QUnit.test('chaining', function(assert) {
+QUnit.test('disposing', function(assert) {
   var foo = { };
   fabric.util.object.extend(foo, fabric.Observable);
 
-  var event1Fired = false, event2Fired = false;
-  foo
-    .on('event1', function() {
-      event1Fired = true;
-    })
-    .on('event2', function() {
-      event2Fired = true;
+  var fired = new Array(7).fill(false);
+  var getEventName = function (index) {
+    return `event${index + 1}`;
+  }
+  var createHandler = function (index) {
+    return function () {
+      fired[index] = true;
+    }
+  }
+  var attach = function () {
+    return [
+      foo.on(getEventName(0), createHandler(0)),
+      foo.on(getEventName(1), createHandler(1)),
+      foo.once(getEventName(2), createHandler(2)),
+      foo.on({
+        [getEventName(3)]: createHandler(3),
+        [getEventName(4)]: createHandler(4),
+      }),
+      foo.once({
+        [getEventName(5)]: createHandler(5),
+        [getEventName(6)]: createHandler(6),
+      })
+    ];
+  }
+  var disposers;
+  var fireAll = function () {
+    fired.forEach(function (__, index) {
+      foo.fire(getEventName(index));
     });
+  }
+  var dispose = function () {
+    disposers.forEach(function (disposer) {
+      disposer();
+    });
+  }
 
-  foo.fire('event2').fire('event1');
+  //  dispose before firing
+  disposers = attach();
+  disposers.forEach(function (disposer) {
+    disposer();
+  });
+  fireAll();
+  assert.deepEqual(fired, new Array(fired.length).fill(false));
 
-  assert.equal(event1Fired, true);
-  assert.equal(event2Fired, true);
+  //  dispose after firing
+  disposers = attach();
+  fireAll();
+  assert.deepEqual(fired, new Array(fired.length).fill(true));
+  fired = new Array(fired.length).fill(false);
+  dispose();
+  fireAll();
+  assert.deepEqual(fired, new Array(fired.length).fill(false));
 
-  event1Fired = false;
-  event2Fired = false;
-
-  foo.off('event1').off('event2');
-  foo.fire('event2').fire('event1');
-
-  assert.equal(event1Fired, false);
-  assert.equal(event2Fired, false);
 });


### PR DESCRIPTION
This PR makes observable easier to use by changing it's methods return values:
- return disposer for on/once
- void for fire/off

This means this PR is **BREAKING**. 
As we discussed chainable objects are overrated and IMO are bad design because then a simple change such as this proposal becomes breaking.

So instead of:
```js
const cb = () => {
 ...
}
obj.on('event', cb)
const dispose = () => obj.off('event', cb);
...

dispose()

```

This is possible

```js
const dispose = obj.on('event', () => {
  ...
})
...

dispose()
```

For the dev (me for example) it saves a lot of repetitive code. It makes things easier.