### PR TITLE
ci(): safeguard build end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [next]
+
+- ci(build): safeguard concurrent unlocking [#8309](https://github.com/fabricjs/fabric.js/pull/8309)
 - ci(test): await golden generation in visual tests [#8284](https://github.com/fabricjs/fabric.js/pull/8284)
 - ci(): Add a pipeline check for verifying that CHANGELOG.md has been updated [#8302](https://github.com/fabricjs/fabric.js/pull/8302)
 - BREAKING feat(fabric.IText) rename data-fabric-hiddentextarea to data-fabric with value textarea

--- a/scripts/buildLock.mjs
+++ b/scripts/buildLock.mjs
@@ -110,6 +110,6 @@ export function report(type, data) {
       );
       break;
     case 'end':
-      !readLockFile().error && unlock();
+      isLocked() && !readLockFile().error && unlock();
   }
 }


### PR DESCRIPTION
This PR safeguards concurrent unlocking
If more than one process is watching fabric it is possible that an error will raise when a process is trying to read the lock file on the `end` lifecycle event because another process has unlocked build beforehand.