### PR TITLE
minor(Canvas.getPointer): `recalculate` arg

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -935,14 +935,15 @@
      * of the time.
      * @param {Event} e
      * @param {Boolean} ignoreVpt
+     * @param {Boolean} [recalculate] force recalculation in case of cached pointers
      * @return {fabric.Point}
      */
-    getPointer: function (e, ignoreVpt) {
+    getPointer: function (e, ignoreVpt, recalculate) {
       // return cached values if we are in the event processing chain
-      if (this._absolutePointer && !ignoreVpt) {
+      if (this._absolutePointer && !ignoreVpt && !recalculate) {
         return this._absolutePointer;
       }
-      if (this._pointer && ignoreVpt) {
+      if (this._pointer && ignoreVpt && !recalculate) {
         return this._pointer;
       }
 


### PR DESCRIPTION
This PR is very minor and add a `recalculate` arg to `getPointer`
It is needed in some edge cases when calling `getPointer` and for some reason the caches still exist.


I am not sure about the PR cause it seems there is a bug somewhere else not invalidating caches.
It happens when I draw with a brush and then use canvas.getPointer on a drop event
calling `resetTransformData` does the trick of course