### PR TITLE
ci(): guides follow up

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,24 +12,24 @@ body:
 
         If you have a question or if an issue is not right for what you mean
         to file use
-        [Discussions](../discussions).
+        [Discussions](https://github.com/fabricjs/fabric.js/discussions).
   - type: checkboxes
     id: terms
     attributes:
       label: CheckList
       description: >-
         By submitting this issue, you agree to follow our [Code of
-        Conduct](../blob/master/CODE_OF_CONDUCT.md)
+        Conduct](https://github.com/fabricjs/fabric.js/blob/master/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
         - label: >-
             I have read and followed the [Contributing
-            Guide](../blob/master/CONTRIBUTING.md)
+            Guide](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md)
           required: true
         - label: >-
             I have read and followed the [Issue Tracker
-            Guide](../blob/master/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
+            Guide](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
           required: true
         - label: I have searched and referenced existing issues and discussions
           required: true
@@ -58,7 +58,7 @@ body:
       label: In What environments are you experiencing the problem?
       description: >-
         checkout the [supported
-        browsers](../blob/master/README.md#supported-browsersenvironments)
+        browsers](https://github.com/fabricjs/fabric.js/blob/master/README.md#supported-browsersenvironments)
       multiple: true
       options:
         - Firefox

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,10 +9,7 @@ body:
 
         Before you do, please ensure you are filing the issue in the right
         place. 
-
-        If you have a question or if an issue is not right for what you mean
-        to file use
-        [Discussions](https://github.com/fabricjs/fabric.js/discussions).
+        For anything else (such as questions) use [Discussions](https://github.com/fabricjs/fabric.js/discussions).
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
         Before you do, please ensure you are filing the issue in the right
         place. 
 
-        * If you have a question or if an issue is not right for what you mean
+        If you have a question or if an issue is not right for what you mean
         to file use
         [Discussions](https://github.com/fabricjs/fabric.js/discussions).
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,24 +12,24 @@ body:
 
         If you have a question or if an issue is not right for what you mean
         to file use
-        [Discussions](https://github.com/fabricjs/fabric.js/discussions).
+        [Discussions](../discussions).
   - type: checkboxes
     id: terms
     attributes:
       label: CheckList
       description: >-
         By submitting this issue, you agree to follow our [Code of
-        Conduct](https://github.com/fabricjs/fabric.js/CODE_OF_CONDUCT.md)
+        Conduct](../blob/master/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
         - label: >-
             I have read and followed the [Contributing
-            Guide](https://github.com/fabricjs/fabric.js/CONTRIBUTING.md)
+            Guide](../blob/master/CONTRIBUTING.md)
           required: true
         - label: >-
             I have read and followed the [Issue Tracker
-            Guide](https://github.com/fabricjs/fabric.js/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
+            Guide](../blob/master/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
           required: true
         - label: I have searched and referenced existing issues and discussions
           required: true
@@ -58,7 +58,7 @@ body:
       label: In What environments are you experiencing the problem?
       description: >-
         checkout the [supported
-        browsers](/README.md#supported-browsersenvironments)
+        browsers](../blob/master/README.md#supported-browsersenvironments)
       multiple: true
       options:
         - Firefox

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions
-    url: ./discussions
+    url: ../../discussions
     about: Please ask and answer questions here.
   - name: GOTCHAS
     url: http://fabricjs.com/fabric-gotchas

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,12 @@
 
 blank_issues_enabled: false
 contact_links:
+  - name: Website
+    url: http://fabricjs.com/
+    about: Checkout the website.
+  - name: Docs
+    url: http://fabricjs.com/docs/
+    about: Checkout the docs.
   - name: Discussions
     url: https://github.com/fabricjs/fabric.js/discussions
     about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions
-    url: ../../discussions
+    url: https://github.com/fabricjs/fabric.js/discussions
     about: Please ask and answer questions here.
   - name: GOTCHAS
     url: http://fabricjs.com/fabric-gotchas

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
         place. 
 
         If you have a question use
-        [Discussions](https://github.com/fabricjs/fabric.js/discussions).
+        [Discussions](../discussions).
 
         If you are up for contributing see [CONTRIBUTING](CONTRIBUTING.md)
   - type: checkboxes
@@ -20,17 +20,17 @@ body:
       label: CheckList
       description: >-
         By submitting this ticket, you agree to follow our [Code of
-        Conduct](https://github.com/fabricjs/fabric.js/CODE_OF_CONDUCT.md)
+        Conduct](../blob/master/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
         - label: >-
             I have read and followed the [Contributing
-            Guide](https://github.com/fabricjs/fabric.js/CONTRIBUTING.md)
+            Guide](../blob/master/CONTRIBUTING.md)
           required: true
         - label: >-
             I have read and followed the [Issue Tracker
-            Guide](https://github.com/fabricjs/fabric.js/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
+            Guide](../blob/master/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
           required: true
         - label: I have searched and referenced existing issues and discussions
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
         [Discussions](https://github.com/fabricjs/fabric.js/discussions).
 
         If you are up for PRing see [Pull Requests](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md#-pull-requests). 
-        It is advised to wait for a green light before beginning.
+        It is advised to wait for a green light before you start coding.
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,8 @@ body:
         If you have a question use
         [Discussions](https://github.com/fabricjs/fabric.js/discussions).
 
-        If you are up for contributing see [CONTRIBUTING](CONTRIBUTING.md)
+        If you are up for PRing see [Pull Requests](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md#-pull-requests). 
+        It is advised to wait for a green light before beginning.
   - type: checkboxes
     id: terms
     attributes:
@@ -28,11 +29,7 @@ body:
             I have read and followed the [Contributing
             Guide](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md)
           required: true
-        - label: >-
-            I have read and followed the [Issue Tracker
-            Guide](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
-          required: true
-        - label: I have searched and referenced existing issues and discussions
+        - label: I have searched and referenced existing issues, feature requests and discussions
           required: true
         - label: I am filing a **FEATURE** request.
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
         [Discussions](https://github.com/fabricjs/fabric.js/discussions).
 
         If you are interested in submitted a PR see [Pull Requests](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md#-pull-requests).         
-        While bug fixes are always welcome, we recommend submitting a feature request and waiting for approval before you begin coding new features.
+        We recommend submitting a feature request and waiting for approval **before** you begin coding new features.
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
         place. 
 
         If you have a question use
-        [Discussions](../discussions).
+        [Discussions](https://github.com/fabricjs/fabric.js/discussions).
 
         If you are up for contributing see [CONTRIBUTING](CONTRIBUTING.md)
   - type: checkboxes
@@ -20,17 +20,17 @@ body:
       label: CheckList
       description: >-
         By submitting this ticket, you agree to follow our [Code of
-        Conduct](../blob/master/CODE_OF_CONDUCT.md)
+        Conduct](https://github.com/fabricjs/fabric.js/blob/master/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
         - label: >-
             I have read and followed the [Contributing
-            Guide](../blob/master/CONTRIBUTING.md)
+            Guide](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md)
           required: true
         - label: >-
             I have read and followed the [Issue Tracker
-            Guide](../blob/master/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
+            Guide](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
           required: true
         - label: I have searched and referenced existing issues and discussions
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,8 +13,8 @@ body:
         If you have a question use
         [Discussions](https://github.com/fabricjs/fabric.js/discussions).
 
-        If you are up for PRing see [Pull Requests](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md#-pull-requests). 
-        It is advised to wait for a green light before you start coding.
+        If you are interested in submitted a PR see [Pull Requests](https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md#-pull-requests).         
+        While bug fixes are always welcome, we recommend submitting a feature request and waiting for approval before you begin coding new features.
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: 🔓 Feature Request
+description: File a feature request
+title: '[Feature]: '
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for wanting to contribute to this repository. 
+
+        Before you do, please ensure you are filing the ticket in the right
+        place. 
+
+        If you have a question use
+        [Discussions](https://github.com/fabricjs/fabric.js/discussions).
+
+        If you are up for contributing see [CONTRIBUTING](CONTRIBUTING.md)
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: CheckList
+      description: >-
+        By submitting this ticket, you agree to follow our [Code of
+        Conduct](https://github.com/fabricjs/fabric.js/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true
+        - label: >-
+            I have read and followed the [Contributing
+            Guide](https://github.com/fabricjs/fabric.js/CONTRIBUTING.md)
+          required: true
+        - label: >-
+            I have read and followed the [Issue Tracker
+            Guide](https://github.com/fabricjs/fabric.js/CONTRIBUTING.md#%EF%B8%8F-issue-tracker)
+          required: true
+        - label: I have searched and referenced existing issues and discussions
+          required: true
+        - label: I am filing a **FEATURE** request.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Detail your suggestion and the desired behavior.
+        Provide screenshots/screencasts if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current State
+      description: Detail current state/behavior and existing solutions/workarounds
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Provide additional context
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,18 @@
----
-name: Pull Request
-about: Creating a PR
----
-
 <!--
         Hi there!
         Thanks for taking the time and putting the effort into making fabric better! 💖
         Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
         https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md
 
-        Adding tests that verify your fix and safegurad it from unwanted loss and changes is a MUST.
+        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.
 
-        PRing is not always simple, don't hestitate to ask for help (beware of 'em gotchas 😓).
+        PRing is not always simple, don't hesitate to ask for help (beware of 'em gotchas 😓).
         We appreciate your effort and would like the process to be productive and enjoyable.
         A strong community means a strong and better product for everyone.
 -->
 
 <!--
-        📣 IMPORTANT NOTICE - PR LOCKDOWN 🔒    04/2022
+        📣 IMPORTANT NOTICE - PR LOCK DOWN 🔒    04/2022
         We are excited to announce that fabric is migrating to modern typescript/javascript 🤩.
         This means we will ⛔ not be accepting any PRs out of scope with the migration.
         We understand this might be annoying but wasted work is ever more so.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
         Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.
 
-        PRing is not always simple, don't hesitate to ask for help (beware of 'em gotchas 😓).
+        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
         We appreciate your effort and would like the process to be productive and enjoyable.
         A strong community means a strong and better product for everyone.
 -->

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     # wait for publishing to complete
     needs: publish-npm
+    if: always()
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          ref: master
       - name: Update bug report version
         uses: ShaMan123/gha-populate-form-version@v2.0.1
         with:
@@ -47,7 +48,7 @@ jobs:
         with:
           add-paths: .github/ISSUE_TEMPLATE/bug_report.yml
           branch: ci-update-bug-report
-          base: ${{ needs.pre.outputs.branch }}
+          base: master
           delete-branch: true
           labels: CI/CD, bot, task
           title: 'chore(): Update bug report'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- docs(): guides follow up, feature request template [#8379](https://github.com/fabricjs/fabric.js/pull/8379)
 - docs(): refactor guides, bug report template [#8189](https://github.com/fabricjs/fabric.js/pull/8189)
 - BREAKING fix(polyline/polygon): stroke bounding box for all line join/cap cases [#8344](https://github.com/fabricjs/fabric.js/pull/8344)
   BREAKING: `_setPositionDimensions` was removed in favor of `setDimensions`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Fabric is an open source project 🦄 and as such depends on the **genuine effor
 ### ✅ Guidelines
 
 - **Code Style** \
-  Fabric uses [`prettier`][prettier] to format files and [`eslint`][eslint]) for linting (`npm run lint -- --fix`).\
+  Fabric uses [`prettier`][prettier] to format files and [`eslint`][eslint] for linting (`npm run lint -- --fix`).\
   To enjoy a seamless dev experience add the [`Prettier - Code formatter`][prettier_extension] extension via the extensions toolbar in VSCode.
 - **⛔ `dist`** \
   Commit changes to [source files](src). Don't commit the generated [distribution files](dist).


### PR DESCRIPTION
Fix left overs from #8189 
closes #8378 

- typos
- links - the new form templates don't support relative links yet
- add feature request template
- `.github/workflows/npmpublish.yml`: update bug report action to run on master always