### PR TITLE
ci(): add `source-map-support` for testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "rollup": "^2.75.6",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-ts": "^3.0.2",
+        "source-map-support": "^0.5.21",
         "testem": "^3.8.0",
         "typescript": "^4.7.4"
       },

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "rollup": "^2.75.6",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-ts": "^3.0.2",
+    "source-map-support": "^0.5.21",
     "testem": "^3.8.0",
     "typescript": "^4.7.4"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,7 @@ export default {
       file: process.env.BUILD_OUTPUT || './dist/fabric.js',
       name: 'fabric',
       format: 'cjs',
+      sourcemap: true
     },
     Number(process.env.MINIFY) ?
       {

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -1,3 +1,4 @@
+require('source-map-support/register');
 // set the fabric framework as a global for tests
 var chalk = require('chalk');
 var diff = require('deep-object-diff').diff;

--- a/test/tests.mustache
+++ b/test/tests.mustache
@@ -7,6 +7,9 @@
 <script src="/node_modules/qunit/qunit/qunit.js"></script>
 <link rel="stylesheet" href="/node_modules/qunit/qunit/qunit.css"/>
 
+<script src="/node_modules/source-map-support/browser-source-map-support.js"></script>
+<script>sourceMapSupport.install();</script>
+
 <script src="/testem.js"></script>
 {{#serve_files}}<script src="{{{src}}}"{{#attrs}} {{&.}}{{/attrs}}></script>{{/serve_files}}
 


### PR DESCRIPTION
Added source map to errors when testing.
Rollup outputs a build warning that seems a false positive.
https://github.com/evanw/node-source-map-support#source-map-support


See outputs after I inserted an error at `src/mixins/canvas_events.mixin.ts:727`

```bash
## browser
not ok 95 Chrome 105.0 - [4 ms] - fabric.Canvas events mixin: A transform will call mouseup and mousedown on the control
    ---
        actual: >
            null
        stack: >
            Error: bip
                at klass._handleEvent (http://localhost:8080/586986970993100/src/mixins/canvas_events.mixin.ts:727:15)
                at klass.__onMouseUp (http://localhost:8080/586986970993100/src/mixins/canvas_events.mixin.ts:662:12)
                at Object.<anonymous> (http://localhost:8080/586986970993100/test/unit/canvas_events.js:428:12)
                at runTest (http://localhost:8080/node_modules/qunit/qunit/qunit.js:2959:35)
                at Test.run (http://localhost:8080/node_modules/qunit/qunit/qunit.js:2942:9)
                at http://localhost:8080/node_modules/qunit/qunit/qunit.js:3233:16
                at processTaskQueue (http://localhost:8080/node_modules/qunit/qunit/qunit.js:2504:26)
                at http://localhost:8080/node_modules/qunit/qunit/qunit.js:2508:13
        message: >
            Died on test #1: bip
                at Object.test (http://localhost:8080/node_modules/qunit/qunit/qunit.js:3624:5)
                at http://localhost:8080/586986970993100/test/unit/canvas_events.js:407:9
                at http://localhost:8080/586986970993100/test/unit/canvas_events.js:1151:3
        negative: >
            false
        browser log: |
    ...
```

```bash
## node
not ok 217 fabric.Canvas events mixin > mouse:up isClick = true
  ---
  message: |+
    Died on test #1: bip
        at Object.test (C:\Users\DELL\Desktop\DEV\fabric.js\node_modules\qunit\qunit\qunit.js:3624:5)
        at C:\Users\DELL\Desktop\DEV\fabric.js\test\unit\canvas_events.js:296:9
        at Object.<anonymous> (C:\Users\DELL\Desktop\DEV\fabric.js\test\unit\canvas_events.js:1151:3)
        at Module._compile (node:internal/modules/cjs/loader:1103:14)
        at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
        at Module.load (node:internal/modules/cjs/loader:981:32)
        at Function.Module._load (node:internal/modules/cjs/loader:822:12)
        at Module.require (node:internal/modules/cjs/loader:1005:19)
  severity: failed
  actual  : null
  expected: undefined
  stack: |
    Error: bip
        at klass._handleEvent (C:\Users\DELL\Desktop\DEV\fabric.js\src\mixins\canvas_events.mixin.ts:727:15)
        at klass.__onMouseUp (C:\Users\DELL\Desktop\DEV\fabric.js\src\mixins\canvas_events.mixin.ts:662:12)
        at Object.<anonymous> (C:\Users\DELL\Desktop\DEV\fabric.js\test\unit\canvas_events.js:303:12)
        at runTest (C:\Users\DELL\Desktop\DEV\fabric.js\node_modules\qunit\qunit\qunit.js:2959:35)
        at Test.run (C:\Users\DELL\Desktop\DEV\fabric.js\node_modules\qunit\qunit\qunit.js:2942:9)
        at C:\Users\DELL\Desktop\DEV\fabric.js\node_modules\qunit\qunit\qunit.js:3233:16
        at processTaskQueue (C:\Users\DELL\Desktop\DEV\fabric.js\node_modules\qunit\qunit\qunit.js:2504:26)
        at C:\Users\DELL\Desktop\DEV\fabric.js\node_modules\qunit\qunit\qunit.js:2508:13
  ...
```