### PR TITLE
fix(): add pointer data to drop event

### DIFF
--- a/src/mixins/canvas_events.mixin.ts
+++ b/src/mixins/canvas_events.mixin.ts
@@ -381,7 +381,10 @@
      * @param {Event} e
      */
     _onDrop: function (e) {
-      var options = this._simpleEventHandler('drop:before', e, { dragSource: this._dragSource });
+      var options = this._simpleEventHandler('drop:before', e, {
+        dragSource: this._dragSource,
+        pointer: this.getPointer(e)
+      });
       //  will be set by the drop target
       options.didDrop = false;
       //  will be set by the drop target, used in case options.target refuses the drop


### PR DESCRIPTION
the need for the pointer in a drop event is a must and because `mouse:move` fires just after, something very weird happens with cached pointers and I get a bad pointer... 
Related #8081
I guess I should add for all drag events as well... (in follow up)