### PR TITLE
fix(textStyles): Handle empty style object in stylesToArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(textStyles): Handle empty style object in stylesToArray [#8357](https://github.com/fabricjs/fabric.js/pull/8357)
 - ci(build): safeguard concurrent unlocking [#8309](https://github.com/fabricjs/fabric.js/pull/8309)
 - ci(): update stale bot [#8307](https://github.com/fabricjs/fabric.js/pull/8307)
 - ci(test): await golden generation in visual tests [#8284](https://github.com/fabricjs/fabric.js/pull/8284)

--- a/src/util/misc/textStyles.ts
+++ b/src/util/misc/textStyles.ts
@@ -54,7 +54,7 @@ export const stylesToArray = (styles: any, text: string) => {
       charIndex++;
       const thisStyle = styles[i][c];
       //check if style exists for this character
-      if (thisStyle) {
+      if (thisStyle && Object.keys(thisStyle).length > 0) {
         if (hasStyleChanged(prevStyle, thisStyle, true)) {
           stylesArray.push({
             start: charIndex,

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -345,9 +345,9 @@
     var text = new fabric.Text('xxxxxx\nx y');
     text.styles = { 1: { 0: { }, 1: { }}, 2: { }, 3: { 4: { }}};
     text.cleanStyle('any');
-    assert.equal(text.styles[1], undefined, 'the style has been cleaned since there were no usefull informations');
-    assert.equal(text.styles[2], undefined, 'the style has been cleaned since there were no usefull informations');
-    assert.equal(text.styles[3], undefined, 'the style has been cleaned since there were no usefull informations');
+    assert.equal(text.styles[1], undefined, 'the style has been cleaned since there was no useful information');
+    assert.equal(text.styles[2], undefined, 'the style has been cleaned since there was no useful information');
+    assert.equal(text.styles[3], undefined, 'the style has been cleaned since there was no useful information');
   });
 
   QUnit.test('text cleanStyle with full style', function(assert) {
@@ -385,6 +385,13 @@
     text.styles = { 0: { 0: { fill: 'blue' }, 1:  { fill: 'blue' }, 2:  { fill: 'blue' }}};
     text.removeStyle('fill');
     assert.equal(text.styles[0], undefined, 'the styles got empty and has been removed');
+  });
+
+  QUnit.test('text toObject removes empty style object', function(assert) {
+    var text = new fabric.Text('xxx');
+    text.styles = { 0: { 0: {} } };
+    var obj = text.toObject();
+    assert.deepEqual(obj.styles, [], 'empty style object has been removed');
   });
 
   QUnit.test('getFontCache works with fontWeight numbers', function(assert) {


### PR DESCRIPTION
Handle empty style object in stylesToArray method

Thanks to @av01d
closes https://github.com/fabricjs/fabric.js/issues/8354