### PR TITLE
Observable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(TS): Observable types [#8431](https://github.com/fabricjs/fabric.js/pull/8431)
 - chore(TS): migrate Rect [#8411](https://github.com/fabricjs/fabric.js/pull/8411)
 - chore(TS): migrate Ellipse [#8408](https://github.com/fabricjs/fabric.js/pull/8408)
 - chore(TS): migrate Triangle to TS [#8410](https://github.com/fabricjs/fabric.js/pull/8410)

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -1,8 +1,8 @@
-import { Point } from '../point.class';
-import { FabricObject } from '../shapes/fabricObject.class';
-import { Group, LayoutEventData } from '../shapes/group.class';
-import { TEvent, TransformEvent, TPointerEvent } from '../typedefs';
-import { Canvas } from '../__types__';
+import { Point } from './point.class';
+import { FabricObject } from './shapes/fabricObject.class';
+import { Group, LayoutEventData } from './shapes/group.class';
+import { TEvent, TransformEvent, TPointerEvent } from './typedefs';
+import { Canvas } from './__types__';
 
 export type TModificationEvents =
   | 'moving'

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -156,11 +156,13 @@ export type TObjectEvents = ObjectPointerEvents &
     removed: { target: Group | Canvas };
 
     // IText
+    // todo - move to file
     'selection:changed': never;
     changed: never;
     tripleclick: XTransformEvent;
 
     // Group
+    // todo - move to file
     layout: LayoutEventData;
 
     // erasing

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -1,8 +1,70 @@
+import type { Control } from './controls/control.class';
 import type { Point } from './point.class';
 import type { FabricObject } from './shapes/fabricObject.class';
 import type { Group } from './shapes/group.class';
-import type { TEvent, TPointerEvent, TransformEvent } from './typedefs';
+import type { TOriginX, TOriginY, TRadian } from './typedefs';
+import type { saveObjectTransform } from './util/misc/objectTransforms';
 import type { Canvas } from './__types__';
+
+export type ModifierKey = 'altKey' | 'shiftKey' | 'ctrlKey';
+
+export type TPointerEvent = MouseEvent | TouchEvent;
+
+export type TransformAction<T extends Transform = Transform, R = void> = (
+  eventData: TPointerEvent,
+  transform: T,
+  x: number,
+  y: number
+) => R;
+
+export type TransformActionHandler<T extends Transform = Transform> =
+  TransformAction<T, boolean>;
+
+export type ControlCallback<R = void> = (
+  eventData: TPointerEvent,
+  control: Control,
+  fabricObject: FabricObject
+) => R;
+
+export type ControlCursorCallback = ControlCallback<string>;
+/**
+ * relative to target's containing coordinate plane
+ * both agree on every point
+ */
+
+export type Transform = {
+  target: FabricObject;
+  action: string;
+  actionHandler: TransformActionHandler;
+  corner: string;
+  scaleX: number;
+  scaleY: number;
+  skewX: number;
+  skewY: number;
+  offsetX: number;
+  offsetY: number;
+  originX: TOriginX;
+  originY: TOriginY;
+  ex: number;
+  ey: number;
+  lastX: number;
+  lastY: number;
+  theta: TRadian;
+  width: number;
+  height: number;
+  shiftKey: boolean;
+  altKey: boolean;
+  original: ReturnType<typeof saveObjectTransform>;
+};
+
+export type TEvent<E extends Event = TPointerEvent> = {
+  e: E;
+};
+
+export type TransformEvent<E extends Event = TPointerEvent> = TEvent<E> & {
+  transform: Transform;
+  pointer: Point;
+};
 
 export type TModificationEvents =
   | 'moving'

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -5,6 +5,7 @@ import type { Group } from './shapes/group.class';
 import type { TOriginX, TOriginY, TRadian } from './typedefs';
 import type { saveObjectTransform } from './util/misc/objectTransforms';
 import type { Canvas } from './__types__';
+import type { IText } from './shapes/itext.class';
 
 export type ModifierKey = 'altKey' | 'shiftKey' | 'ctrlKey';
 
@@ -213,8 +214,10 @@ export type CanvasEvents = CanvasPointerEvents &
         };
 
     // IText
-    'text:selection:changed': { target: FabricObject };
-    'text:changed': { target: FabricObject };
+    'text:selection:changed': { target: IText };
+    'text:changed': { target: IText };
+    'text:editing:entered': { target: IText };
+    'text:editing:exited': { target: IText };
 
     // misc
     'contextmenu:before': SimpleEventHandler<Event>;

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -104,7 +104,7 @@ type TPointerEvents<Prefix extends string, E = Record<string, never>> = Record<
 export type ObjectPointerEvents = TPointerEvents<'mouse'>;
 export type CanvasPointerEvents = TPointerEvents<'mouse:'>;
 
-export type ObjectEventsSpec = ObjectPointerEvents &
+export type ObjectEvents = ObjectPointerEvents &
   DnDEvents &
   ObjectModifiedEvents & {
     // selection
@@ -119,7 +119,7 @@ export type ObjectEventsSpec = ObjectPointerEvents &
     'erasing:end': { path: FabricObject };
   };
 
-export type CanvasEventsSpec = CanvasPointerEvents &
+export type CanvasEvents = CanvasPointerEvents &
   CanvasDnDEvents &
   CanvasModifiedEvents &
   CanvasSelectionEvents & {

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -182,19 +182,22 @@ export type ObjectEvents = ObjectPointerEvents &
     'erasing:end': { path: FabricObject };
   };
 
-export type CanvasEvents = CanvasPointerEvents &
+export type StaticCanvasEvents = {
+  // tree
+  'object:added': { target: FabricObject };
+  'object:removed': { target: FabricObject };
+  'canvas:cleared': never;
+
+  // rendering
+  'before:render': { ctx: CanvasRenderingContext2D };
+  'after:render': { ctx: CanvasRenderingContext2D };
+};
+
+export type CanvasEvents = StaticCanvasEvents &
+  CanvasPointerEvents &
   CanvasDnDEvents &
   CanvasModifiedEvents &
   CanvasSelectionEvents & {
-    // tree
-    'object:added': { target: FabricObject };
-    'object:removed': { target: FabricObject };
-    'canvas:cleared': never;
-
-    // rendering
-    'before:render': { ctx: CanvasRenderingContext2D };
-    'after:render': { ctx: CanvasRenderingContext2D };
-
     // brushes
     'before:path:created': { path: FabricObject };
     'path:created': { path: FabricObject };

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -1,8 +1,8 @@
-import { Point } from './point.class';
-import { FabricObject } from './shapes/fabricObject.class';
-import { Group, LayoutEventData } from './shapes/group.class';
-import { TEvent, TransformEvent, TPointerEvent } from './typedefs';
-import { Canvas } from './__types__';
+import type { Point } from './point.class';
+import type { FabricObject } from './shapes/fabricObject.class';
+import type { Group } from './shapes/group.class';
+import type { TEvent, TPointerEvent, TransformEvent } from './typedefs';
+import type { Canvas } from './__types__';
 
 export type TModificationEvents =
   | 'moving'

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -171,8 +171,14 @@ export type ObjectEvents = ObjectPointerEvents &
   DnDEvents &
   ObjectModifiedEvents & {
     // selection
-    selected: never;
-    deselected: never;
+    selected: {
+      e: TEvent;
+      target: FabricObject;
+    };
+    deselected: {
+      e?: TEvent;
+      target: FabricObject;
+    };
 
     // tree
     added: { target: Group | Canvas };

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -27,11 +27,11 @@ export type ControlCallback<R = void> = (
 ) => R;
 
 export type ControlCursorCallback = ControlCallback<string>;
+
 /**
  * relative to target's containing coordinate plane
  * both agree on every point
  */
-
 export type Transform = {
   target: FabricObject;
   action: string;
@@ -61,7 +61,7 @@ export type TEvent<E extends Event = TPointerEvent> = {
   e: E;
 };
 
-export type TransformEvent<E extends Event = TPointerEvent> = TEvent<E> & {
+export type BasicTransformEvent<E extends Event = TPointerEvent> = TEvent<E> & {
   transform: Transform;
   pointer: Point;
 };
@@ -73,17 +73,17 @@ export type TModificationEvents =
   | 'skewing'
   | 'resizing';
 
-type ObjectModifiedEvents = Record<TModificationEvents, TransformEvent> & {
-  modified: TransformEvent | never;
+type ObjectModifiedEvents = Record<TModificationEvents, BasicTransformEvent> & {
+  modified: BasicTransformEvent | never;
 };
 
 type CanvasModifiedEvents = Record<
   `object:${keyof ObjectModifiedEvents}`,
-  TransformEvent & { target: FabricObject }
+  BasicTransformEvent & { target: FabricObject }
 >;
 
-export type XTransformEvent<T extends Event = TPointerEvent> =
-  TransformEvent<T> & {
+export type TransformEvent<T extends Event = TPointerEvent> =
+  BasicTransformEvent<T> & {
     target: FabricObject;
     subTargets: FabricObject[];
     button: number;
@@ -157,11 +157,11 @@ type TPointerEvents<Prefix extends string, E = Record<string, never>> = Record<
     | WithBeforeSuffix<'move'>
     | WithBeforeSuffix<'up'>
     | 'dblclick'}`,
-  XTransformEvent & E
+  TransformEvent & E
 > &
-  Record<`${Prefix}wheel`, XTransformEvent<WheelEvent> & E> &
-  Record<`${Prefix}over`, XTransformEvent & InEvent & E> &
-  Record<`${Prefix}out`, XTransformEvent & OutEvent & E>;
+  Record<`${Prefix}wheel`, TransformEvent<WheelEvent> & E> &
+  Record<`${Prefix}over`, TransformEvent & InEvent & E> &
+  Record<`${Prefix}out`, TransformEvent & OutEvent & E>;
 
 export type ObjectPointerEvents = TPointerEvents<'mouse'>;
 export type CanvasPointerEvents = TPointerEvents<'mouse:'>;

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -104,6 +104,21 @@ type TPointerEvents<Prefix extends string, E = Record<string, never>> = Record<
 export type ObjectPointerEvents = TPointerEvents<'mouse'>;
 export type CanvasPointerEvents = TPointerEvents<'mouse:'>;
 
+export type TObjectEvents = ObjectPointerEvents &
+  DnDEvents &
+  ObjectModifiedEvents & {
+    // selection
+    selected: never;
+    deselected: never;
+
+    // tree
+    added: { target: Group | Canvas };
+    removed: { target: Group | Canvas };
+
+    // erasing
+    'erasing:end': { path: FabricObject };
+  };
+
 export type TCanvasEvents = CanvasPointerEvents &
   CanvasDnDEvents &
   CanvasModifiedEvents &
@@ -142,29 +157,4 @@ export type TCanvasEvents = CanvasPointerEvents &
     // misc
     'contextmenu:before': SimpleEventHandler<Event>;
     contextmenu: SimpleEventHandler<Event>;
-  };
-
-export type TObjectEvents = ObjectPointerEvents &
-  DnDEvents &
-  ObjectModifiedEvents & {
-    // selection
-    selected: never;
-    deselected: never;
-
-    // tree
-    added: { target: Group | Canvas };
-    removed: { target: Group | Canvas };
-
-    // IText
-    // todo - move to file
-    'selection:changed': never;
-    changed: never;
-    tripleclick: XTransformEvent;
-
-    // Group
-    // todo - move to file
-    layout: LayoutEventData;
-
-    // erasing
-    'erasing:end': { path: FabricObject };
   };

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -104,7 +104,7 @@ type TPointerEvents<Prefix extends string, E = Record<string, never>> = Record<
 export type ObjectPointerEvents = TPointerEvents<'mouse'>;
 export type CanvasPointerEvents = TPointerEvents<'mouse:'>;
 
-export type TObjectEvents = ObjectPointerEvents &
+export type ObjectEventsSpec = ObjectPointerEvents &
   DnDEvents &
   ObjectModifiedEvents & {
     // selection
@@ -119,7 +119,7 @@ export type TObjectEvents = ObjectPointerEvents &
     'erasing:end': { path: FabricObject };
   };
 
-export type TCanvasEvents = CanvasPointerEvents &
+export type CanvasEventsSpec = CanvasPointerEvents &
   CanvasDnDEvents &
   CanvasModifiedEvents &
   CanvasSelectionEvents & {

--- a/src/__types__.ts
+++ b/src/__types__.ts
@@ -1,3 +1,4 @@
+import { TCanvasEvents } from './mixins/EventTypeDefs';
 import type { Observable } from './mixins/observable.mixin';
 import type { Point } from './point.class';
 import { ModifierKey, TMat2D } from './typedefs';
@@ -19,6 +20,6 @@ export type StaticCanvas = Record<string, any> & {
     br: Point;
   };
   getRetinaScaling(): number;
-} & Observable;
+} & Observable<TCanvasEvents>;
 export type Rect = any;
 export type TObject = any;

--- a/src/__types__.ts
+++ b/src/__types__.ts
@@ -1,7 +1,8 @@
 import { CanvasEvents } from './EventTypeDefs';
 import type { Observable } from './mixins/observable.mixin';
 import type { Point } from './point.class';
-import { ModifierKey, TMat2D } from './typedefs';
+import { TMat2D } from './typedefs';
+import { ModifierKey } from './EventTypeDefs';
 
 /**
  * @todo remove transient

--- a/src/__types__.ts
+++ b/src/__types__.ts
@@ -1,8 +1,7 @@
-import { CanvasEvents } from './EventTypeDefs';
+import { CanvasEvents, ModifierKey } from './EventTypeDefs';
 import type { Observable } from './mixins/observable.mixin';
 import type { Point } from './point.class';
 import { TMat2D } from './typedefs';
-import { ModifierKey } from './EventTypeDefs';
 
 /**
  * @todo remove transient

--- a/src/__types__.ts
+++ b/src/__types__.ts
@@ -1,4 +1,4 @@
-import { TCanvasEvents } from './EventTypeDefs';
+import { CanvasEventsSpec } from './EventTypeDefs';
 import type { Observable } from './mixins/observable.mixin';
 import type { Point } from './point.class';
 import { ModifierKey, TMat2D } from './typedefs';
@@ -20,6 +20,6 @@ export type StaticCanvas = Record<string, any> & {
     br: Point;
   };
   getRetinaScaling(): number;
-} & Observable<TCanvasEvents>;
+} & Observable<CanvasEventsSpec>;
 export type Rect = any;
 export type TObject = any;

--- a/src/__types__.ts
+++ b/src/__types__.ts
@@ -1,4 +1,4 @@
-import { CanvasEventsSpec } from './EventTypeDefs';
+import { CanvasEvents } from './EventTypeDefs';
 import type { Observable } from './mixins/observable.mixin';
 import type { Point } from './point.class';
 import { ModifierKey, TMat2D } from './typedefs';
@@ -20,6 +20,6 @@ export type StaticCanvas = Record<string, any> & {
     br: Point;
   };
   getRetinaScaling(): number;
-} & Observable<CanvasEventsSpec>;
+} & Observable<CanvasEvents>;
 export type Rect = any;
 export type TObject = any;

--- a/src/__types__.ts
+++ b/src/__types__.ts
@@ -1,4 +1,4 @@
-import { TCanvasEvents } from './mixins/EventTypeDefs';
+import { TCanvasEvents } from './EventTypeDefs';
 import type { Observable } from './mixins/observable.mixin';
 import type { Point } from './point.class';
 import { ModifierKey, TMat2D } from './typedefs';

--- a/src/brushes/pencil_brush.class.ts
+++ b/src/brushes/pencil_brush.class.ts
@@ -3,7 +3,7 @@ import { ModifierKey, TEvent } from '../EventTypeDefs';
 import { Point } from '../point.class';
 import { Shadow } from '../shadow.class';
 import { Path } from '../shapes/path.class';
-import { TEvent, ModifierKey, PathData } from '../typedefs';
+import { PathData } from '../typedefs';
 import { getSmoothPathFromPoints, joinPath } from '../util/path';
 import { Canvas } from '../__types__';
 import { BaseBrush } from './base_brush.class';

--- a/src/brushes/pencil_brush.class.ts
+++ b/src/brushes/pencil_brush.class.ts
@@ -1,6 +1,7 @@
 import { fabric } from '../../HEADER';
+import { ModifierKey, TEvent } from '../EventTypeDefs';
 import { Point } from '../point.class';
-import { TEvent, ModifierKey, PathData } from '../typedefs';
+import { PathData } from '../typedefs';
 import { getSmoothPathFromPoints, joinPath } from '../util/path';
 import { Canvas } from '../__types__';
 import { BaseBrush } from './base_brush.class';

--- a/src/canvas.class.ts
+++ b/src/canvas.class.ts
@@ -2,7 +2,7 @@
 import { dragHandler, getActionFromCorner } from './controls/actions';
 import { Point } from './point.class';
 import { FabricObject } from './shapes/fabricObject.class';
-import { Transform } from './typedefs';
+import { Transform } from './EventTypeDefs';
 import { saveObjectTransform } from './util/misc/objectTransforms';
 
 (function (global) {

--- a/src/canvas.class.ts
+++ b/src/canvas.class.ts
@@ -441,10 +441,12 @@ import { saveObjectTransform } from './util/misc/objectTransforms';
         this._objectsToRender = undefined;
         // removing active object should fire "selection:cleared" events
         if (obj === this._activeObject) {
-          this.fire('before:selection:cleared', { target: obj });
+          this.fire('before:selection:cleared', { deselected: [obj] });
           this._discardActiveObject();
-          this.fire('selection:cleared', { target: obj });
-          obj.fire('deselected');
+          this.fire('selection:cleared', { deselected: [obj] });
+          obj.fire('deselected', {
+            target: obj,
+          });
         }
         if (obj === this._hoveredTarget) {
           this._hoveredTarget = null;
@@ -548,7 +550,7 @@ import { saveObjectTransform } from './util/misc/objectTransforms';
         var ctx = this.contextTop;
         this.clearContext(ctx);
         this.renderTopLayer(ctx);
-        this.fire('after:render');
+        this.fire('after:render', { ctx });
         return this;
       },
 
@@ -1363,7 +1365,10 @@ import { saveObjectTransform } from './util/misc/objectTransforms';
         var currentActives = this.getActiveObjects(),
           activeObject = this.getActiveObject();
         if (currentActives.length) {
-          this.fire('before:selection:cleared', { target: activeObject, e: e });
+          this.fire('before:selection:cleared', {
+            e,
+            deselected: [activeObject],
+          });
         }
         this._discardActiveObject(e);
         this._fireSelectionEvents(currentActives, e);

--- a/src/controls/changeWidth.ts
+++ b/src/controls/changeWidth.ts
@@ -1,4 +1,4 @@
-import { TransformActionHandler } from '../typedefs';
+import { TransformActionHandler } from '../EventTypeDefs';
 import { getLocalPoint, isTransformCentered } from './util';
 import { wrapWithFireEvent } from './wrapWithFireEvent';
 import { wrapWithFixedAnchor } from './wrapWithFixedAnchor';

--- a/src/controls/control.class.ts
+++ b/src/controls/control.class.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { fabric } from '../../HEADER';
 import { halfPI } from '../constants';
-import { Point } from '../point.class';
-import type { FabricObject } from '../shapes/object.class';
 import {
-  TDegree,
-  TMat2D,
   TPointerEvent,
   TransformAction,
   TransformActionHandler,
-} from '../typedefs';
+} from '../EventTypeDefs';
+import { Point } from '../point.class';
+import type { FabricObject } from '../shapes/object.class';
+import { TDegree, TMat2D } from '../typedefs';
 import { cos } from '../util/misc/cos';
 import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { sin } from '../util/misc/sin';

--- a/src/controls/drag.ts
+++ b/src/controls/drag.ts
@@ -1,4 +1,4 @@
-import { TransformActionHandler } from '../typedefs';
+import { TransformActionHandler } from '../EventTypeDefs';
 import { fireEvent } from '../util/fireEvent';
 import { commonEventInfo, isLocked } from './util';
 

--- a/src/controls/rotate.ts
+++ b/src/controls/rotate.ts
@@ -1,6 +1,9 @@
 // @ts-nocheck
 
-import { ControlCursorCallback, TransformActionHandler } from '../typedefs';
+import {
+  ControlCursorCallback,
+  TransformActionHandler,
+} from '../EventTypeDefs';
 import { radiansToDegrees } from '../util/misc/radiansDegreesConversion';
 import { isLocked, NOT_ALLOWED_CURSOR } from './util';
 import { wrapWithFireEvent } from './wrapWithFireEvent';

--- a/src/controls/rotate.ts
+++ b/src/controls/rotate.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import {
   ControlCursorCallback,
   TransformActionHandler,

--- a/src/controls/scale.ts
+++ b/src/controls/scale.ts
@@ -1,11 +1,11 @@
-import type { FabricObject } from '../shapes/fabricObject.class';
 import {
   ControlCursorCallback,
-  TAxis,
   TPointerEvent,
   Transform,
   TransformActionHandler,
-} from '../typedefs';
+} from '../EventTypeDefs';
+import type { FabricObject } from '../shapes/fabricObject.class';
+import { TAxis } from '../typedefs';
 import { Canvas } from '../__types__';
 import {
   findCornerQuadrant,

--- a/src/controls/scaleSkew.ts
+++ b/src/controls/scaleSkew.ts
@@ -1,11 +1,11 @@
-import type { FabricObject } from '../shapes/object.class';
 import {
   ControlCallback,
   ControlCursorCallback,
-  TAxisKey,
   TPointerEvent,
   TransformActionHandler,
-} from '../typedefs';
+} from '../EventTypeDefs';
+import type { FabricObject } from '../shapes/object.class';
+import { TAxisKey } from '../typedefs';
 import { Canvas } from '../__types__';
 import { scaleCursorStyleHandler, scalingX, scalingY } from './scale';
 import { skewCursorStyleHandler, skewHandlerX, skewHandlerY } from './skew';

--- a/src/controls/skew.ts
+++ b/src/controls/skew.ts
@@ -1,13 +1,12 @@
-import { resolveOrigin } from '../mixins/object_origin.mixin';
-import { Point } from '../point.class';
 import {
   ControlCursorCallback,
-  TAxis,
-  TAxisKey,
   TPointerEvent,
   Transform,
   TransformActionHandler,
-} from '../typedefs';
+} from '../EventTypeDefs';
+import { resolveOrigin } from '../mixins/object_origin.mixin';
+import { Point } from '../point.class';
+import { TAxis, TAxisKey } from '../typedefs';
 import {
   degreesToRadians,
   radiansToDegrees,

--- a/src/controls/util.ts
+++ b/src/controls/util.ts
@@ -1,14 +1,13 @@
-import { resolveOrigin } from '../mixins/object_origin.mixin';
-import { Point } from '../point.class';
-import type { FabricObject } from '../shapes/fabricObject.class';
 import {
-  TOriginX,
-  TOriginY,
   TPointerEvent,
   Transform,
   TransformAction,
   TransformEvent,
-} from '../typedefs';
+} from '../EventTypeDefs';
+import { resolveOrigin } from '../mixins/object_origin.mixin';
+import { Point } from '../point.class';
+import type { FabricObject } from '../shapes/fabricObject.class';
+import { TOriginX, TOriginY } from '../typedefs';
 import {
   degreesToRadians,
   radiansToDegrees,

--- a/src/controls/util.ts
+++ b/src/controls/util.ts
@@ -2,7 +2,7 @@ import {
   TPointerEvent,
   Transform,
   TransformAction,
-  TransformEvent,
+  BasicTransformEvent,
 } from '../EventTypeDefs';
 import { resolveOrigin } from '../mixins/object_origin.mixin';
 import { Point } from '../point.class';
@@ -61,12 +61,10 @@ export const isLocked = (
     | 'lockScalingFlip'
 ) => target[lockingKey];
 
-export const commonEventInfo: TransformAction<Transform, TransformEvent> = (
-  eventData,
-  transform,
-  x,
-  y
-) => {
+export const commonEventInfo: TransformAction<
+  Transform,
+  BasicTransformEvent
+> = (eventData, transform, x, y) => {
   return {
     e: eventData,
     transform,

--- a/src/controls/wrapWithFireEvent.ts
+++ b/src/controls/wrapWithFireEvent.ts
@@ -1,5 +1,8 @@
-import { TModificationEvents } from '../EventTypeDefs';
-import { Transform, TransformActionHandler } from '../typedefs';
+import {
+  TModificationEvents,
+  Transform,
+  TransformActionHandler,
+} from '../EventTypeDefs';
 import { fireEvent } from '../util/fireEvent';
 import { commonEventInfo } from './util';
 

--- a/src/controls/wrapWithFireEvent.ts
+++ b/src/controls/wrapWithFireEvent.ts
@@ -1,3 +1,4 @@
+import { TModificationEvents } from '../mixins/EventTypeDefs';
 import { Transform, TransformActionHandler } from '../typedefs';
 import { fireEvent } from '../util/fireEvent';
 import { commonEventInfo } from './util';
@@ -8,7 +9,7 @@ import { commonEventInfo } from './util';
  * @return {Function} a function with an action handler signature
  */
 export const wrapWithFireEvent = <T extends Transform>(
-  eventName: string,
+  eventName: TModificationEvents,
   actionHandler: TransformActionHandler<T>
 ) => {
   return ((eventData, transform, x, y) => {

--- a/src/controls/wrapWithFireEvent.ts
+++ b/src/controls/wrapWithFireEvent.ts
@@ -1,4 +1,4 @@
-import { TModificationEvents } from '../mixins/EventTypeDefs';
+import { TModificationEvents } from '../EventTypeDefs';
 import { Transform, TransformActionHandler } from '../typedefs';
 import { fireEvent } from '../util/fireEvent';
 import { commonEventInfo } from './util';

--- a/src/controls/wrapWithFixedAnchor.ts
+++ b/src/controls/wrapWithFixedAnchor.ts
@@ -1,4 +1,4 @@
-import { Transform, TransformActionHandler } from '../typedefs';
+import { Transform, TransformActionHandler } from '../EventTypeDefs';
 
 /**
  * Wrap an action handler with saving/restoring object position on the transform.

--- a/src/mixins/EventTypeDefs.ts
+++ b/src/mixins/EventTypeDefs.ts
@@ -1,0 +1,149 @@
+import { Point } from '../point.class';
+import { FabricObject } from '../shapes/fabricObject.class';
+import { Group, LayoutEventData } from '../shapes/group.class';
+import { TEvent, TransformEvent, TPointerEvent } from '../typedefs';
+import { Canvas } from '../__types__';
+
+export type XTransformEvent<T extends Event = TPointerEvent> =
+  TransformEvent<T> & {
+    target: FabricObject;
+    subTargets: FabricObject[];
+    button: number;
+    isClick: boolean;
+    pointer: Point;
+    absolutePointer: Point;
+  };
+
+type SimpleEventHandler<T extends Event = TPointerEvent> = TEvent<T> & {
+  target: FabricObject;
+  subTargets: FabricObject[];
+};
+
+type InEvent = {
+  previousTarget?: FabricObject;
+};
+
+type OutEvent = {
+  nextTarget?: FabricObject;
+};
+
+type DragEventData = TEvent<DragEvent> & {
+  target: FabricObject;
+  subTargets?: FabricObject[];
+  dragSource?: FabricObject;
+  canDrop?: boolean;
+  dropTarget?: FabricObject;
+};
+
+type DropEventData = DragEventData & { pointer: Point };
+
+type DnDEvents = {
+  dragstart: TEvent<DragEvent> & { target: FabricObject };
+  drag: DragEventData;
+  dragover: DragEventData;
+  dragenter: DragEventData & InEvent;
+  dragleave: DragEventData & OutEvent;
+  dragend: DragEventData;
+  'drop:before': DropEventData;
+  drop: DropEventData;
+  'drop:after': DropEventData;
+};
+
+type CanvasDnDEvents = DnDEvents & {
+  'drag:enter': DragEventData & InEvent;
+  'drag:leave': DragEventData & OutEvent;
+};
+
+export type TCanvasEvents = {
+  // selection
+  'selection:created': TEvent & {
+    selected: FabricObject[];
+  };
+  'selection:updated': TEvent & {
+    selected: FabricObject[];
+    deselected: FabricObject[];
+  };
+  'before:selection:cleared': Partial<TEvent> & {
+    deselected: FabricObject[];
+  };
+  'selection:cleared': Partial<TEvent> & {
+    deselected: FabricObject[];
+  };
+
+  // tree
+  'object:added': { target: FabricObject };
+  'object:removed': { target: FabricObject };
+  'canvas:cleared': never;
+
+  // rendering
+  'before:render': { ctx: CanvasRenderingContext2D };
+  'after:render': { ctx: CanvasRenderingContext2D };
+
+  // pointer
+  'mouse:down:before': XTransformEvent;
+  'mouse:down': XTransformEvent;
+  'mouse:move:before': XTransformEvent;
+  'mouse:move': XTransformEvent;
+  'mouse:up:before': XTransformEvent;
+  'mouse:up': XTransformEvent;
+  'mouse:dblclick': XTransformEvent;
+  'mouse:wheel': XTransformEvent<WheelEvent>;
+  'mouse:over': XTransformEvent & InEvent;
+  'mouse:out': XTransformEvent & OutEvent;
+
+  // brushes
+  'before:path:created': { path: FabricObject };
+  'path:created': { path: FabricObject };
+
+  // erasing
+  'erasing:start': never;
+  'erasing:end':
+    | never
+    | {
+        path: FabricObject;
+        targets: FabricObject[];
+        subTargets: FabricObject[];
+        drawables: {
+          backgroundImage?: FabricObject;
+          overlayImage?: FabricObject;
+        };
+      };
+
+  // IText
+  'text:selection:changed': { target: FabricObject };
+  'text:changed': { target: FabricObject };
+
+  // misc
+  'contextmenu:before': SimpleEventHandler<Event>;
+  contextmenu: SimpleEventHandler<Event>;
+} & CanvasDnDEvents;
+
+export type TObjectEvents = {
+  selected: never;
+  deselected: never;
+  added: { target: Group | Canvas };
+  removed: { target: Group | Canvas };
+
+  // pointer events
+  'mousedown:before': XTransformEvent;
+  mousedown: XTransformEvent;
+  'mousemove:before': XTransformEvent;
+  mousemove: XTransformEvent;
+  'mouseup:before': XTransformEvent;
+  mouseup: XTransformEvent;
+  mousedblclick: XTransformEvent;
+  mousewheel: XTransformEvent<WheelEvent>;
+  mouseover: XTransformEvent & InEvent;
+  mouseout: XTransformEvent & OutEvent;
+
+  // IText
+  'selection:changed': never;
+  changed: never;
+  tripleclick: XTransformEvent;
+
+  // Group
+  layout: LayoutEventData;
+
+  // erasing
+  'erasing:end': { path: FabricObject };
+} & DnDEvents;

--- a/src/mixins/EventTypeDefs.ts
+++ b/src/mixins/EventTypeDefs.ts
@@ -4,6 +4,22 @@ import { Group, LayoutEventData } from '../shapes/group.class';
 import { TEvent, TransformEvent, TPointerEvent } from '../typedefs';
 import { Canvas } from '../__types__';
 
+export type TModificationEvents =
+  | 'moving'
+  | 'scaling'
+  | 'rotating'
+  | 'skewing'
+  | 'resizing';
+
+type ObjectModifiedEvents = Record<TModificationEvents, TransformEvent> & {
+  modified: TransformEvent | never;
+};
+
+type CanvasModifiedEvents = Record<
+  `object:${keyof ObjectModifiedEvents}`,
+  TransformEvent & { target: FabricObject }
+>;
+
 export type XTransformEvent<T extends Event = TPointerEvent> =
   TransformEvent<T> & {
     target: FabricObject;
@@ -54,8 +70,7 @@ type CanvasDnDEvents = DnDEvents & {
   'drag:leave': DragEventData & OutEvent;
 };
 
-export type TCanvasEvents = {
-  // selection
+type CanvasSelectionEvents = {
   'selection:created': TEvent & {
     selected: FabricObject[];
   };
@@ -69,81 +84,85 @@ export type TCanvasEvents = {
   'selection:cleared': Partial<TEvent> & {
     deselected: FabricObject[];
   };
+};
 
-  // tree
-  'object:added': { target: FabricObject };
-  'object:removed': { target: FabricObject };
-  'canvas:cleared': never;
+type BeforeSuffix<T extends string> = `${T}:before`;
+type WithBeforeSuffix<T extends string> = T | BeforeSuffix<T>;
 
-  // rendering
-  'before:render': { ctx: CanvasRenderingContext2D };
-  'after:render': { ctx: CanvasRenderingContext2D };
+type TPointerEvents<Prefix extends string, E = Record<string, never>> = Record<
+  `${Prefix}${
+    | WithBeforeSuffix<'down'>
+    | WithBeforeSuffix<'move'>
+    | WithBeforeSuffix<'up'>
+    | 'dblclick'}`,
+  XTransformEvent & E
+> &
+  Record<`${Prefix}wheel`, XTransformEvent<WheelEvent> & E> &
+  Record<`${Prefix}over`, XTransformEvent & InEvent & E> &
+  Record<`${Prefix}out`, XTransformEvent & OutEvent & E>;
 
-  // pointer
-  'mouse:down:before': XTransformEvent;
-  'mouse:down': XTransformEvent;
-  'mouse:move:before': XTransformEvent;
-  'mouse:move': XTransformEvent;
-  'mouse:up:before': XTransformEvent;
-  'mouse:up': XTransformEvent;
-  'mouse:dblclick': XTransformEvent;
-  'mouse:wheel': XTransformEvent<WheelEvent>;
-  'mouse:over': XTransformEvent & InEvent;
-  'mouse:out': XTransformEvent & OutEvent;
+export type ObjectPointerEvents = TPointerEvents<'mouse'>;
+export type CanvasPointerEvents = TPointerEvents<'mouse:'>;
 
-  // brushes
-  'before:path:created': { path: FabricObject };
-  'path:created': { path: FabricObject };
+export type TCanvasEvents = CanvasPointerEvents &
+  CanvasDnDEvents &
+  CanvasModifiedEvents &
+  CanvasSelectionEvents & {
+    // tree
+    'object:added': { target: FabricObject };
+    'object:removed': { target: FabricObject };
+    'canvas:cleared': never;
 
-  // erasing
-  'erasing:start': never;
-  'erasing:end':
-    | never
-    | {
-        path: FabricObject;
-        targets: FabricObject[];
-        subTargets: FabricObject[];
-        drawables: {
-          backgroundImage?: FabricObject;
-          overlayImage?: FabricObject;
+    // rendering
+    'before:render': { ctx: CanvasRenderingContext2D };
+    'after:render': { ctx: CanvasRenderingContext2D };
+
+    // brushes
+    'before:path:created': { path: FabricObject };
+    'path:created': { path: FabricObject };
+
+    // erasing
+    'erasing:start': never;
+    'erasing:end':
+      | never
+      | {
+          path: FabricObject;
+          targets: FabricObject[];
+          subTargets: FabricObject[];
+          drawables: {
+            backgroundImage?: FabricObject;
+            overlayImage?: FabricObject;
+          };
         };
-      };
 
-  // IText
-  'text:selection:changed': { target: FabricObject };
-  'text:changed': { target: FabricObject };
+    // IText
+    'text:selection:changed': { target: FabricObject };
+    'text:changed': { target: FabricObject };
 
-  // misc
-  'contextmenu:before': SimpleEventHandler<Event>;
-  contextmenu: SimpleEventHandler<Event>;
-} & CanvasDnDEvents;
+    // misc
+    'contextmenu:before': SimpleEventHandler<Event>;
+    contextmenu: SimpleEventHandler<Event>;
+  };
 
-export type TObjectEvents = {
-  selected: never;
-  deselected: never;
-  added: { target: Group | Canvas };
-  removed: { target: Group | Canvas };
+export type TObjectEvents = ObjectPointerEvents &
+  DnDEvents &
+  ObjectModifiedEvents & {
+    // selection
+    selected: never;
+    deselected: never;
 
-  // pointer events
-  'mousedown:before': XTransformEvent;
-  mousedown: XTransformEvent;
-  'mousemove:before': XTransformEvent;
-  mousemove: XTransformEvent;
-  'mouseup:before': XTransformEvent;
-  mouseup: XTransformEvent;
-  mousedblclick: XTransformEvent;
-  mousewheel: XTransformEvent<WheelEvent>;
-  mouseover: XTransformEvent & InEvent;
-  mouseout: XTransformEvent & OutEvent;
+    // tree
+    added: { target: Group | Canvas };
+    removed: { target: Group | Canvas };
 
-  // IText
-  'selection:changed': never;
-  changed: never;
-  tripleclick: XTransformEvent;
+    // IText
+    'selection:changed': never;
+    changed: never;
+    tripleclick: XTransformEvent;
 
-  // Group
-  layout: LayoutEventData;
+    // Group
+    layout: LayoutEventData;
 
-  // erasing
-  'erasing:end': { path: FabricObject };
-} & DnDEvents;
+    // erasing
+    'erasing:end': { path: FabricObject };
+  };

--- a/src/mixins/itext_behavior.mixin.ts
+++ b/src/mixins/itext_behavior.mixin.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 import { fabric } from '../../HEADER';
+import { ObjectEvents } from '../EventTypeDefs';
 import { Point } from '../point.class';
 import { Text } from '../shapes/text.class';
 import { TEvent, TPointerEvent } from '../typedefs';
@@ -14,7 +15,9 @@ import { TextStyleDeclaration } from './text_style.mixin';
 // extend this regex to support non english languages
 const reNonWord = /[ \n\.,;!\?\-]/;
 
-export abstract class ITextBehaviorMixin extends Text {
+export abstract class ITextBehaviorMixin<
+  EventSpec extends ObjectEvents
+> extends Text<EventSpec> {
   abstract isEditing: boolean;
   abstract cursorDelay: number;
   abstract selectionStart: number;

--- a/src/mixins/itext_behavior.mixin.ts
+++ b/src/mixins/itext_behavior.mixin.ts
@@ -1,10 +1,10 @@
 // @ts-nocheck
 
 import { fabric } from '../../HEADER';
-import { ObjectEvents } from '../EventTypeDefs';
+import { ObjectEvents, TEvent } from '../EventTypeDefs';
 import { Point } from '../point.class';
 import { Text } from '../shapes/text.class';
-import { TEvent, TPointerEvent } from '../typedefs';
+import { TPointerEvent } from '../typedefs';
 import { setStyle } from '../util/dom_style';
 import { removeFromArray } from '../util/internals';
 import { createCanvasElement } from '../util/misc/dom';

--- a/src/mixins/itext_click_behavior.mixin.ts
+++ b/src/mixins/itext_click_behavior.mixin.ts
@@ -1,11 +1,14 @@
 //@ts-nocheck
+import { ObjectEvents } from '../EventTypeDefs';
 import { IPoint, Point } from '../point.class';
 import { TPointerEvent, TransformEvent } from '../typedefs';
 import { stopEvent } from '../util/dom_event';
 import { invertTransform, transformPoint } from '../util/misc/matrix';
 import { ITextKeyBehaviorMixin } from './itext_key_behavior.mixin';
 
-export abstract class ITextClickBehaviorMixin extends ITextKeyBehaviorMixin {
+export abstract class ITextClickBehaviorMixin<
+  EventSpec extends ObjectEvents
+> extends ITextKeyBehaviorMixin<EventSpec> {
   private __lastClickTime: number;
   private __lastLastClickTime: number;
   private __lastPointer: IPoint | Record<string, never>;

--- a/src/mixins/itext_key_behavior.mixin.ts
+++ b/src/mixins/itext_key_behavior.mixin.ts
@@ -2,11 +2,14 @@
 
 import { fabric } from '../../HEADER';
 import { config } from '../config';
+import { ObjectEvents } from '../EventTypeDefs';
 import { TPointerEvent } from '../typedefs';
 import { capValue } from '../util/misc/capValue';
 import { ITextBehaviorMixin } from './itext_behavior.mixin';
 
-export abstract class ITextKeyBehaviorMixin extends ITextBehaviorMixin {
+export abstract class ITextKeyBehaviorMixin<
+  EventSpec extends ObjectEvents
+> extends ITextBehaviorMixin<EventSpec> {
   /**
    * For functionalities on keyDown
    * Map a special key to a function of the instance/prototype

--- a/src/mixins/object_geometry.mixin.ts
+++ b/src/mixins/object_geometry.mixin.ts
@@ -23,7 +23,7 @@ import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { sin } from '../util/misc/sin';
 import { Canvas, StaticCanvas } from '../__types__';
 import { ObjectOrigin } from './object_origin.mixin';
-import { ObjectEventsSpec } from '../EventTypeDefs';
+import { ObjectEvents } from '../EventTypeDefs';
 
 type TLineDescriptor = {
   o: Point;
@@ -45,7 +45,7 @@ type TMatrixCache = {
 type TACoords = TCornerPoint;
 
 export class ObjectGeometry<
-  EventSpec extends ObjectEventsSpec = ObjectEventsSpec
+  EventSpec extends ObjectEvents = ObjectEvents
 > extends ObjectOrigin<EventSpec> {
   /**
    * When true, an object is rendered as flipped horizontally

--- a/src/mixins/object_geometry.mixin.ts
+++ b/src/mixins/object_geometry.mixin.ts
@@ -23,6 +23,7 @@ import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { sin } from '../util/misc/sin';
 import { Canvas, StaticCanvas } from '../__types__';
 import { ObjectOrigin } from './object_origin.mixin';
+import { TObjectEvents } from '../EventTypeDefs';
 
 type TLineDescriptor = {
   o: Point;
@@ -43,7 +44,9 @@ type TMatrixCache = {
 
 type TACoords = TCornerPoint;
 
-export class ObjectGeometry extends ObjectOrigin {
+export class ObjectGeometry<
+  T extends TObjectEvents = TObjectEvents
+> extends ObjectOrigin<T> {
   /**
    * When true, an object is rendered as flipped horizontally
    * @type Boolean

--- a/src/mixins/object_geometry.mixin.ts
+++ b/src/mixins/object_geometry.mixin.ts
@@ -23,7 +23,7 @@ import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { sin } from '../util/misc/sin';
 import { Canvas, StaticCanvas } from '../__types__';
 import { ObjectOrigin } from './object_origin.mixin';
-import { TObjectEvents } from '../EventTypeDefs';
+import { ObjectEventsSpec } from '../EventTypeDefs';
 
 type TLineDescriptor = {
   o: Point;
@@ -45,8 +45,8 @@ type TMatrixCache = {
 type TACoords = TCornerPoint;
 
 export class ObjectGeometry<
-  T extends TObjectEvents = TObjectEvents
-> extends ObjectOrigin<T> {
+  EventSpec extends ObjectEventsSpec = ObjectEventsSpec
+> extends ObjectOrigin<EventSpec> {
   /**
    * When true, an object is rendered as flipped horizontally
    * @type Boolean

--- a/src/mixins/object_interactivity.mixin.ts
+++ b/src/mixins/object_interactivity.mixin.ts
@@ -11,7 +11,7 @@ import {
 import { ObjectGeometry } from './object_geometry.mixin';
 import type { Control } from '../controls/control.class';
 import { sizeAfterTransform } from '../util/misc/objectTransforms';
-import { ObjectEventsSpec } from '../EventTypeDefs';
+import { ObjectEvents } from '../EventTypeDefs';
 
 type TOCoord = IPoint & {
   corner: TCornerPoint;
@@ -21,7 +21,7 @@ type TOCoord = IPoint & {
 type TControlSet = Record<string, Control>;
 
 export class InteractiveFabricObject<
-  EventSpec extends ObjectEventsSpec = ObjectEventsSpec
+  EventSpec extends ObjectEvents = ObjectEvents
 > extends FabricObject<EventSpec> {
   /**
    * Describe object's corner position in canvas element coordinates.

--- a/src/mixins/object_interactivity.mixin.ts
+++ b/src/mixins/object_interactivity.mixin.ts
@@ -11,6 +11,7 @@ import {
 import { ObjectGeometry } from './object_geometry.mixin';
 import type { Control } from '../controls/control.class';
 import { sizeAfterTransform } from '../util/misc/objectTransforms';
+import { TObjectEvents } from '../EventTypeDefs';
 
 type TOCoord = IPoint & {
   corner: TCornerPoint;
@@ -19,7 +20,9 @@ type TOCoord = IPoint & {
 
 type TControlSet = Record<string, Control>;
 
-export class InteractiveFabricObject extends FabricObject {
+export class InteractiveFabricObject<
+  T extends TObjectEvents = TObjectEvents
+> extends FabricObject<T> {
   /**
    * Describe object's corner position in canvas element coordinates.
    * properties are depending on control keys and padding the main controls.

--- a/src/mixins/object_interactivity.mixin.ts
+++ b/src/mixins/object_interactivity.mixin.ts
@@ -11,7 +11,7 @@ import {
 import { ObjectGeometry } from './object_geometry.mixin';
 import type { Control } from '../controls/control.class';
 import { sizeAfterTransform } from '../util/misc/objectTransforms';
-import { TObjectEvents } from '../EventTypeDefs';
+import { ObjectEventsSpec } from '../EventTypeDefs';
 
 type TOCoord = IPoint & {
   corner: TCornerPoint;
@@ -21,8 +21,8 @@ type TOCoord = IPoint & {
 type TControlSet = Record<string, Control>;
 
 export class InteractiveFabricObject<
-  T extends TObjectEvents = TObjectEvents
-> extends FabricObject<T> {
+  EventSpec extends ObjectEventsSpec = ObjectEventsSpec
+> extends FabricObject<EventSpec> {
   /**
    * Describe object's corner position in canvas element coordinates.
    * properties are depending on control keys and padding the main controls.

--- a/src/mixins/object_origin.mixin.ts
+++ b/src/mixins/object_origin.mixin.ts
@@ -5,7 +5,7 @@ import { CommonMethods } from './shared_methods.mixin';
 import { TDegree, TOriginX, TOriginY } from '../typedefs';
 import { Group } from '../shapes/group.class';
 import { sizeAfterTransform } from '../util/misc/objectTransforms';
-import { TObjectEvents } from './EventTypeDefs';
+import { TObjectEvents } from '../EventTypeDefs';
 
 const originOffset = {
   left: -0.5,
@@ -28,7 +28,7 @@ export const resolveOrigin = (
     ? originOffset[originValue]
     : originValue - 0.5;
 
-export class ObjectOrigin extends CommonMethods<TObjectEvents> {
+export class ObjectOrigin<T> extends CommonMethods<T> {
   /**
    * Top position of an object. Note that by default it's relative to object top. You can change this by setting originY={top/center/bottom}
    * @type Number

--- a/src/mixins/object_origin.mixin.ts
+++ b/src/mixins/object_origin.mixin.ts
@@ -1,5 +1,5 @@
 import { Point } from '../point.class';
-import { Group } from '../shapes/group.class';
+import type { Group } from '../shapes/group.class';
 import { TDegree, TOriginX, TOriginY } from '../typedefs';
 import { transformPoint } from '../util/misc/matrix';
 import { sizeAfterTransform } from '../util/misc/objectTransforms';

--- a/src/mixins/object_origin.mixin.ts
+++ b/src/mixins/object_origin.mixin.ts
@@ -1,11 +1,10 @@
 import { Point } from '../point.class';
+import { Group } from '../shapes/group.class';
+import { TDegree, TOriginX, TOriginY } from '../typedefs';
 import { transformPoint } from '../util/misc/matrix';
+import { sizeAfterTransform } from '../util/misc/objectTransforms';
 import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { CommonMethods } from './shared_methods.mixin';
-import { TDegree, TOriginX, TOriginY } from '../typedefs';
-import { Group } from '../shapes/group.class';
-import { sizeAfterTransform } from '../util/misc/objectTransforms';
-import { ObjectEventsSpec } from '../EventTypeDefs';
 
 const originOffset = {
   left: -0.5,

--- a/src/mixins/object_origin.mixin.ts
+++ b/src/mixins/object_origin.mixin.ts
@@ -5,6 +5,7 @@ import { CommonMethods } from './shared_methods.mixin';
 import { TDegree, TOriginX, TOriginY } from '../typedefs';
 import { Group } from '../shapes/group.class';
 import { sizeAfterTransform } from '../util/misc/objectTransforms';
+import { TObjectEvents } from './EventTypeDefs';
 
 const originOffset = {
   left: -0.5,
@@ -27,7 +28,7 @@ export const resolveOrigin = (
     ? originOffset[originValue]
     : originValue - 0.5;
 
-export class ObjectOrigin extends CommonMethods {
+export class ObjectOrigin extends CommonMethods<TObjectEvents> {
   /**
    * Top position of an object. Note that by default it's relative to object top. You can change this by setting originY={top/center/bottom}
    * @type Number

--- a/src/mixins/object_origin.mixin.ts
+++ b/src/mixins/object_origin.mixin.ts
@@ -5,7 +5,7 @@ import { CommonMethods } from './shared_methods.mixin';
 import { TDegree, TOriginX, TOriginY } from '../typedefs';
 import { Group } from '../shapes/group.class';
 import { sizeAfterTransform } from '../util/misc/objectTransforms';
-import { TObjectEvents } from '../EventTypeDefs';
+import { ObjectEventsSpec } from '../EventTypeDefs';
 
 const originOffset = {
   left: -0.5,
@@ -28,7 +28,7 @@ export const resolveOrigin = (
     ? originOffset[originValue]
     : originValue - 0.5;
 
-export class ObjectOrigin<T> extends CommonMethods<T> {
+export class ObjectOrigin<EventSpec> extends CommonMethods<EventSpec> {
   /**
    * Top position of an object. Note that by default it's relative to object top. You can change this by setting originY={top/center/bottom}
    * @type Number

--- a/src/mixins/observable.mixin.ts
+++ b/src/mixins/observable.mixin.ts
@@ -2,7 +2,10 @@ import { fabric } from '../../HEADER';
 
 export type TEventCallback<T = any> = (options: T) => any;
 
-type EventRegistryObject<T = any> = Record<string, TEventCallback<T>>;
+type EventRegistryObject<
+  K extends string | number | symbol = string,
+  E = any
+> = Record<K, TEventCallback<E>>;
 
 /**
  * @tutorial {@link http://fabricjs.com/fabric-intro-part-2#events}
@@ -24,11 +27,15 @@ export class Observable<EventSpec> {
     eventName: K,
     handler: TEventCallback<E>
   ): VoidFunction;
-  on<K extends keyof EventSpec, E extends EventSpec[K]>(
-    handlers: EventRegistryObject<E>
+  on<K extends string, E>(
+    eventName: K,
+    handler: TEventCallback<E>
   ): VoidFunction;
   on<K extends keyof EventSpec, E extends EventSpec[K]>(
-    arg0: K | EventRegistryObject<E>,
+    handlers: EventRegistryObject<K, E>
+  ): VoidFunction;
+  on<K extends keyof EventSpec, E extends EventSpec[K]>(
+    arg0: K | EventRegistryObject<K, E>,
     handler?: TEventCallback<E>
   ): VoidFunction {
     if (!this.__eventListeners) {
@@ -65,11 +72,15 @@ export class Observable<EventSpec> {
     eventName: K,
     handler: TEventCallback<E>
   ): VoidFunction;
-  once<K extends keyof EventSpec, E extends EventSpec[K]>(
-    handlers: EventRegistryObject<E>
+  once<K extends string, E>(
+    eventName: K,
+    handler: TEventCallback<E>
   ): VoidFunction;
   once<K extends keyof EventSpec, E extends EventSpec[K]>(
-    arg0: K | EventRegistryObject<E>,
+    handlers: EventRegistryObject<K, E>
+  ): VoidFunction;
+  once<K extends keyof EventSpec, E extends EventSpec[K]>(
+    arg0: K | EventRegistryObject<K, E>,
     handler?: TEventCallback<E>
   ): VoidFunction {
     if (typeof arg0 === 'object') {

--- a/src/mixins/observable.mixin.ts
+++ b/src/mixins/observable.mixin.ts
@@ -139,7 +139,7 @@ export class Observable<EventMap> {
     // one object with key/value pairs was passed
     else if (typeof arg0 === 'object') {
       for (const eventName in arg0) {
-        this._removeEventListener(eventName, arg0[eventName]);
+        this._removeEventListener(eventName as K, arg0[eventName]);
       }
     } else {
       this._removeEventListener(arg0, handler);

--- a/src/mixins/observable.mixin.ts
+++ b/src/mixins/observable.mixin.ts
@@ -8,9 +8,9 @@ type EventRegistryObject<T = any> = Record<string, TEventCallback<T>>;
  * @tutorial {@link http://fabricjs.com/fabric-intro-part-2#events}
  * @see {@link http://fabricjs.com/events|Events demo}
  */
-export class Observable<EventMap> {
-  private __eventListeners: Record<keyof EventMap, TEventCallback[]> =
-    {} as Record<keyof EventMap, TEventCallback[]>;
+export class Observable<EventSpec> {
+  private __eventListeners: Record<keyof EventSpec, TEventCallback[]> =
+    {} as Record<keyof EventSpec, TEventCallback[]>;
 
   /**
    * Observes specified event
@@ -20,19 +20,19 @@ export class Observable<EventMap> {
    * @param {Function} handler Function that receives a notification when an event of the specified type occurs
    * @return {Function} disposer
    */
-  on<K extends keyof EventMap, E extends EventMap[K]>(
+  on<K extends keyof EventSpec, E extends EventSpec[K]>(
     eventName: K,
     handler: TEventCallback<E>
   ): VoidFunction;
-  on<K extends keyof EventMap, E extends EventMap[K]>(
+  on<K extends keyof EventSpec, E extends EventSpec[K]>(
     handlers: EventRegistryObject<E>
   ): VoidFunction;
-  on<K extends keyof EventMap, E extends EventMap[K]>(
+  on<K extends keyof EventSpec, E extends EventSpec[K]>(
     arg0: K | EventRegistryObject<E>,
     handler?: TEventCallback<E>
   ): VoidFunction {
     if (!this.__eventListeners) {
-      this.__eventListeners = {} as Record<keyof EventMap, TEventCallback[]>;
+      this.__eventListeners = {} as Record<keyof EventSpec, TEventCallback[]>;
     }
     if (typeof arg0 === 'object') {
       // one object with key/value pairs was passed
@@ -61,14 +61,14 @@ export class Observable<EventMap> {
    * @param {Function} handler Function that receives a notification when an event of the specified type occurs
    * @return {Function} disposer
    */
-  once<K extends keyof EventMap, E extends EventMap[K]>(
+  once<K extends keyof EventSpec, E extends EventSpec[K]>(
     eventName: K,
     handler: TEventCallback<E>
   ): VoidFunction;
-  once<K extends keyof EventMap, E extends EventMap[K]>(
+  once<K extends keyof EventSpec, E extends EventSpec[K]>(
     handlers: EventRegistryObject<E>
   ): VoidFunction;
-  once<K extends keyof EventMap, E extends EventMap[K]>(
+  once<K extends keyof EventSpec, E extends EventSpec[K]>(
     arg0: K | EventRegistryObject<E>,
     handler?: TEventCallback<E>
   ): VoidFunction {
@@ -96,7 +96,7 @@ export class Observable<EventMap> {
    * @param {string} eventName
    * @param {Function} [handler]
    */
-  private _removeEventListener<K extends keyof EventMap>(
+  private _removeEventListener<K extends keyof EventSpec>(
     eventName: K,
     handler?: TEventCallback
   ) {
@@ -120,9 +120,9 @@ export class Observable<EventMap> {
    * @param {EventRegistryObject} handlers key/value pairs (eg. {'after:render': handler, 'selection:cleared': handler})
    * @param {Function} handler Function to be deleted from EventListeners
    */
-  off<K extends keyof EventMap>(eventName: K, handler: TEventCallback): void;
+  off<K extends keyof EventSpec>(eventName: K, handler: TEventCallback): void;
   off(handlers: EventRegistryObject): void;
-  off<K extends keyof EventMap>(
+  off<K extends keyof EventSpec>(
     arg0?: K | EventRegistryObject,
     handler?: TEventCallback
   ) {
@@ -151,7 +151,7 @@ export class Observable<EventMap> {
    * @param {String} eventName Event name to fire
    * @param {Object} [options] Options object
    */
-  fire<K extends keyof EventMap>(eventName: K, options?: EventMap[K]) {
+  fire<K extends keyof EventSpec>(eventName: K, options?: EventSpec[K]) {
     if (!this.__eventListeners) {
       return;
     }

--- a/src/mixins/shared_methods.mixin.ts
+++ b/src/mixins/shared_methods.mixin.ts
@@ -1,7 +1,7 @@
 //@ts-nocheck
 import { Observable } from './observable.mixin';
 
-export class CommonMethods extends Observable {
+export class CommonMethods<T> extends Observable<T> {
   /**
    * Sets object's properties from options
    * @param {Object} [options] Options object

--- a/src/mixins/shared_methods.mixin.ts
+++ b/src/mixins/shared_methods.mixin.ts
@@ -1,7 +1,7 @@
 //@ts-nocheck
 import { Observable } from './observable.mixin';
 
-export class CommonMethods<T> extends Observable<T> {
+export class CommonMethods<EventSpec> extends Observable<EventSpec> {
   /**
    * Sets object's properties from options
    * @param {Object} [options] Options object

--- a/src/mixins/text_style.mixin.ts
+++ b/src/mixins/text_style.mixin.ts
@@ -1,3 +1,4 @@
+import { ObjectEvents } from '../EventTypeDefs';
 import { FabricObject } from '../shapes/fabricObject.class';
 
 export type TextStyleDeclaration = Record<string, any>;
@@ -6,7 +7,9 @@ export type TextStyle = {
   [line: number | string]: { [char: number | string]: TextStyleDeclaration };
 };
 
-export abstract class TextStyleMixin extends FabricObject {
+export abstract class TextStyleMixin<
+  EventSpec extends ObjectEvents
+> extends FabricObject<EventSpec> {
   abstract styles: TextStyle;
   protected abstract _textLines: string[][];
   protected abstract _forceClearCache: boolean;

--- a/src/shapes/group.class.ts
+++ b/src/shapes/group.class.ts
@@ -28,7 +28,7 @@ export type LayoutResult = {
   height: number;
 };
 
-export type GroupEventsSpec = TObjectEvents & {
+export type GroupEvents = TObjectEvents & {
   layout: {
     context: LayoutContext;
     result: LayoutResult;
@@ -36,7 +36,7 @@ export type GroupEventsSpec = TObjectEvents & {
   };
 };
 
-export class Group extends FabricObject<GroupEventsSpec> {}
+export class Group extends FabricObject<GroupEvents> {}
 
 (function (global) {
   var fabric = global.fabric || (global.fabric = {}),

--- a/src/shapes/group.class.ts
+++ b/src/shapes/group.class.ts
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import { TObjectEvents } from '../EventTypeDefs';
+import { ObjectEvents } from '../EventTypeDefs';
 import { createCollectionMixin } from '../mixins/collection.mixin';
 import { resolveOrigin } from '../mixins/object_origin.mixin';
 import { Point } from '../point.class';
@@ -29,7 +29,7 @@ export type LayoutResult = {
   height: number;
 };
 
-export type GroupEvents = TObjectEvents & {
+export type GroupEvents = ObjectEvents & {
   layout: {
     context: LayoutContext;
     result: LayoutResult;

--- a/src/shapes/group.class.ts
+++ b/src/shapes/group.class.ts
@@ -3,6 +3,36 @@ import { Point } from '../point.class';
 import { FabricObject } from './fabricObject.class';
 import { resolveOrigin } from '../mixins/object_origin.mixin';
 
+export type LayoutContextType =
+  | 'initialization'
+  | 'object_modified'
+  | 'added'
+  | 'removed'
+  | 'layout_change'
+  | 'imperative';
+
+export type LayoutContext = {
+  type: LayoutContextType;
+  /**
+   * array of objects starting from the object that triggered the call to the current one
+   */
+  path?: Group[];
+  [key: string]: any;
+};
+
+export type LayoutResult = {
+  centerX: number;
+  centerY: number;
+  width: number;
+  height: number;
+};
+
+export type LayoutEventData = {
+  context: LayoutContext;
+  result: LayoutResult;
+  diff: Point;
+};
+
 export class Group extends FabricObject {}
 
 (function (global) {

--- a/src/shapes/group.class.ts
+++ b/src/shapes/group.class.ts
@@ -50,6 +50,8 @@ export type GroupEvents = ObjectEvents & {
     result: LayoutResult;
     diff: Point;
   };
+  'object:added': { target: FabricObject };
+  'object:removed': { target: FabricObject };
 };
 
 export type LayoutStrategy =
@@ -87,7 +89,7 @@ export type LayoutResult = {
  * @fires object:removed
  * @fires layout once layout completes
  */
-export class Group extends createCollectionMixin(FabricObject) {
+export class Group extends createCollectionMixin(FabricObject<GroupEvents>) {
   /**
    * Specifies the **layout strategy** for instance
    * Used by `getLayoutStrategyResult` to calculate layout

--- a/src/shapes/group.class.ts
+++ b/src/shapes/group.class.ts
@@ -1,8 +1,8 @@
 //@ts-nocheck
+import { TObjectEvents } from '../EventTypeDefs';
+import { resolveOrigin } from '../mixins/object_origin.mixin';
 import { Point } from '../point.class';
 import { FabricObject } from './fabricObject.class';
-import { resolveOrigin } from '../mixins/object_origin.mixin';
-import { TObjectEvents } from '../EventTypeDefs';
 
 export type LayoutContextType =
   | 'initialization'

--- a/src/shapes/group.class.ts
+++ b/src/shapes/group.class.ts
@@ -2,6 +2,7 @@
 import { Point } from '../point.class';
 import { FabricObject } from './fabricObject.class';
 import { resolveOrigin } from '../mixins/object_origin.mixin';
+import { TObjectEvents } from '../EventTypeDefs';
 
 export type LayoutContextType =
   | 'initialization'
@@ -27,13 +28,15 @@ export type LayoutResult = {
   height: number;
 };
 
-export type LayoutEventData = {
-  context: LayoutContext;
-  result: LayoutResult;
-  diff: Point;
+export type GroupEvents = TObjectEvents & {
+  layout: {
+    context: LayoutContext;
+    result: LayoutResult;
+    diff: Point;
+  };
 };
 
-export class Group extends FabricObject {}
+export class Group extends FabricObject<GroupEvents> {}
 
 (function (global) {
   var fabric = global.fabric || (global.fabric = {}),

--- a/src/shapes/group.class.ts
+++ b/src/shapes/group.class.ts
@@ -28,7 +28,7 @@ export type LayoutResult = {
   height: number;
 };
 
-export type GroupEvents = TObjectEvents & {
+export type GroupEventsSpec = TObjectEvents & {
   layout: {
     context: LayoutContext;
     result: LayoutResult;
@@ -36,7 +36,7 @@ export type GroupEvents = TObjectEvents & {
   };
 };
 
-export class Group extends FabricObject<GroupEvents> {}
+export class Group extends FabricObject<GroupEventsSpec> {}
 
 (function (global) {
   var fabric = global.fabric || (global.fabric = {}),

--- a/src/shapes/itext.class.ts
+++ b/src/shapes/itext.class.ts
@@ -2,7 +2,7 @@
 import { TObjectEvents, XTransformEvent } from '../EventTypeDefs';
 import { FabricObject } from './fabricObject.class';
 
-export type ITextEvents = TObjectEvents & {
+export type ITextEventsSpec = TObjectEvents & {
   'selection:changed': never;
   changed: never;
   tripleclick: XTransformEvent;

--- a/src/shapes/itext.class.ts
+++ b/src/shapes/itext.class.ts
@@ -64,7 +64,7 @@ export type ITextEvents = ObjectEvents & {
  *   Select line:                    triple click
  * </pre>
  */
-export class IText extends ITextClickBehaviorMixin {
+export class IText extends ITextClickBehaviorMixin<ITextEvents> {
   /**
    * Index where text selection starts (or where cursor is when there is no selection)
    * @type Number

--- a/src/shapes/itext.class.ts
+++ b/src/shapes/itext.class.ts
@@ -1,5 +1,12 @@
-//@ts-nocheck
+// @ts-nocheck
+import { TObjectEvents, XTransformEvent } from '../EventTypeDefs';
 import { FabricObject } from './fabricObject.class';
+
+export type ITextEvents = TObjectEvents & {
+  'selection:changed': never;
+  changed: never;
+  tripleclick: XTransformEvent;
+};
 
 (function (global) {
   var fabric = global.fabric;

--- a/src/shapes/itext.class.ts
+++ b/src/shapes/itext.class.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
-import { TObjectEvents, TransformEvent } from '../EventTypeDefs';
 import { fabric } from '../../HEADER';
+import { ObjectEvents, TransformEvent } from '../EventTypeDefs';
 import { TClassProperties, TFiller } from '../typedefs';
 import { stylesFromArray } from '../util/misc/textStyles';
 import { FabricObject } from './fabricObject.class';
 import { Text } from './text.class';
 
-export type ITextEvents = TObjectEvents & {
+export type ITextEvents = ObjectEvents & {
   'selection:changed': never;
   changed: never;
   tripleclick: TransformEvent;

--- a/src/shapes/itext.class.ts
+++ b/src/shapes/itext.class.ts
@@ -2,7 +2,7 @@
 import { TObjectEvents, XTransformEvent } from '../EventTypeDefs';
 import { FabricObject } from './fabricObject.class';
 
-export type ITextEventsSpec = TObjectEvents & {
+export type ITextEvents = TObjectEvents & {
   'selection:changed': never;
   changed: never;
   tripleclick: XTransformEvent;

--- a/src/shapes/itext.class.ts
+++ b/src/shapes/itext.class.ts
@@ -1,11 +1,11 @@
 // @ts-nocheck
-import { TObjectEvents, XTransformEvent } from '../EventTypeDefs';
+import { TObjectEvents, TransformEvent } from '../EventTypeDefs';
 import { FabricObject } from './fabricObject.class';
 
 export type ITextEvents = TObjectEvents & {
   'selection:changed': never;
   changed: never;
-  tripleclick: XTransformEvent;
+  tripleclick: TransformEvent;
 };
 
 (function (global) {

--- a/src/shapes/itext.class.ts
+++ b/src/shapes/itext.class.ts
@@ -10,6 +10,8 @@ export type ITextEvents = TObjectEvents & {
   'selection:changed': never;
   changed: never;
   tripleclick: TransformEvent;
+  'editing:entered': never;
+  'editing:exited': never;
 };
 
 /**

--- a/src/shapes/object.class.ts
+++ b/src/shapes/object.class.ts
@@ -17,7 +17,7 @@ import { createCanvasElement } from '../util/misc/dom';
 import { ObjectGeometry } from '../mixins/object_geometry.mixin';
 import { qrDecompose, transformPoint } from '../util/misc/matrix';
 import { Canvas, Shadow, StaticCanvas } from '../__types__';
-import { TObjectEvents } from '../EventTypeDefs';
+import { ObjectEventsSpec } from '../EventTypeDefs';
 
 // temporary hack for unfinished migration
 type TCallSuper = (arg0: string, ...moreArgs: any[]) => any;
@@ -55,8 +55,8 @@ const ALIASING_LIMIT = 2;
  * @fires drop
  */
 export class FabricObject<
-  T extends TObjectEvents = TObjectEvents
-> extends ObjectGeometry<T> {
+  EventSpec extends ObjectEventsSpec = ObjectEventsSpec
+> extends ObjectGeometry<EventSpec> {
   type: string;
 
   /**

--- a/src/shapes/object.class.ts
+++ b/src/shapes/object.class.ts
@@ -17,7 +17,7 @@ import { createCanvasElement } from '../util/misc/dom';
 import { ObjectGeometry } from '../mixins/object_geometry.mixin';
 import { qrDecompose, transformPoint } from '../util/misc/matrix';
 import { Canvas, Shadow, StaticCanvas } from '../__types__';
-import { ObjectEventsSpec } from '../EventTypeDefs';
+import { ObjectEvents } from '../EventTypeDefs';
 
 // temporary hack for unfinished migration
 type TCallSuper = (arg0: string, ...moreArgs: any[]) => any;
@@ -55,7 +55,7 @@ const ALIASING_LIMIT = 2;
  * @fires drop
  */
 export class FabricObject<
-  EventSpec extends ObjectEventsSpec = ObjectEventsSpec
+  EventSpec extends ObjectEvents = ObjectEvents
 > extends ObjectGeometry<EventSpec> {
   type: string;
 

--- a/src/shapes/object.class.ts
+++ b/src/shapes/object.class.ts
@@ -17,6 +17,7 @@ import { createCanvasElement } from '../util/misc/dom';
 import { ObjectGeometry } from '../mixins/object_geometry.mixin';
 import { qrDecompose, transformPoint } from '../util/misc/matrix';
 import { Canvas, Shadow, StaticCanvas } from '../__types__';
+import { TObjectEvents } from '../EventTypeDefs';
 
 // temporary hack for unfinished migration
 type TCallSuper = (arg0: string, ...moreArgs: any[]) => any;
@@ -34,17 +35,12 @@ const ALIASING_LIMIT = 2;
  *
  * @fires selected
  * @fires deselected
- * @fires modified
- * @fires modified
- * @fires moved
- * @fires scaled
- * @fires rotated
- * @fires skewed
  *
  * @fires rotating
  * @fires scaling
  * @fires moving
  * @fires skewing
+ * @fires modified
  *
  * @fires mousedown
  * @fires mouseup
@@ -58,7 +54,9 @@ const ALIASING_LIMIT = 2;
  * @fires dragleave
  * @fires drop
  */
-export class FabricObject extends ObjectGeometry {
+export class FabricObject<
+  T extends TObjectEvents = TObjectEvents
+> extends ObjectGeometry<T> {
   type: string;
 
   /**

--- a/src/shapes/text.class.ts
+++ b/src/shapes/text.class.ts
@@ -2,6 +2,7 @@
 import { fabric } from '../../HEADER';
 import { cache } from '../cache';
 import { DEFAULT_SVG_FONT_SIZE } from '../constants';
+import { ObjectEvents } from '../EventTypeDefs';
 import { TextStyle, TextStyleMixin } from '../mixins/text_style.mixin';
 import { TClassProperties, TFiller } from '../typedefs';
 import { graphemeSplit } from '../util/lang_string';
@@ -57,7 +58,9 @@ const additionalProps = [
  * @tutorial {@link http://fabricjs.com/fabric-intro-part-2#text}
  * @see {@link Text#initialize} for constructor definition
  */
-export class Text extends TextStyleMixin {
+export class Text<
+  EventSpec extends ObjectEvents = ObjectEvents
+> extends TextStyleMixin<EventSpec> {
   /**
    * Properties which when set cause object to change dimensions
    * @type Array

--- a/src/static_canvas.class.ts
+++ b/src/static_canvas.class.ts
@@ -1,6 +1,7 @@
 //@ts-nocheck
 import { config } from './config';
 import { VERSION } from './constants';
+import { CanvasEvents } from './EventTypeDefs';
 import { createCollectionMixin } from './mixins/collection.mixin';
 import { CommonMethods } from './mixins/shared_methods.mixin';
 import { Point } from './point.class';
@@ -34,7 +35,7 @@ import { pick } from './util/misc/pick';
    */
   // eslint-disable-next-line max-len
   fabric.StaticCanvas = fabric.util.createClass(
-    class extends createCollectionMixin(CommonMethods) {
+    class extends createCollectionMixin(CommonMethods<CanvasEvents>) {
       add(...objects: FabricObject[]) {
         super.add(...objects);
         objects.length > 0 && this.renderOnAddRemove && this.requestRenderAll();

--- a/src/static_canvas.class.ts
+++ b/src/static_canvas.class.ts
@@ -1,7 +1,6 @@
 //@ts-nocheck
 import { config } from './config';
 import { VERSION } from './constants';
-import { CanvasEvents } from './EventTypeDefs';
 import { createCollectionMixin } from './mixins/collection.mixin';
 import { CommonMethods } from './mixins/shared_methods.mixin';
 import { Point } from './point.class';
@@ -35,7 +34,7 @@ import { pick } from './util/misc/pick';
    */
   // eslint-disable-next-line max-len
   fabric.StaticCanvas = fabric.util.createClass(
-    class extends createCollectionMixin(CommonMethods<CanvasEvents>) {
+    class extends createCollectionMixin(CommonMethods) {
       add(...objects: FabricObject[]) {
         super.add(...objects);
         objects.length > 0 && this.renderOnAddRemove && this.requestRenderAll();

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -71,12 +71,12 @@ export const enum SupportedSVGUnit {
 
 export type TMat2D = [number, number, number, number, number, number];
 
-export type ModifierKey = 'altKey' | 'shiftKey' | 'ctrlKey';
-
 /**
  * SVG path commands
  */
 export type PathData = (string | number)[][];
+
+export type ModifierKey = 'altKey' | 'shiftKey' | 'ctrlKey';
 
 export type TPointerEvent = MouseEvent | TouchEvent;
 

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -131,7 +131,7 @@ export type TEvent<E extends Event = TPointerEvent> = {
   e: E;
 };
 
-export type TransformEvent = TEvent & {
+export type TransformEvent<E extends Event = TPointerEvent> = TEvent<E> & {
   transform: Transform;
   pointer: Point;
 };

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -1,10 +1,7 @@
 // https://www.typescriptlang.org/docs/handbook/utility-types.html
-import type { Control } from './controls/control.class';
 import type { Gradient } from './gradient/gradient.class';
 import type { Pattern } from './pattern.class';
 import type { Point } from './point.class';
-import type { FabricObject } from './shapes/fabricObject.class';
-import type { saveObjectTransform } from './util/misc/objectTransforms';
 
 interface NominalTag<T> {
   nominalTag?: T;
@@ -75,66 +72,6 @@ export type TMat2D = [number, number, number, number, number, number];
  * SVG path commands
  */
 export type PathData = (string | number)[][];
-
-export type ModifierKey = 'altKey' | 'shiftKey' | 'ctrlKey';
-
-export type TPointerEvent = MouseEvent | TouchEvent;
-
-export type TransformAction<T extends Transform = Transform, R = void> = (
-  eventData: TPointerEvent,
-  transform: T,
-  x: number,
-  y: number
-) => R;
-
-export type TransformActionHandler<T extends Transform = Transform> =
-  TransformAction<T, boolean>;
-
-export type ControlCallback<R = void> = (
-  eventData: TPointerEvent,
-  control: Control,
-  fabricObject: FabricObject
-) => R;
-
-export type ControlCursorCallback = ControlCallback<string>;
-
-/**
- * relative to target's containing coordinate plane
- * both agree on every point
- */
-export type Transform = {
-  target: FabricObject;
-  action: string;
-  actionHandler: TransformActionHandler;
-  corner: string;
-  scaleX: number;
-  scaleY: number;
-  skewX: number;
-  skewY: number;
-  offsetX: number;
-  offsetY: number;
-  originX: TOriginX;
-  originY: TOriginY;
-  ex: number;
-  ey: number;
-  lastX: number;
-  lastY: number;
-  theta: TRadian;
-  width: number;
-  height: number;
-  shiftKey: boolean;
-  altKey: boolean;
-  original: ReturnType<typeof saveObjectTransform>;
-};
-
-export type TEvent<E extends Event = TPointerEvent> = {
-  e: E;
-};
-
-export type TransformEvent<E extends Event = TPointerEvent> = TEvent<E> & {
-  transform: Transform;
-  pointer: Point;
-};
 
 /**
  * An invalid keyword and an empty string will be handled as the `anonymous` keyword.

--- a/src/util/fireEvent.ts
+++ b/src/util/fireEvent.ts
@@ -1,5 +1,4 @@
-import { TModificationEvents } from '../EventTypeDefs';
-import { TransformEvent } from '../typedefs';
+import { TModificationEvents, TransformEvent } from '../EventTypeDefs';
 
 export const fireEvent = (
   eventName: TModificationEvents,

--- a/src/util/fireEvent.ts
+++ b/src/util/fireEvent.ts
@@ -1,8 +1,8 @@
-import { TModificationEvents, TransformEvent } from '../EventTypeDefs';
+import { TModificationEvents, BasicTransformEvent } from '../EventTypeDefs';
 
 export const fireEvent = (
   eventName: TModificationEvents,
-  options: TransformEvent
+  options: BasicTransformEvent
 ) => {
   const {
     transform: { target },

--- a/src/util/fireEvent.ts
+++ b/src/util/fireEvent.ts
@@ -1,6 +1,10 @@
+import { TModificationEvents } from '../mixins/EventTypeDefs';
 import { TransformEvent } from '../typedefs';
 
-export const fireEvent = (eventName: string, options: TransformEvent) => {
+export const fireEvent = (
+  eventName: TModificationEvents,
+  options: TransformEvent
+) => {
   const {
     transform: { target },
   } = options;

--- a/src/util/fireEvent.ts
+++ b/src/util/fireEvent.ts
@@ -1,4 +1,4 @@
-import { TModificationEvents } from '../mixins/EventTypeDefs';
+import { TModificationEvents } from '../EventTypeDefs';
 import { TransformEvent } from '../typedefs';
 
 export const fireEvent = (

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -332,22 +332,24 @@
   });
 
   QUnit.test('before:selection:cleared gets target the active object', function(assert) {
-    var passedTarget;
+    var deselected;
     canvas.on('before:selection:cleared', function(options) {
-      passedTarget = options.target;
+      deselected = options.deselected;
     });
     var rect = new fabric.Rect();
     canvas.add(rect);
     canvas.setActiveObject(rect);
     canvas.discardActiveObject();
-    assert.equal(passedTarget, rect, 'options.target was the removed object');
+    assert.equal(deselected.length, 1, 'options.deselected was the removed object');
+    assert.equal(deselected[0], rect, 'options.deselected was the removed object');
     var rect1 = new fabric.Rect();
     var rect2 = new fabric.Rect();
     canvas.add(rect1, rect2);
     var activeSelection = new fabric.ActiveSelection([rect1, rect2], { canvas: canvas });
     canvas.setActiveObject(activeSelection);
     canvas.discardActiveObject();
-    assert.equal(passedTarget, activeSelection, 'removing an activeSelection pass that as a target');
+    assert.equal(deselected.length, 1, 'options.deselected was the removed object');
+    assert.equal(deselected[0], activeSelection, 'removing an activeSelection pass that as a target');
   });
 
   QUnit.test('selection:cleared', function(assert) {


### PR DESCRIPTION
## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

Enforce strict typing for events handlers in the Observables.

## Description

~~This PR showcases the pros of TS.~~
~~With it using the observable is so easy and fun.~~
~~Found a few discrepancies in the code and fixed them.~~

This PR add a type definition file that describes in minute detail every event fired by fabricJS.
Events are divided by kind, transformation events, selection events, canvas/group events ( add and remove from the object tree), and interaction events.

Every class then takes a dynamic type of event type that is used to bring down to Observable class the type of event that will fire.

Doing so when using the on function for example, Typescript will be able to suggest what events are available and what options are available in the callback.

There are no functional changes on top of that, apart some event property change that has been found clashing with types and so fixed.
The changed events are:
- after:render, added the ctx property to the callback
- selection:cleared, fixed the last instance that was using target instead of deselected
- before:selection:cleared, changed from target to deselected ( those were all `target` but it seems to me that `deselected` makes more sense )

<!-- What you are proposing -->

## Changes

- fix some events that were fired with missing/wrong data 

## Gist

<!-- Technical stuff if necessary -->

## In Action


![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/34343793/200867692-1ae211b7-98ea-4bd8-a658-f43ad63a2fcd.gif)

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
