### PR TITLE
fix(): `window` => `fabric.window`

### DIFF
--- a/src/mixins/itext_behavior.mixin.ts
+++ b/src/mixins/itext_behavior.mixin.ts
@@ -400,7 +400,7 @@ const reNonWord = /[ \n\.,;!\?\-]/;
       }
 
       // regain focus
-      document.activeElement !== this.hiddenTextarea && this.hiddenTextarea.focus();
+      fabric.document.activeElement !== this.hiddenTextarea && this.hiddenTextarea.focus();
 
       var newSelectionStart = this.getSelectionStartFromPointer(options.e),
           currentStart = this.selectionStart,


### PR DESCRIPTION
This patch is entirely redundant because the method is called only in the browser and because of #8208 
But for the sake of code styling.