### PR TITLE
fix(ci): inform ci of test failure

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -282,7 +282,12 @@ async function test(suite, tests, options = {}) {
         shell: true,
         stdio: 'inherit',
         detached: options.dev
-    });
+    })
+        .on('exit', (code) => {
+            // propagate failed exit code to the process for ci to fail
+            // don't exit if tests passed - this is for parallel local testing
+            code && process.exit(code);
+        });
 
     if (options.launch) {
         // open localhost


### PR DESCRIPTION
closes #8186

propagate failed exit code to the process
tests were failing because the process didn't receive the exit code