### PR TITLE
fix(IText): regain focus on mouse move

### DIFF
--- a/src/mixins/canvas_events.mixin.ts
+++ b/src/mixins/canvas_events.mixin.ts
@@ -158,14 +158,6 @@
         nestedTarget && nestedTarget.fire('mouseout', { e: e });
       }, this);
       this._hoveredTargets = [];
-
-      if (this._iTextInstances) {
-        this._iTextInstances.forEach(function(obj) {
-          if (obj.isEditing) {
-            obj.hiddenTextarea.focus();
-          }
-        });
-      }
     },
 
     /**

--- a/src/mixins/itext_behavior.mixin.ts
+++ b/src/mixins/itext_behavior.mixin.ts
@@ -398,6 +398,9 @@ import { removeFromArray } from '../util/internals';
         return;
       }
 
+      // regain focus
+      document.activeElement !== this.hiddenTextarea && this.hiddenTextarea.focus();
+
       var newSelectionStart = this.getSelectionStartFromPointer(options.e),
           currentStart = this.selectionStart,
           currentEnd = this.selectionEnd;


### PR DESCRIPTION
fixes #8177 caused by #3759 (that was hacky) and fixes #3661 that was the motivation for #3759

This issue was caused because the hiddenTextarea looses focus after mousedown.
So I have added a focus call in mousemove that fixes both issues.