### PR TITLE
ci(): fix codeql action

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+paths:
+  - src
+  - lib

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,12 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
-  schedule:
-    - cron: '28 13 * * 4'
-
-paths:
-  - src
-  - lib
+  # schedule:
+  #   - cron: '28 13 * * 4'
 
 jobs:
   analyze:
@@ -49,6 +45,9 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
           languages: ${{ matrix.language }}
+          paths:
+            - src
+            - lib
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,12 +42,12 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
+        with:
+          config-file: ./.github/codeql/codeql-config.yml
         with:
           languages: ${{ matrix.language }}
-          paths:
-            - src
-            - lib
+
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
@@ -65,4 +65,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,6 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           config-file: ./.github/codeql/codeql-config.yml
-        with:
           languages: ${{ matrix.language }}
 
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
-  # schedule:
-  #   - cron: '28 13 * * 4'
+  schedule:
+    - cron: '28 13 * * 4'
 
 jobs:
   analyze:


### PR DESCRIPTION
I see that CodeQL is failing due to syntax
https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-a-custom-configuration-file

on master:
[![CodeQL on master](https://github.com/fabricjs/fabric.js/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/fabricjs/fabric.js/actions/workflows/codeql-analysis.yml)

here:
[![CodeQL fixed](https://github.com/fabricjs/fabric.js/actions/workflows/codeql-analysis.yml/badge.svg?branch=ci-fix-codeql)](https://github.com/fabricjs/fabric.js/actions/workflows/codeql-analysis.yml)

