### PR TITLE
tests(): fix tests output for the website

### DIFF
--- a/test/lib/visualCallbackQunit.js
+++ b/test/lib/visualCallbackQunit.js
@@ -9,7 +9,7 @@
 
   visualCallback.prototype.testDone = function(details) {
     if (window && document && this.currentArgs.enabled) {
-      var fabricCanvas = this.currentArgs.fabric;
+      var fabricCanvasDataRef = this.currentArgs.fabric;
       var ouputImageDataRef = this.currentArgs.diff;
       var goldenCanvasRef = this.currentArgs.golden;
       var goldenName = this.currentArgs.goldenName;
@@ -17,15 +17,15 @@
       var node = document.getElementById(id);
       var fabricCopy = document.createElement('canvas');
       var diff = document.createElement('canvas');
-      diff.width = fabricCopy.width = fabricCanvas.width;
-      diff.height = fabricCopy.height = fabricCanvas.height;
+      diff.width = fabricCopy.width = fabricCanvasDataRef.width;
+      diff.height = fabricCopy.height = fabricCanvasDataRef.height;
       diff.getContext('2d').putImageData(ouputImageDataRef, 0, 0);
-      fabricCopy.getContext('2d').drawImage(fabricCanvas, 0, 0);
+      fabricCopy.getContext('2d').putImageData(fabricCanvasDataRef, 0, 0);
 
       var data = {
         actual: fabricCopy,
         expected: goldenCanvasRef,
-        diff
+        diff: diff,
       };
 
       var template = document.getElementById('error_output');
@@ -41,8 +41,9 @@
           link.click();
         }
       });
-      node.appendChild(errorOutput);
-      
+      if (node) {
+        node.appendChild(errorOutput);
+      }
       // after one run, disable
       this.currentArgs.enabled = false;
     }

--- a/test/lib/visualTestLoop.js
+++ b/test/lib/visualTestLoop.js
@@ -134,34 +134,29 @@
           var width = renderedCanvas.width;
           var height = renderedCanvas.height;
           var totalPixels = width * height;
-          var imageDataCanvas = renderedCanvas.getContext('2d').getImageData(0, 0, width, height).data;
+          var imageDataCanvas = renderedCanvas.getContext('2d').getImageData(0, 0, width, height);
           var canvas = fabric.document.createElement('canvas');
-          var canvas2 = fabric.document.createElement('canvas');
           canvas.width = width;
           canvas.height = height;
-          canvas2.width = width;
-          canvas2.height = height;
           var ctx = canvas.getContext('2d');
           var output = ctx.getImageData(0, 0, width, height);
-          canvas2.getContext('2d').drawImage(renderedCanvas, 0, 0, width, height);
           getImage(getGoldeName(golden), renderedCanvas, function(goldenImage) {
             ctx.drawImage(goldenImage, 0, 0);
             visualCallback.addArguments({
               enabled: true,
               golden: canvas,
-              fabric: canvas2,
+              fabric: imageDataCanvas,
               diff: output,
               goldenName: golden
             });
             var imageDataGolden = ctx.getImageData(0, 0, width, height).data;
-            var differentPixels = _pixelMatch(imageDataCanvas, imageDataGolden, output.data, width, height, pixelmatchOptions);
+            var differentPixels = _pixelMatch(imageDataCanvas.data, imageDataGolden, output.data, width, height, pixelmatchOptions);
             var percDiff = differentPixels / totalPixels * 100;
             var okDiff = totalPixels * percentage;
             var isOK = differentPixels <= okDiff;
             assert.ok(
               isOK,
-              `${testName} [${golden}] has ${differentPixels} (>${okDiff}) different pixels
-              representing ${percDiff}% (>${percentage * 100}%)`
+              testName + ' [' + golden + '] has too many different pixels ' + differentPixels + '(' + okDiff + ') representing ' + percDiff + '% (>' + (percentage * 100) + '%)'
             );
             if (!isOK) {
               var stringa = imageDataToChalk(output);


### PR DESCRIPTION
This change avoid the dispose operation to wipe away the pixels of the actual render on the html visualization and also make the node append optional.