### PR TITLE
docs(Collection): JSDOC fix `item` return type

### DIFF
--- a/src/mixins/collection.mixin.ts
+++ b/src/mixins/collection.mixin.ts
@@ -110,7 +110,7 @@
     /**
      * Returns object at specified index
      * @param {Number} index
-     * @return {Self} thisArg
+     * @return {Object} object at index
      */
     item: function (index) {
       return this._objects[index];


### PR DESCRIPTION
[Collection item should return an object, not it's own type](http://fabricjs.com/docs/fabric.Collection.html#.item)