### PR TITLE
chore(): move away from extend/clone

### DIFF
--- a/src/controls.actions.js
+++ b/src/controls.actions.js
@@ -32,10 +32,8 @@
 
   function fireEvent(eventName, options) {
     var target = options.transform.target,
-        canvas = target.canvas,
-        canvasOptions = fabric.util.object.clone(options);
-    canvasOptions.target = target;
-    canvas && canvas.fire('object:' + eventName, canvasOptions);
+        canvas = target.canvas;
+    canvas && canvas.fire('object:' + eventName, Object.assign({}, options, { target: target }));
     target.fire(eventName, options);
   }
 

--- a/src/filters/blendimage_filter.class.js
+++ b/src/filters/blendimage_filter.class.js
@@ -237,9 +237,7 @@
    */
   fabric.Image.filters.BlendImage.fromObject = function(object) {
     return fabric.Image.fromObject(object.image).then(function(image) {
-      var options = fabric.util.object.clone(object);
-      options.image = image;
-      return new fabric.Image.filters.BlendImage(options);
+      return new fabric.Image.filters.BlendImage(Object.assign({}, options, { image: image }));
     });
   };
 

--- a/src/filters/blendimage_filter.class.js
+++ b/src/filters/blendimage_filter.class.js
@@ -237,7 +237,7 @@
    */
   fabric.Image.filters.BlendImage.fromObject = function(object) {
     return fabric.Image.fromObject(object.image).then(function(image) {
-      return new fabric.Image.filters.BlendImage(Object.assign({}, options, { image: image }));
+      return new fabric.Image.filters.BlendImage(Object.assign({}, object, { image: image }));
     });
   };
 

--- a/src/gradient.class.js
+++ b/src/gradient.class.js
@@ -71,8 +71,6 @@
   }
   /* _FROM_SVG_END_ */
 
-  var clone = fabric.util.object.clone;
-
   /**
    * Gradient class
    * @class fabric.Gradient
@@ -218,8 +216,8 @@
      * @return {String} SVG representation of an gradient (linear/radial)
      */
     toSVG: function(object, options) {
-      var coords = clone(this.coords, true), i, len, options = options || {},
-          markup, commonAttributes, colorStops = clone(this.colorStops, true),
+      var coords = this.coords, i, len, options = options || {},
+          markup, commonAttributes, colorStops = this.colorStops,
           needsSwap = coords.r1 > coords.r2,
           transform = this.gradientTransform ? this.gradientTransform.concat() : fabric.iMatrix.concat(),
           offsetX = -this.offsetX, offsetY = -this.offsetY,
@@ -320,7 +318,7 @@
      * @return {CanvasGradient}
      */
     toLive: function(ctx) {
-      var gradient, coords = fabric.util.object.clone(this.coords), i, len;
+      var gradient, coords = this.coords, i, len;
 
       if (!this.type) {
         return;

--- a/src/mixins/animation.mixin.js
+++ b/src/mixins/animation.mixin.js
@@ -157,12 +157,7 @@ fabric.util.object.extend(fabric.Object.prototype, /** @lends fabric.Object.prot
 
     to = to.toString();
 
-    if (!options) {
-      options = { };
-    }
-    else {
-      options = fabric.util.object.clone(options);
-    }
+    options = Object.assign({}, options);
 
     if (~property.indexOf('.')) {
       propPair = property.split('.');

--- a/src/mixins/canvas_serialization.mixin.js
+++ b/src/mixins/canvas_serialization.mixin.js
@@ -27,7 +27,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
     // serialize if it wasn't already
     var serialized = (typeof json === 'string')
       ? JSON.parse(json)
-      : fabric.util.object.clone(json);
+      : Object.assign({}, json);
 
     var _this = this,
         renderOnAddRemove = this.renderOnAddRemove;

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -1,7 +1,5 @@
 (function() {
 
-  var clone = fabric.util.object.clone;
-
   fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.prototype */ {
 
     /**
@@ -713,7 +711,7 @@
     shiftLineStyles: function(lineIndex, offset) {
       // shift all line styles by offset upward or downward
       // do not clone deep. we need new array, not new style objects
-      var clonedStyles = clone(this.styles);
+      var clonedStyles = Object.assign({}, this.styles);
       for (var line in this.styles) {
         var numericLine = parseInt(line, 10);
         if (numericLine > lineIndex) {
@@ -782,10 +780,10 @@
       // we clone current char style onto the next (otherwise empty) line
       while (qty > 0) {
         if (copiedStyle && copiedStyle[qty - 1]) {
-          this.styles[lineIndex + qty] = { 0: clone(copiedStyle[qty - 1]) };
+          this.styles[lineIndex + qty] = { 0: Object.assign({}, copiedStyle[qty - 1]) };
         }
         else if (currentCharStyle) {
-          this.styles[lineIndex + qty] = { 0: clone(currentCharStyle) };
+          this.styles[lineIndex + qty] = { 0: Object.assign({}, currentCharStyle) };
         }
         else {
           delete this.styles[lineIndex + qty];
@@ -806,8 +804,8 @@
       if (!this.styles) {
         this.styles = {};
       }
-      var currentLineStyles       = this.styles[lineIndex],
-          currentLineStylesCloned = currentLineStyles ? clone(currentLineStyles) : {};
+      var currentLineStyles = this.styles[lineIndex],
+          currentLineStylesCloned = currentLineStyles ? Object.assign({}, currentLineStyles) : {};
 
       quantity || (quantity = 1);
       // shift all char styles by quantity forward
@@ -831,7 +829,7 @@
           if (!this.styles[lineIndex]) {
             this.styles[lineIndex] = {};
           }
-          this.styles[lineIndex][charIndex + quantity] = clone(copiedStyle[quantity]);
+          this.styles[lineIndex][charIndex + quantity] = Object.assign({}, copiedStyle[quantity]);
         }
         return;
       }
@@ -840,7 +838,7 @@
       }
       var newStyle = currentLineStyles[charIndex ? charIndex - 1 : 1];
       while (newStyle && quantity--) {
-        this.styles[lineIndex][charIndex + quantity] = clone(newStyle);
+        this.styles[lineIndex][charIndex + quantity] = Object.assign({}, newStyle);
       }
     },
 

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -50,7 +50,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
    * your prototype.
    * the map change will affect all Instances unless you need for only some text Instances
    * in that case you have to clone this object and assign your Instance.
-   * this.keysMap = fabric.util.object.clone(this.keysMap);
+   * this.keysMap = Object.assign({}, this.keysMap);
    * The function must be in fabric.Itext.prototype.myFunction And will receive event as args[0]
    */
   keysMap: {

--- a/src/parser.js
+++ b/src/parser.js
@@ -876,11 +876,11 @@
       }, { });
       // add values parsed from style, which take precedence over attributes
       // (see: http://www.w3.org/TR/SVG/styling.html#UsingPresentationAttributes)
-      var cssAttrs = extend(
+      var cssAttrs = Object.assign(
         getGlobalStylesForElement(element, svgUid),
         fabric.parseStyleAttribute(element)
       );
-      ownAttributes = extend(
+      ownAttributes = Object.assign(
         ownAttributes,
         cssAttrs
       );
@@ -902,7 +902,7 @@
       if (normalizedStyle && normalizedStyle.font) {
         fabric.parseFontDeclaration(normalizedStyle.font, normalizedStyle);
       }
-      var mergedAttrs = extend(parentAttributes, normalizedStyle);
+      var mergedAttrs = Object.assign(parentAttributes, normalizedStyle);
       return fabric.svgValidParentsRegEx.test(element.nodeName) ? mergedAttrs : _setStrokeFillOpacity(mergedAttrs);
     },
 
@@ -1026,10 +1026,10 @@
               return;
             }
             if (allRules[_rule]) {
-              fabric.util.object.extend(allRules[_rule], ruleObj);
+              Object.assign(allRules[_rule], ruleObj);
             }
             else {
-              allRules[_rule] = fabric.util.object.clone(ruleObj);
+              allRules[_rule] = Object.assign({}, ruleObj);
             }
           });
         });

--- a/src/parser.js
+++ b/src/parser.js
@@ -8,8 +8,6 @@
    */
 
   var fabric = global.fabric || (global.fabric = { }),
-      extend = fabric.util.object.extend,
-      clone = fabric.util.object.clone,
       toFixed = fabric.util.toFixed,
       parseUnit = fabric.util.parseUnit,
       multiplyTransformMatrices = fabric.util.multiplyTransformMatrices,
@@ -742,7 +740,7 @@
         delete fabric.cssRules[svgUid];
         delete fabric.clipPaths[svgUid];
       }
-    }, clone(options), reviver, parsingOptions);
+    }, Object.assign({}, options), reviver, parsingOptions);
   };
 
   function recursivelyParseGradientsXlink(doc, gradient) {
@@ -773,7 +771,7 @@
       fabric.reNum +
     '(?:px|cm|mm|em|pt|pc|in)*)(?:\\/(normal|' + fabric.reNum + '))?\\s+(.*)');
 
-  extend(fabric, {
+  fabric.util.object.extend(fabric, {
     /**
      * Parses a short font declaration, building adding its properties to a style object
      * @static

--- a/src/shapes/group.class.js
+++ b/src/shapes/group.class.js
@@ -8,8 +8,7 @@
       transformPoint = fabric.util.transformPoint,
       applyTransformToObject = fabric.util.applyTransformToObject,
       degreesToRadians = fabric.util.degreesToRadians,
-      clone = fabric.util.object.clone,
-      extend = fabric.util.object.extend;
+      clone = fabric.util.object.clone;
 
   if (fabric.Group) {
     fabric.warn('fabric.Group is already defined');
@@ -184,7 +183,7 @@
      * @private
      */
     __objectMonitor: function (opt) {
-      this._applyLayoutStrategy(extend(clone(opt), {
+      this._applyLayoutStrategy(Object.assign({}, opt, {
         type: 'object_modified'
       }));
       this._set('dirty', true);

--- a/src/shapes/image.class.js
+++ b/src/shapes/image.class.js
@@ -684,7 +684,7 @@
    * @returns {Promise<fabric.Image>}
    */
   fabric.Image.fromObject = function(_object) {
-    var object = fabric.util.object.clone(_object),
+    var object = Object.assign({}, _object),
         filters = object.filters,
         resizeFilter = object.resizeFilter;
     // the generic enliving will fail on filters for now

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -167,7 +167,7 @@
     parsedAttributes.top  = parsedAttributes.top  || 0;
     parsedAttributes.height  = parsedAttributes.height || 0;
     parsedAttributes.width  = parsedAttributes.width || 0;
-    var rect = new fabric.Rect(extend((options ? fabric.util.object.clone(options) : { }), parsedAttributes));
+    var rect = new fabric.Rect(Object.assign({}, options, parsedAttributes));
     rect.visible = rect.visible && rect.width > 0 && rect.height > 0;
     callback(rect);
   };

--- a/src/shapes/rect.class.js
+++ b/src/shapes/rect.class.js
@@ -2,8 +2,7 @@
 
   'use strict';
 
-  var fabric = global.fabric || (global.fabric = { }),
-      extend = fabric.util.object.extend;
+  var fabric = global.fabric || (global.fabric = { });
 
   if (fabric.Rect) {
     fabric.warn('fabric.Rect is already defined');

--- a/src/shapes/text.class.js
+++ b/src/shapes/text.class.js
@@ -1649,7 +1649,7 @@
 
     var parsedAttributes = fabric.parseAttributes(element, fabric.Text.ATTRIBUTE_NAMES),
         parsedAnchor = parsedAttributes.textAnchor || 'left';
-    options = fabric.util.object.extend((options ? clone(options) : { }), parsedAttributes);
+    options = Object.assign({}, options, parsedAttributes);
 
     options.top = options.top || 0;
     options.left = options.left || 0;

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -1,8 +1,5 @@
 (function () {
 
-  var extend = fabric.util.object.extend,
-      clone = fabric.util.object.clone;
-
   /**
    * 
    * @typedef {Object} AnimationOptions
@@ -157,7 +154,7 @@
           return index > -1 && fabric.runningAnimations.splice(index, 1)[0];
         };
 
-    context = extend(clone(options), {
+    context = Object.assign({}, options, {
       cancel: function () {
         cancel = true;
         return removeFromRegistry();

--- a/src/util/animate_color.js
+++ b/src/util/animate_color.js
@@ -33,7 +33,7 @@
         originalOnChange = options.onChange;
     options = options || {};
 
-    return fabric.util.animate(fabric.util.object.extend(options, {
+    return fabric.util.animate(Object.assign(options, {
       duration: duration || 500,
       startValue: startColor,
       endValue: endColor,


### PR DESCRIPTION
A semantic PR that replaces `fabric.util.object.extend` or the shallow version of `fabric.util.object.clone` with `Object.assign` to prepare for the js/ts migration.
I replaced relevant code after using the transformer (It uses extend as a search value).
The deep version of clone is used sparsely and in the future could be replaced by [`lodash.cloneDeep`](https://www.npmjs.com/package/lodash.clonedeep) (~44KB vs. ~4KB of `lang_object` 😬). BTW I'm not sure it is really necessary in most cases.