### PR TITLE
fix(canvas_events): `mouseout` bug

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -146,9 +146,9 @@
       this._hoveredTarget = null;
       target && target.fire('mouseout', { e: e });
 
-      this._hoveredTargets.forEach(function(_target){
-        this.fire('mouse:out', { target: _target, e: e });
-        _target && _target.fire('mouseout', { e: e });
+      this._hoveredTargets.forEach(function(nestedTarget){
+        this.fire('mouse:out', { target: nestedTarget, e: e });
+        nestedTarget && nestedTarget.fire('mouseout', { e: e });
       }, this);
       this._hoveredTargets = [];
 

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -146,11 +146,10 @@
       this._hoveredTarget = null;
       target && target.fire('mouseout', { e: e });
 
-      var _this = this;
       this._hoveredTargets.forEach(function(_target){
-        _this.fire('mouse:out', { target: target, e: e });
-        _target && target.fire('mouseout', { e: e });
-      });
+        this.fire('mouse:out', { target: _target, e: e });
+        _target && _target.fire('mouseout', { e: e });
+      }, this);
       this._hoveredTargets = [];
 
       if (this._iTextInstances) {

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -614,22 +614,56 @@
     });
   });
 
-  ['mouseout', 'mouseenter'].forEach(function(eventType) {
-    QUnit.test('Fabric event fired - ' + eventType, function(assert) {
-      var eventname = eventType.slice(0, 5) + ':' + eventType.slice(5);
-      if (eventType === 'mouseenter') {
-        eventname = 'mouse:over';
-      }
-      var counter = 0;
-      var c = new fabric.Canvas();
-      c.on(eventname, function() {
-        counter++;
-      });
-      var event = fabric.document.createEvent('HTMLEvents');
-      event.initEvent(eventType, true, true);
-      c.upperCanvasEl.dispatchEvent(event);
-      assert.equal(counter, 1, eventname + ' fabric event fired');
+  QUnit.test('mouseenter (mouse:over)', function (assert) {
+    var eventname = 'mouse:over'
+    var counter = 0;
+    var c = new fabric.Canvas();
+    c.on(eventname, function () {
+      counter++;
     });
+    var event = fabric.document.createEvent('HTMLEvents');
+    event.initEvent('mouseenter', true, true);
+    c.upperCanvasEl.dispatchEvent(event);
+    assert.equal(counter, 1, eventname + ' fabric event fired');
+  });
+
+  QUnit.test('mouseout', function (assert) {
+    var eventName = 'mouseout';
+    var canvasEventName = 'mouse:out';
+    var c = new fabric.Canvas();
+    var o1 = new fabric.Object();
+    var o2 = new fabric.Object();
+    var o3 = new fabric.Object();
+    var control = [];
+    var targetControl = [];
+    [o1, o2, o3].forEach(target => {
+      target.on(canvasEventName.replace(':', ''), (ev) => {
+        targetControl.push(ev);
+      });
+    });
+    canvas.add(o1, o2, o3);
+    c.on(canvasEventName, function (ev) {
+      control.push(ev);
+    });
+    var event = fabric.document.createEvent('HTMLEvents');
+    event.initEvent(eventName, true, true);
+
+    //  with targets
+    c._hoveredTarget = o3;
+    c._hoveredTargets = [o2, o1];
+    c.upperCanvasEl.dispatchEvent(event);
+    assert.equal(c._hoveredTarget, null, 'should clear `_hoveredTarget` ref');
+    assert.deepEqual(c._hoveredTargets, [], 'should clear `_hoveredTargets` ref');
+    const expected = [o3, o2, o1].map(target => ({ e: event, target }));
+    assert.deepEqual(control, expected, 'should equal control');
+    assert.deepEqual(targetControl, expected, 'should equal target control');
+
+    //  without targets
+    control = [];
+    targetControl = [];
+    c.upperCanvasEl.dispatchEvent(event);
+    assert.deepEqual(control, [{ e: event, target: null }]);
+    assert.deepEqual(targetControl, []);
   });
 
   QUnit.test('mouseover and mouseout with subtarget check', function(assert) {

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -638,7 +638,7 @@
     var targetControl = [];
     [o1, o2, o3].forEach(target => {
       target.on(canvasEventName.replace(':', ''), (ev) => {
-        targetControl.push(ev);
+        targetControl.push(target);
       });
     });
     canvas.add(o1, o2, o3);
@@ -654,16 +654,17 @@
     c.upperCanvasEl.dispatchEvent(event);
     assert.equal(c._hoveredTarget, null, 'should clear `_hoveredTarget` ref');
     assert.deepEqual(c._hoveredTargets, [], 'should clear `_hoveredTargets` ref');
-    const expected = [o3, o2, o1].map(target => ({ e: event, target }));
-    assert.deepEqual(control, expected, 'should equal control');
+    const expected = [o3, o2, o1];
+    assert.deepEqual(control.map(ev => ev.target), expected, 'should equal control');
     assert.deepEqual(targetControl, expected, 'should equal target control');
 
     //  without targets
     control = [];
     targetControl = [];
     c.upperCanvasEl.dispatchEvent(event);
-    assert.deepEqual(control, [{ e: event, target: null }]);
-    assert.deepEqual(targetControl, []);
+    assert.equal(control.length, 1, 'should have fired once');
+    assert.equal(control[0].target, null, 'no target should be referenced');
+    assert.deepEqual(targetControl, [], 'no target should be referenced');
   });
 
   QUnit.test('mouseover and mouseout with subtarget check', function(assert) {


### PR DESCRIPTION
I have encountered a severe bug so I've allowed myself to PR disregarding the PR lockdown.
It's a simple fix, the bug seems to be a typo.

https://github.com/fabricjs/fabric.js/blame/master/src/mixins/canvas_events.mixin.js#L151