### PR TITLE
chore(`Object#clearContextTop`): negate `manuallyRestore` - pulloted history

### DIFF
--- a/src/canvas.class.js
+++ b/src/canvas.class.js
@@ -1409,7 +1409,7 @@
 
     setViewportTransform: function (vpt) {
       if (this.renderOnAddRemove && this._activeObject && this._activeObject.isEditing) {
-        this._activeObject.clearContextTop();
+        this._activeObject.clearContextTop(true);
       }
       fabric.StaticCanvas.prototype.setViewportTransform.call(this, vpt);
     }

--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -236,14 +236,14 @@
     _renderDragEffects: function (e, source, target) {
       var ctx = this.contextTop;
       if (source) {
-        source.clearContextTop(true);
+        source.clearContextTop(false);
         source.renderDragSourceEffect(e);
       }
       if (target) {
         if (target !== source) {
           ctx.restore();
           ctx.save();
-          target.clearContextTop(true);
+          target.clearContextTop(false);
         }
         target.renderDropTargetEffect(e);
       }

--- a/src/mixins/itext_behavior.mixin.js
+++ b/src/mixins/itext_behavior.mixin.js
@@ -172,7 +172,7 @@
 
       //  make sure we clear context even if instance is not editing
       if (shouldClear) {
-        this.clearContextTop();
+        this.clearContextTop(true);
       }
     },
 
@@ -604,7 +604,7 @@
             this._updateTextarea();
           }
           else {
-            this.clearContextTop();
+            this.clearContextTop(true);
             if (dropEffect === 'move') {
               this.insertChars('', null, selectionStart, selectionEnd);
               this.selectionStart = this.selectionEnd = selectionStart;

--- a/src/mixins/itext_key_behavior.mixin.js
+++ b/src/mixins/itext_key_behavior.mixin.js
@@ -130,7 +130,7 @@ fabric.util.object.extend(fabric.IText.prototype, /** @lends fabric.IText.protot
     if (e.keyCode >= 33 && e.keyCode <= 40) {
       // if i press an arrow key just update selection
       this.inCompositionMode = false;
-      this.clearContextTop();
+      this.clearContextTop(true);
       this.renderCursorOrSelection();
     }
     else {

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -285,11 +285,11 @@
      * This function is used to clear pieces of contextTop where we render ephemeral effects on top of the object.
      * Example: blinking cursror text selection, drag effects.
      * // TODO: discuss swapping restoreManually with a renderCallback, but think of async issues
-     * @param {Boolean} [restoreManually] When true won't restore the context after clear, in order to draw something else.
+     * @param {Boolean} [restore] restore the context after clearing
      * @return {CanvasRenderingContext2D|undefined} canvas.contextTop that is either still transformed
      * with the object transformMatrix, or restord to neutral transform
      */
-    clearContextTop: function(restoreManually) {
+    clearContextTop: function(restore) {
       if (!this.canvas || !this.canvas.contextTop) {
         return;
       }
@@ -304,7 +304,7 @@
       var width = this.width + 4, height = this.height + 4;
       ctx.clearRect(-width / 2, -height / 2, width, height);
 
-      restoreManually || ctx.restore();
+      restore && ctx.restore();
       return ctx;
     },
 

--- a/src/shapes/itext.class.js
+++ b/src/shapes/itext.class.js
@@ -246,7 +246,7 @@
      */
     initDimensions: function() {
       this.isEditing && this.initDelayedCursor();
-      this.clearContextTop();
+      this.clearContextTop(true);
       this.callSuper('initDimensions');
     },
 
@@ -255,7 +255,7 @@
      * @param {CanvasRenderingContext2D} ctx Context to render on
      */
     render: function (ctx) {
-      this.clearContextTop();
+      this.clearContextTop(true);
       this.callSuper('render', ctx);
       // clear the cursorOffsetCache, so we ensure to calculate once per renderCursor
       // the correct position but not at every cursor animation.
@@ -279,7 +279,7 @@
       if (!this.isEditing) {
         return;
       }
-      var ctx = this.clearContextTop(true);
+      var ctx = this.clearContextTop(false);
       if (!ctx) {
         return;
       }

--- a/src/shapes/textbox.class.js
+++ b/src/shapes/textbox.class.js
@@ -89,7 +89,7 @@
         return;
       }
       this.isEditing && this.initDelayedCursor();
-      this.clearContextTop();
+      this.clearContextTop(true);
       this._clearCache();
       // clear dynamicMinWidth as it will be different after we re-wrap line
       this.dynamicMinWidth = 0;


### PR DESCRIPTION
Instead of `clearContextTop(manuallyRestore)`  => `clearContextTop(restore)` 