### PR TITLE
feat(): I/O Registry

### DIFF
--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -8,7 +8,7 @@ type TJSONData = {
     type: string
 }
 
-export type TClassIO<T = unknown> = Function & {
+export type TClassIO<T = unknown> = FunctionConstructor & {
     fromObject(data: TJSONData): T | Promise<T>;
     fromElement?(svgEl: SVGElement, instance: T, options: unknown): T | Promise<T>;
 }

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -1,0 +1,45 @@
+
+export type TRegistry<T = unknown, D = unknown, S extends SVGElement = SVGElement, O = unknown> = {
+    fromJSON(data: D): T | Promise<T>;
+    fromSVG(svgEl: S, options: O): T | Promise<T>;
+}
+
+export type TClassIO<T = unknown, D = unknown, S extends SVGElement = SVGElement, O = unknown> = {
+    prototype: {
+        type: string
+    };
+    fromObject(data: D): T | Promise<T>;
+    fromElement(svgEl: S, options: O): T | Promise<T>;
+}
+
+export class Registry {
+    readonly registry: Map<string, TRegistry>
+    
+    constructor(registry?: Map<string, TRegistry>) {
+        this.registry = new Map(registry);
+    }
+
+    register(type: string, value: TRegistry) {
+        return this.registry.set(type, value);
+    }
+
+    registerClass<T extends TClassIO>(klass: T) {
+        this.register(klass.prototype.type, {
+            fromJSON: klass.fromObject,
+            fromSVG: klass.fromElement
+        });
+    }
+
+    /**
+     * override for custom handling
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    resolve(type: string, data: object) {
+        return this.registry.get(type);
+    }
+}
+
+export const registry = new Registry();
+
+
+

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -17,7 +17,7 @@ export type TClassIO<T = unknown, D = unknown, S extends SVGElement = SVGElement
 
 export class Registry {
     readonly registry: Map<string, TRegistry>
-    
+
     constructor(registry?: Map<string, TRegistry>) {
         this.registry = new Map(registry);
     }
@@ -33,12 +33,16 @@ export class Registry {
         });
     }
 
-    /**
-     * override for custom handling
-     */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    resolve(type: string, data: object) {
-        return this.registry.get(type);
+    fromJSON<T extends { type: string }>(data: T) {
+        return this.registry.get(data.type)?.fromJSON(data);
+    }
+
+    resolveSVGType(el: SVGElement) {
+        return el.tagName.replace('svg:', '');
+    }
+
+    fromSVG<T extends SVGElement, S>(el: T, options: S) {
+        return this.registry.get(this.resolveSVGType(el))?.fromSVG(el, options);
     }
 }
 

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -4,10 +4,13 @@ export type TRegistry<T = unknown, D = unknown, S extends SVGElement = SVGElemen
     fromSVG(svgEl: S, options: O): T | Promise<T>;
 }
 
-export type TClassIO<T = unknown, D = unknown, S extends SVGElement = SVGElement, O = unknown> = {
+type TClassIdentifier = {
     prototype: {
         type: string
-    };
+    }
+}
+
+export type TClassIO<T = unknown, D = unknown, S extends SVGElement = SVGElement, O = unknown> = TClassIdentifier & {
     fromObject(data: D): T | Promise<T>;
     fromElement(svgEl: S, options: O): T | Promise<T>;
 }
@@ -40,6 +43,3 @@ export class Registry {
 }
 
 export const registry = new Registry();
-
-
-


### PR DESCRIPTION
```ts

import { registry } from 'fabric';

class Mip {
    type = 'mip'
    static async fromObject(d) {
        return new Mip();
    }
    static fromElement(a, b) {
        return new Mip();
    }
}

registry.registerClass(Mip);

```

```ts
const mipInstance = registry.fromJSON({ type: 'mip', ...})
```