### PR TITLE
feat(): SideEffect

### DIFF
--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -1,0 +1,10 @@
+export abstract class SideEffect<T, K extends keyof T> {
+  abstract name: string;
+  abstract keys: K[] | '*';
+  abstract onChange(key: K, value: T[K], prevValue: T[K]): void;
+  invoke(key: K, value: T[K], prevValue: T[K]) {
+    (this.keys === '*' || this.keys.includes(key)) &&
+      value !== prevValue &&
+      this.onChange(key, value, prevValue);
+  }
+}

--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -1,9 +1,13 @@
 export abstract class SideEffect<T, K extends keyof T> {
   abstract name: string;
   abstract keys: K[] | '*';
+  enable = true;
+
   abstract onChange(key: K, value: T[K], prevValue: T[K]): void;
+
   invoke(key: K, value: T[K], prevValue: T[K]) {
-    (this.keys === '*' || this.keys.includes(key)) &&
+    this.enable &&
+      (this.keys === '*' || this.keys.includes(key)) &&
       value !== prevValue &&
       this.onChange(key, value, prevValue);
   }

--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -18,12 +18,8 @@ export class SideEffect<
   }
 
   isEqual(incoming: P) {
-    for (const key in incoming) {
-      if (this.persistance[key] !== incoming[key]) {
-        return false;
-      }
-    }
-    return true;
+    const keys = this.keys === '*' ? (Object.keys(incoming) as K[]) : this.keys;
+    return !keys.some((key) => this.persistance[key] !== incoming[key]);
   }
 
   invoke(key: K, value: P[K]) {

--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -9,12 +9,23 @@ export class SideEffect<
   private callback: C;
   private enabled = true;
   private persistance: P;
+  /**
+   * Flags if this effect should be dismissed by preceding effects with the same id
+   */
+  private dismissible: boolean;
 
-  constructor(id: string, keys: K[] | '*', callback: C, initialValue?: P) {
+  constructor(
+    id: string,
+    keys: K[] | '*',
+    callback: C,
+    initialValue?: P,
+    { dismissible }: { dismissible?: boolean } = {}
+  ) {
     this.id = id;
     this.keys = keys;
     this.callback = callback;
     this.persistance = initialValue || ({} as P);
+    this.dismissible = typeof dismissible === 'boolean' ? dismissible : true;
   }
 
   isEqual(incoming: P) {
@@ -54,5 +65,9 @@ export class SideEffect<
 
   disable() {
     this.enabled = false;
+  }
+
+  isDismissible() {
+    return this.dismissible;
   }
 }

--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -4,8 +4,8 @@ export class SideEffect<
   P extends Partial<Record<K, T[K]>>,
   C extends (key: K, value: P[K], prevValue?: P[K]) => void
 > {
-  id: string;
-  private keys: K[] | '*';
+  readonly id: string;
+  keys: K[] | '*';
   private callback: C;
   private enabled = true;
   private persistance: P;

--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -6,7 +6,7 @@ export class SideEffect<
   id: string;
   private keys: K[] | '*';
   private callback: C;
-  enable = true;
+  private enabled = true;
 
   constructor(id: string, keys: K[] | '*', callback: C) {
     this.id = id;
@@ -15,9 +15,21 @@ export class SideEffect<
   }
 
   invoke(key: K, value: T[K], prevValue: T[K]) {
-    this.enable &&
+    this.enabled &&
       (this.keys === '*' || this.keys.includes(key)) &&
       value !== prevValue &&
       this.callback(key, value, prevValue);
+  }
+
+  isEnabled() {
+    return this.enabled;
+  }
+
+  enable() {
+    this.enabled = true;
+  }
+
+  disable() {
+    this.enabled = false;
   }
 }

--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -19,7 +19,13 @@ export class SideEffect<
 
   isEqual(incoming: P) {
     const keys = this.keys === '*' ? (Object.keys(incoming) as K[]) : this.keys;
-    return !keys.some((key) => this.persistance[key] !== incoming[key]);
+    return !keys.some((key) =>
+      this.compare(key, this.persistance[key], incoming[key])
+    );
+  }
+
+  compare(key: K, a: P[K], b: P[K]) {
+    return a === b;
   }
 
   invoke(key: K, value: P[K]) {

--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -1,24 +1,45 @@
 export class SideEffect<
   T,
   K extends keyof T,
-  C extends (key: K, value: T[K], prevValue: T[K]) => void
+  P extends Partial<Record<K, T[K]>>,
+  C extends (key: K, value: P[K], prevValue?: P[K]) => void
 > {
   id: string;
   private keys: K[] | '*';
   private callback: C;
   private enabled = true;
+  private persistance: P;
 
-  constructor(id: string, keys: K[] | '*', callback: C) {
+  constructor(id: string, keys: K[] | '*', callback: C, initialValue?: P) {
     this.id = id;
     this.keys = keys;
     this.callback = callback;
+    this.persistance = initialValue || ({} as P);
   }
 
-  invoke(key: K, value: T[K], prevValue: T[K]) {
-    this.enabled &&
+  isEqual(incoming: P) {
+    for (const key in incoming) {
+      if (this.persistance[key] !== incoming[key]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  invoke(key: K, value: P[K]) {
+    const prevValue = this.persistance[key];
+    if (
+      this.enabled &&
       (this.keys === '*' || this.keys.includes(key)) &&
-      value !== prevValue &&
+      value !== prevValue
+    ) {
       this.callback(key, value, prevValue);
+      this.persist(key, value);
+    }
+  }
+
+  persist(key: K, value: P[K]) {
+    this.persistance[key] = value;
   }
 
   isEnabled() {

--- a/src/SideEffect.ts
+++ b/src/SideEffect.ts
@@ -1,14 +1,23 @@
-export abstract class SideEffect<T, K extends keyof T> {
-  abstract name: string;
-  abstract keys: K[] | '*';
+export class SideEffect<
+  T,
+  K extends keyof T,
+  C extends (key: K, value: T[K], prevValue: T[K]) => void
+> {
+  id: string;
+  private keys: K[] | '*';
+  private callback: C;
   enable = true;
 
-  abstract onChange(key: K, value: T[K], prevValue: T[K]): void;
+  constructor(id: string, keys: K[] | '*', callback: C) {
+    this.id = id;
+    this.keys = keys;
+    this.callback = callback;
+  }
 
   invoke(key: K, value: T[K], prevValue: T[K]) {
     this.enable &&
       (this.keys === '*' || this.keys.includes(key)) &&
       value !== prevValue &&
-      this.onChange(key, value, prevValue);
+      this.callback(key, value, prevValue);
   }
 }


### PR DESCRIPTION
I will use this PR to propose a change and discuss it since it is easier to write code and comment in PRs.

## Gist
- class `SideEffect`
- register/unregister a side effect on object/canvas/whatever level
- flush side effects in the `_set` method and in other relevant places
- should side effects run in initialization?


## Motivation
- history (undo/redo) discussed by the team - the dev could register as many side effects they want and trigger custom logic
- replacing stateful #7920 
- the need to run side effects and block them at runtime
- a cleaner way to write side effects - move things like `dimensionsAffectingProps` under a class that contains the logic as well, all under one roof. Easier to read, develop and debug.
- something similar to events - you can register/unregister a side effect, control it, create more. Eliminates the need to subclass, Easier to control behavior and easier to understand I hope.
- https://github.com/fabricjs/fabric.js/pull/8344#pullrequestreview-1143233737 and others regarding what side effects should or shouldn't run by default.
- use instead of events in cases in which we don't want `off` to deregister the event and kill the side effect.
- perf: using `set({ ... })` invokes side effects for each key. That is suboptimal and can be addressed using side effects.
- since using `set({ ... })` invokes side effects for each key I can think of an edge case in which passing the same object with keys ordered differently will result in a different effect

## Comments
I think this could be part of v6. No rush. As I wrote, this is a discussion that might turn into a PR.

## Usage
```ts

class Polyline {
  constructor(...) {
     this.registerSideEffect(
          new SideEffect(
            'StrokeBBoxSideEffect', 
            ['strokeWidth', 'points', ...], 
           () => this.setDimensions()
      ))
  }

  flushSideEffects(key, value) {
    this.sideEffects.forEach(effect => effect.invoke(key, value))
  }
}

const lazyPolyline = new Polyline(...);
lazyPolyline.set('strokeWidth', 10) // sets dimensions
lazyPolyline.getSideEffect('StrokeBBoxSideEffect').disable()
lazyPolyline.set('strokeWidth', 20) // does nothing
lazyPolyline.unregisterSideEffect('StrokeBBoxSideEffect')
lazyPolyline.set('strokeWidth', 30) // does nothing for good

const shouldRunDimensionsEffect = !lazyPolyline.getSideEffect('StrokeBBoxSideEffect').isEqual({ strokewidth: 10, strokeUniform: false, ... })
```


