### PR TITLE
fix(Itext): show incorrect pointer position after scale changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Itext): show incorrect pointer position after scale changed
 - chore(TS): migrate text classes/mixins [#8408](https://github.com/fabricjs/fabric.js/pull/8408)
 - chore(TS): migrate Collection [#8433](https://github.com/fabricjs/fabric.js/pull/8433)
 - ci(): Simplify filestats even more [#8449](https://github.com/fabricjs/fabric.js/pull/8449)

--- a/src/mixins/itext_click_behavior.mixin.ts
+++ b/src/mixins/itext_click_behavior.mixin.ts
@@ -249,7 +249,7 @@ export abstract class ITextClickBehaviorMixin extends ITextKeyBehaviorMixin {
       lineIndex = 0;
     for (let i = 0, len = this._textLines.length; i < len; i++) {
       if (height <= mouseOffset.y) {
-        height += this.getHeightOfLine(i) * this.scaleY;
+        height += this.getHeightOfLine(i);
         lineIndex = i;
         if (i > 0) {
           charIndex +=
@@ -260,20 +260,20 @@ export abstract class ITextClickBehaviorMixin extends ITextKeyBehaviorMixin {
       }
     }
     const lineLeftOffset = Math.abs(this._getLineLeftOffset(lineIndex));
-    let width = lineLeftOffset * this.scaleX;
+    let width = lineLeftOffset;
     const jlen = this._textLines[lineIndex].length;
     // handling of RTL: in order to get things work correctly,
     // we assume RTL writing is mirrored compared to LTR writing.
     // so in position detection we mirror the X offset, and when is time
     // of rendering it, we mirror it again.
     if (this.direction === 'rtl') {
-      mouseOffset.x = this.width * this.scaleX - mouseOffset.x;
+      mouseOffset.x = this.width - mouseOffset.x;
     }
     let prevWidth = 0;
     for (let j = 0; j < jlen; j++) {
       prevWidth = width;
       // i removed something about flipX here, check.
-      width += this.__charBounds[lineIndex][j].kernedWidth * this.scaleX;
+      width += this.__charBounds[lineIndex][j].kernedWidth;
       if (width <= mouseOffset.x) {
         charIndex++;
       } else {

--- a/src/mixins/itext_click_behavior.mixin.ts
+++ b/src/mixins/itext_click_behavior.mixin.ts
@@ -230,9 +230,8 @@ export abstract class ITextClickBehaviorMixin extends ITextKeyBehaviorMixin {
    * @return {Point} Coordinates of a pointer (x, y)
    */
   getLocalPointer(e: TPointerEvent, pointer: IPoint): Point {
-    const thePointer = pointer || this.canvas.getPointer(e);
     return transformPoint(
-      thePointer,
+      pointer || this.canvas.getPointer(e),
       invertTransform(this.calcTransformMatrix())
     ).add(new Point(this.width / 2, this.height / 2));
   }

--- a/test/unit/itext_click_behaviour.js
+++ b/test/unit/itext_click_behaviour.js
@@ -124,6 +124,23 @@
       var selection = iText._getNewSelectionStartFromOffset({ y: 1, x: 1000 }, 500, 520, index, jlen);
       assert.equal(selection, index, 'index value was NOT moved to next char, since is already at end of text');
     });
+    QUnit.test('getSelectionStartFromPointer with scale', function (assert) {
+      const eventData = {
+        which: 1,
+        target: canvas.upperCanvasEl,
+        clientX: 70,
+        clientY: 10
+      };
+      const iText = new fabric.IText('test need some word\nsecond line', { scaleX: 3, scaleY: 2, canvas });
+      assert.equal(iText.getSelectionStartFromPointer(eventData), 2, 'index');
+      assert.equal(iText.getSelectionStartFromPointer({ ...eventData, clientY: 20 }), 2, 'index');
+      iText.set({ scaleX: 0.5, scaleY: 0.25 });
+      assert.equal(iText.getSelectionStartFromPointer(eventData), 9, 'index');
+      assert.equal(iText.getSelectionStartFromPointer({ ...eventData, clientY: 20 }), 29, 'index');
+      iText.set({ scaleX: 1, scaleY: 1 });
+      assert.equal(iText.getSelectionStartFromPointer(eventData), 5, 'index');
+      assert.equal(iText.getSelectionStartFromPointer({ ...eventData, clientY: 20 }), 5, 'index');
+    });
     QUnit.test('_mouseDownHandlerBefore set up selected property', function(assert) {
       var iText = new fabric.IText('test need some word\nsecond line');
       assert.equal(iText.selected, undefined, 'iText has no selected property');


### PR DESCRIPTION
After @ShaMan123 migrated the Pointer.transform util, point already included the scales so no need to multiply object's width/height with scaleX/scaleY

https://user-images.githubusercontent.com/107306319/203584307-4eafca7f-3a47-4800-8691-63c77d487646.mp4 


