### PR TITLE
ci(): fix test global error handlers

### DIFF
--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -22,7 +22,6 @@ QUnit.debugVisual = Number(process.env.QUNIT_DEBUG_VISUAL_TESTS);
 QUnit.recreateVisualRefs = Number(process.env.QUNIT_RECREATE_VISUAL_REFS);
 QUnit.config.filter = process.env.QUNIT_FILTER;
 
-process.on('uncaughtException', QUnit.onUncaughtException);
 
 global.fabric = require('../dist/fabric').fabric;
 global.pixelmatch = require('pixelmatch');
@@ -70,7 +69,6 @@ class CustomResourceLoader extends jsdom.ResourceLoader {
   }
 }
 
-var jsdom = require('jsdom');
 var virtualWindow = new jsdom.JSDOM(
   decodeURIComponent('%3C!DOCTYPE%20html%3E%3Chtml%3E%3Chead%3E%3C%2Fhead%3E%3Cbody%3E%3C%2Fbody%3E%3C%2Fhtml%3E'),
   {
@@ -87,6 +85,26 @@ DOMParser = fabric.window.DOMParser;
 
 
 //  QUnit Logging
+
+//  global error handling
+
+process.on('uncaughtExceptionMonitor', (err, origin) => {
+  QUnit.onUncaughtException(err);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  QUnit.onUncaughtException(reason);
+});
+
+// JSDOM catches errors and throws them to the window
+
+fabric.window.addEventListener('unhandledrejection', (event) => {
+  QUnit.onUncaughtException(event.reason);
+});
+
+fabric.window.addEventListener('error', (event) => {
+  QUnit.onUncaughtException(event);
+});
 
 //  testID
 var objectInit = fabric.Object.prototype.initialize;

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -99,11 +99,15 @@ process.on('unhandledRejection', (reason, promise) => {
 // JSDOM catches errors and throws them to the window
 
 fabric.window.addEventListener('unhandledrejection', (event) => {
+  // prevent logging to console
+  event.preventDefault();
   QUnit.onUncaughtException(event.reason);
 });
 
 fabric.window.addEventListener('error', (event) => {
-  QUnit.onUncaughtException(event);
+  // prevent logging to console
+  event.preventDefault();
+  QUnit.onUncaughtException(event.error);
 });
 
 //  testID

--- a/test/tests.mustache
+++ b/test/tests.mustache
@@ -20,10 +20,15 @@ QUnit.testDone(visualCallback.testDone.bind(visualCallback));
 
 // global error handling
 window.addEventListener('unhandledrejection', (event) => {
+  // prevent logging to console
+  event.preventDefault();
   QUnit.onUncaughtException(event.reason);
 });
+
 window.addEventListener('error', (event) => {
-  QUnit.onUncaughtException(event);
+  // prevent logging to console
+  event.preventDefault();
+  QUnit.onUncaughtException(event.error);
 });
 
 function downloadGoldens() {

--- a/test/tests.mustache
+++ b/test/tests.mustache
@@ -18,8 +18,12 @@ QUnit.config.reorder = false;
 <script>
 QUnit.testDone(visualCallback.testDone.bind(visualCallback));
 
-window.addEventListener('unhandledrejection', function (event) {
+// global error handling
+window.addEventListener('unhandledrejection', (event) => {
   QUnit.onUncaughtException(event.reason);
+});
+window.addEventListener('error', (event) => {
+  QUnit.onUncaughtException(event);
 });
 
 function downloadGoldens() {


### PR DESCRIPTION
If this PR truly  fixes global error handling node unit tests should fail because of #8220 