### PR TITLE
include textBackgroundColor check in hasStyleChanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(textStyles): Handle style objects with only a textBackgroundColor property in stylesToArray [#8365](https://github.com/fabricjs/fabric.js/pull/8365)
 - chore(): fix typos in intersection file [#8345](https://github.com/fabricjs/fabric.js/pull/8345)
 - fix(textStyles): Handle empty style object in stylesToArray [#8357](https://github.com/fabricjs/fabric.js/pull/8357)
 - ci(build): safeguard concurrent unlocking [#8309](https://github.com/fabricjs/fabric.js/pull/8309)

--- a/src/util/misc/textStyles.ts
+++ b/src/util/misc/textStyles.ts
@@ -19,6 +19,7 @@ export const hasStyleChanged = (
   prevStyle.fontFamily !== thisStyle.fontFamily ||
   prevStyle.fontWeight !== thisStyle.fontWeight ||
   prevStyle.fontStyle !== thisStyle.fontStyle ||
+  prevStyle.textBackgroundColor !== thisStyle.textBackgroundColor ||
   prevStyle.deltaY !== thisStyle.deltaY ||
   (forTextSpans &&
     (prevStyle.overline !== thisStyle.overline ||

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -394,6 +394,13 @@
     assert.deepEqual(obj.styles, [], 'empty style object has been removed');
   });
 
+  QUnit.test('text toObject can handle style objects with only a textBackgroundColor property', function(assert) {
+    var text = new fabric.Text('xxx');
+    text.styles = { 0: { 0: { textBackgroundColor: 'blue' } } };
+    var obj = text.toObject();
+    assert.deepEqual(obj.styles, [{ start: 0, end: 1, style: { textBackgroundColor: 'blue' }}], 'empty style object has been removed');
+  });
+
   QUnit.test('getFontCache works with fontWeight numbers', function(assert) {
     var text = new fabric.Text('xxx', { fontWeight: 400 });
     text.initDimensions();

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -398,7 +398,11 @@
     var text = new fabric.Text('xxx');
     text.styles = { 0: { 0: { textBackgroundColor: 'blue' } } };
     var obj = text.toObject();
-    assert.deepEqual(obj.styles, [{ start: 0, end: 1, style: { textBackgroundColor: 'blue' }}], 'empty style object has been removed');
+    assert.deepEqual(
+      obj.styles,
+      [{ start: 0, end: 1, style: { textBackgroundColor: 'blue' }}],
+      'styles with only a textBackgroundColor property do not throw an error'
+    );
   });
 
   QUnit.test('getFontCache works with fontWeight numbers', function(assert) {


### PR DESCRIPTION
Prevent an undefined exception in stylesToArray when converting style objects which only contain a textBackgroundColor property