### PR TITLE
fix(): clear `_target` on discard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(canvas interactivity): stop moving object after discarding, expose `setTransformEventTarget` to hijack transform event from target (continues [#7954](https://github.com/fabricjs/fabric.js/pull/7954)) [#8335](https://github.com/fabricjs/fabric.js/pull/8335s)
 - ci(build): safeguard concurrent unlocking [#8309](https://github.com/fabricjs/fabric.js/pull/8309)
 - ci(): update stale bot [#8307](https://github.com/fabricjs/fabric.js/pull/8307)
 - ci(test): await golden generation in visual tests [#8284](https://github.com/fabricjs/fabric.js/pull/8284)

--- a/src/mixins/canvas_events.mixin.ts
+++ b/src/mixins/canvas_events.mixin.ts
@@ -865,6 +865,7 @@ import { fireEvent } from '../util/fireEvent';
           transform.target.isMoving = false;
         }
         this._currentTransform = null;
+        this._target = null;
       },
 
       /**
@@ -1059,6 +1060,14 @@ import { fireEvent } from '../util/fireEvent';
         this._target = this._currentTransform
           ? this._currentTransform.target
           : this.findTarget(e) || null;
+      },
+
+      /**
+       * Use in `before` events to override the event target
+       * @param target
+       */
+      setTransformEventTarget: function (target) {
+        this._target = target;
       },
 
       /**


### PR DESCRIPTION
Handles the case in which an object is being moved by the user and discarded meanwhile.

Currently the object will continue moving and will be inactive only on mouseup.

Exposes `setTransformEventTarget` to hijack the event from the target