### PR TITLE
chore(): refactor `Object.__uid++` => `uid()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): refactor `Object.__uid++` => `uid()` [#8482](https://github.com/fabricjs/fabric.js/pull/8482)
 - chore(TS): migrate object mixins to TS [#8414](https://github.com/fabricjs/fabric.js/pull/8414)
 - chore(TS): migrate filters [#8474](https://github.com/fabricjs/fabric.js/pull/8474)
 - chore(TS): BaseBrush abstract methods [#8428](https://github.com/fabricjs/fabric.js/pull/8428)

--- a/src/gradient/gradient.class.ts
+++ b/src/gradient/gradient.class.ts
@@ -3,7 +3,9 @@ import { fabric } from '../../HEADER';
 import { Color } from '../color';
 import { iMatrix } from '../constants';
 import { parseTransformAttribute } from '../parser/parseTransformAttribute';
+import type { FabricObject } from '../shapes/fabricObject.class';
 import { TMat2D } from '../typedefs';
+import { uid } from '../util/internals/uid';
 import { pick } from '../util/misc/pick';
 import { matrixToSVG } from '../util/misc/svgParsing';
 import { linearDefaultCoords, radialDefaultCoords } from './constants';
@@ -21,7 +23,6 @@ import {
   GradientUnits,
   SVGOptions,
 } from './typedefs';
-import { FabricObject } from '../shapes/fabricObject.class';
 
 /**
  * Gradient class
@@ -90,8 +91,7 @@ export class Gradient<
     gradientTransform,
     id,
   }: GradientOptions<T>) {
-    const uid = FabricObject.__uid++;
-    this.id = id ? `${id}_${uid}` : uid;
+    this.id = id ? `${id}_${uid()}` : uid();
     this.type = type;
     this.gradientUnits = gradientUnits;
     this.gradientTransform = gradientTransform || null;

--- a/src/mixins/eraser_brush.mixin.ts
+++ b/src/mixins/eraser_brush.mixin.ts
@@ -1,5 +1,6 @@
 //@ts-nocheck
 import { Point } from '../point.class';
+import { uid } from '../util/internals/uid';
 
 (function (global) {
   /** ERASER_START */
@@ -105,7 +106,7 @@ import { Point } from '../point.class';
      */
     _createEraserSVGMarkup: function (reviver) {
       if (this.eraser) {
-        this.eraser.clipPathId = 'MASK_' + fabric.Object.__uid++;
+        this.eraser.clipPathId = 'MASK_' + uid();
         return [
           '<mask id="',
           this.eraser.clipPathId,

--- a/src/mixins/object.svg_export.ts
+++ b/src/mixins/object.svg_export.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { Color } from '../color';
 import { config } from '../config';
-import { FabricObject } from '../shapes/fabricObject.class';
+import { uid } from '../util/internals/uid';
 import { matrixToSVG } from '../util/misc/svgParsing';
 import { toFixed } from '../util/misc/toFixed';
 
@@ -266,7 +266,7 @@ export class FabricObjectSVGExportMixin {
       index = objectMarkup.indexOf('COMMON_PARTS');
     let clipPathMarkup;
     if (clipPath) {
-      clipPath.clipPathId = `CLIPPATH_${FabricObject.__uid++}`;
+      clipPath.clipPathId = `CLIPPATH_${uid()}`;
       clipPathMarkup = `<clipPath id="${
         clipPath.clipPathId
       }" >\n${clipPath.toClipPathSVG(reviver)}</clipPath>\n`;

--- a/src/parser/parseSVGDocument.ts
+++ b/src/parser/parseSVGDocument.ts
@@ -1,5 +1,6 @@
 //@ts-nocheck
 
+import { uid } from '../util/internals/uid';
 import { applyViewboxTransform } from './applyViewboxTransform';
 import {
   clipPaths,
@@ -13,7 +14,6 @@ import { getGradientDefs } from './getGradientDefs';
 import { hasAncestorWithNodeName } from './hasAncestorWithNodeName';
 import { parseElements } from './parseElements';
 import { parseUseDirectives } from './parseUseDirectives';
-import { FabricObject } from '../shapes/fabricObject.class';
 
 /**
  * Parses an SVG document, converts it to an array of corresponding fabric.* instances and passes them to a callback
@@ -41,7 +41,7 @@ export function parseSVGDocument(doc, callback, reviver, parsingOptions) {
   }
   parseUseDirectives(doc);
 
-  let svgUid = FabricObject.__uid++,
+  let svgUid = uid(),
     i,
     len,
     options = applyViewboxTransform(doc),

--- a/src/pattern.class.ts
+++ b/src/pattern.class.ts
@@ -4,10 +4,10 @@ import { fabric } from '../HEADER';
 import { config } from './config';
 import { TCrossOrigin, TMat2D, TSize } from './typedefs';
 import { ifNaN } from './util/internals';
+import { uid } from './util/internals/uid';
 import { loadImage } from './util/misc/objectEnlive';
 import { pick } from './util/misc/pick';
 import { toFixed } from './util/misc/toFixed';
-import { FabricObject } from './shapes/fabricObject.class';
 export type TPatternRepeat = 'repeat' | 'repeat-x' | 'repeat-y' | 'no-repeat';
 
 type TExportedKeys =
@@ -85,7 +85,7 @@ export class Pattern {
    * @param {option.source} [source] the pattern source, eventually empty or a drawable
    */
   constructor(options: TPatternOptions = {}) {
-    this.id = FabricObject.__uid++;
+    this.id = uid();
     this.setOptions(options);
   }
 

--- a/src/shadow.class.ts
+++ b/src/shadow.class.ts
@@ -2,8 +2,9 @@ import { fabric } from '../HEADER';
 import { Color } from './color';
 import { config } from './config';
 import { Point } from './point.class';
-import { FabricObject } from './shapes/fabricObject.class';
+import type { FabricObject } from './shapes/fabricObject.class';
 import { TClassProperties } from './typedefs';
+import { uid } from './util/internals/uid';
 import { degreesToRadians } from './util/misc/radiansDegreesConversion';
 import { toFixed } from './util/misc/toFixed';
 import { rotateVector } from './util/misc/vectors';
@@ -75,7 +76,7 @@ export class Shadow {
       this[prop] = options[prop];
     }
 
-    this.id = FabricObject.__uid++;
+    this.id = uid();
   }
 
   /**

--- a/src/shapes/image.class.ts
+++ b/src/shapes/image.class.ts
@@ -1,11 +1,13 @@
 //@ts-nocheck
 import { fabric } from '../../HEADER';
+import * as filters from '../filters';
 import type { BaseFilter } from '../filters/base_filter.class';
 import { getFilterBackend } from '../filters/FilterBackend';
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
 import { TClassProperties, TSize } from '../typedefs';
 import { cleanUpJsdomNode } from '../util/dom_misc';
+import { uid } from '../util/internals/uid';
 import { createCanvasElement } from '../util/misc/dom';
 import { findScaleToCover, findScaleToFit } from '../util/misc/findScaleTo';
 import {
@@ -16,7 +18,6 @@ import {
 } from '../util/misc/objectEnlive';
 import { parsePreserveAspectRatioAttribute } from '../util/misc/svgParsing';
 import { FabricObject, fabricObjectDefaultValues } from './fabricObject.class';
-import * as filters from '../filters';
 
 export type ImageSource =
   | HTMLImageElement
@@ -134,7 +135,7 @@ export class Image extends FabricObject {
   constructor(arg0: ImageSource | string, options: any = {}) {
     super();
     this.filters = [];
-    this.cacheKey = `texture${FabricObject.__uid++}`;
+    this.cacheKey = `texture${uid()}`;
     this.set(options);
     this.setElement(
       (typeof arg0 === 'string' && fabric.document.getElementById(arg0)) ||
@@ -301,7 +302,7 @@ export class Image extends FabricObject {
       return [];
     }
     if (this.hasCrop()) {
-      const clipPathId = FabricObject.__uid++;
+      const clipPathId = uid();
       svgString.push(
         '<clipPath id="imageCrop_' + clipPathId + '">\n',
         '\t<rect x="' +

--- a/src/shapes/object.class.ts
+++ b/src/shapes/object.class.ts
@@ -596,14 +596,6 @@ export class FabricObject<
    */
   ownCaching?: boolean;
 
-  /**
-   * translation of the cacheCanvas away from the center, for subpixel accuracy and crispness
-   * @static
-   * @memberOf fabric.Object
-   * @type Number
-   */
-  static __uid = 0;
-
   callSuper?: TCallSuper;
 
   /**

--- a/src/static_canvas.class.ts
+++ b/src/static_canvas.class.ts
@@ -4,9 +4,10 @@ import { VERSION } from './constants';
 import { createCollectionMixin } from './mixins/collection.mixin';
 import { CommonMethods } from './mixins/shared_methods.mixin';
 import { Point } from './point.class';
-import { FabricObject } from './shapes/fabricObject.class';
+import type { FabricObject } from './shapes/fabricObject.class';
 import { requestAnimFrame } from './util/animate';
 import { removeFromArray } from './util/internals';
+import { uid } from './util/internals/uid';
 import { pick } from './util/misc/pick';
 (function (global) {
   // aliases for faster resolution
@@ -1287,7 +1288,7 @@ import { pick } from './util/misc/pick';
       createSVGClipPathMarkup: function (options) {
         var clipPath = this.clipPath;
         if (clipPath) {
-          clipPath.clipPathId = 'CLIPPATH_' + FabricObject.__uid++;
+          clipPath.clipPathId = 'CLIPPATH_' + uid();
           return (
             '<clipPath id="' +
             clipPath.clipPathId +

--- a/src/util/internals/uid.ts
+++ b/src/util/internals/uid.ts
@@ -1,0 +1,3 @@
+let id = 0;
+
+export const uid = () => id++;

--- a/test/lib/assert.js
+++ b/test/lib/assert.js
@@ -1,10 +1,13 @@
 const SVG_RE = /(SVGID|CLIPPATH|imageCrop)_[0-9]+/gm;
 const SVG_XLINK_HREF_RE = /xlink:href="([^"]*)"/gm;
 
+function basename(link) {
+    return link.split(/\\|\//).pop().replaceAll('"', '');
+}
 
 function replaceLinks(value) {
     return (value.match(SVG_XLINK_HREF_RE) || []).reduce((final, curr) => {
-        return final.replace(curr, `xlink:href="assets/${curr.split(/\\|\//).pop().replaceAll('"', '')}"`);
+        return final.replace(curr, `xlink:href="assets/${basename(curr)}"`);
     }, value)
 }
 
@@ -22,3 +25,14 @@ QUnit.assert.equalSVG = function (actual, expected, message) {
     QUnit.assert.equal(sanitizeSVG(actual), sanitizeSVG(expected), message);   
 }
 
+QUnit.assert.sameImageObject = function (actual, expected, message = 'image object should equal to ref') {
+    var a = {}, b = {};
+    Object.assign(a, actual, { src: basename(actual.src) });
+    Object.assign(b, expected, { src: basename(expected.src) });
+    this.pushResult({
+        result: QUnit.equiv(a, b),
+        actual,
+        expected,
+        message
+    });
+}

--- a/test/lib/assert.js
+++ b/test/lib/assert.js
@@ -1,0 +1,7 @@
+const SVG_RE = /#SVGID_[0-9]+/gm;
+
+QUnit.assert.equalSVG = function (actual, expected, message) {
+    console.log(actual.match(SVG_RE))
+    require('child_process').execSync(`"${actual}" > out.html && git add out.html && git commit && "${expected}" > out.html`)
+    QUnit.assert.equal(actual.replace(SVG_RE, '#SVGID'), expected.replace(SVG_RE, '#SVGID'), message);   
+}

--- a/test/lib/assert.js
+++ b/test/lib/assert.js
@@ -26,13 +26,15 @@ QUnit.assert.equalSVG = function (actual, expected, message) {
 }
 
 QUnit.assert.sameImageObject = function (actual, expected, message = 'image object should equal to ref') {
-    var a = {}, b = {};
-    Object.assign(a, actual, { src: basename(actual.src) });
-    Object.assign(b, expected, { src: basename(expected.src) });
-    this.pushResult({
-        result: QUnit.equiv(a, b),
-        actual,
-        expected,
+    QUnit.assert.deepEqual(
+        {
+            ...actual,
+            src: basename(actual.src)
+        },
+        {
+            ...expected,
+            src: basename(expected.src)
+        },
         message
-    });
+    );
 }

--- a/test/lib/assert.js
+++ b/test/lib/assert.js
@@ -2,7 +2,7 @@ const SVG_RE = /(SVGID|CLIPPATH|imageCrop)_[0-9]+/gm;
 const SVG_XLINK_HREF_RE = /xlink:href="([^"]*)"/gm;
 
 function basename(link) {
-    return link.split(/\\|\//).pop().replaceAll('"', '');
+    return link.split(/\\|\//).pop().replace(/"/gm, '');
 }
 
 function replaceLinks(value) {

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -1,4 +1,5 @@
 require('source-map-support/register');
+require('./lib/assert');
 // set the fabric framework as a global for tests
 var chalk = require('chalk');
 var diff = require('deep-object-diff').diff;

--- a/test/testem.config.js
+++ b/test/testem.config.js
@@ -6,7 +6,8 @@
 module.exports = {
   framework: 'qunit',
   serve_files: [
-    'dist/fabric.js'
+    'dist/fabric.js',
+    'test/lib/assert.js'
   ],
   styles: [
     'test/lib/tests.css'

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -94,27 +94,6 @@
     return new fabric.Triangle(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
-  function basename(path) {
-    return path.slice(Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/')) + 1);
-  }
-
-  /**
-   *
-   * @param {*} actual
-   * @param {*} [expected]
-   */
-  QUnit.assert.sameImageObject = function (actual, expected) {
-    var a = {}, b = {};
-    Object.assign(a, actual, { src: basename(actual.src) });
-    Object.assign(b, expected, { src: basename(expected.src) });
-    this.pushResult({
-      result: QUnit.equiv(a, b),
-      actual: actual,
-      expected: expected,
-      message: 'image object equal to ref'
-    })
-  }
-
   let ORIGINAL_DPR;
 
   QUnit.module('fabric.Canvas', {

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -159,28 +159,6 @@
     return new fabric.Rect(fabric.util.object.extend(defaultOptions, options || { }));
   }
 
-  function basename(path) {
-    return path.slice(Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/')) + 1);
-  }
-
-  /**
-   *
-   * @param {*} actual
-   * @param {*} [expected]
-   */
-  QUnit.assert.sameImageObject = function (actual, expected) {
-    var a = {}, b = {};
-    expected = expected || REFERENCE_IMG_OBJECT;
-    Object.assign(a, actual, { src: basename(actual.src) });
-    Object.assign(b, expected, { src: basename(expected.src) });
-    this.pushResult({
-      result: QUnit.equiv(a, b),
-      actual: actual,
-      expected: expected,
-      message: 'image object equal to ref'
-    })
-  }
-
   QUnit.module('fabric.StaticCanvas', {
     beforeEach: function() {
       canvas.clear();

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -183,7 +183,6 @@
 
   QUnit.module('fabric.StaticCanvas', {
     beforeEach: function() {
-      fabric.Object.__uid = 0;
       canvas.clear();
       canvas.setDimensions({ width: 200, heigth: 200 });
       canvas2.setDimensions({ width: 200, heigth: 200 });
@@ -839,7 +838,7 @@
     canvas.clear();
     canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
     var svg = canvas.toSVG();
-    assert.equal(svg, CANVAS_SVG);
+    assert.equalSVG(svg, CANVAS_SVG);
   });
 
   QUnit.test('toSVG with different encoding (ISO-8859-1)', function(assert) {
@@ -849,7 +848,7 @@
     var svg = canvas.toSVG({encoding: 'ISO-8859-1'});
     var svgDefaultEncoding = canvas.toSVG();
     assert.ok(svg != svgDefaultEncoding);
-    assert.equal(svg, CANVAS_SVG.replace('encoding="UTF-8"', 'encoding="ISO-8859-1"'));
+    assert.equalSVG(svg, CANVAS_SVG.replace('encoding="UTF-8"', 'encoding="ISO-8859-1"'));
   });
 
   QUnit.test('toSVG without preamble', function(assert) {
@@ -865,7 +864,7 @@
     canvas.clear();
 
     var svg = canvas.toSVG({viewBox: {x: 100, y: 100, width: 300, height: 300}});
-    assert.equal(svg, CANVAS_SVG_VIEWBOX);
+    assert.equalSVG(svg, CANVAS_SVG_VIEWBOX);
   });
 
   QUnit.test('toSVG with reviver', function(assert) {
@@ -983,7 +982,7 @@
     canvasClip.add(new fabric.Circle({ radius: 200 }));
     var svg = canvasClip.toSVG();
     var expectedSVG = '<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" width=\"400\" height=\"400\" viewBox=\"0 0 400 400\" xml:space=\"preserve\">\n<desc>Created with Fabric.js ' + fabric.version + '</desc>\n<defs>\n<clipPath id=\"CLIPPATH_0\" >\n\t<rect transform=\"matrix(1 0 0 1 100.5 100.5)\" x=\"-100\" y=\"-100\" rx=\"0\" ry=\"0\" width=\"200\" height=\"200\" />\n</clipPath>\n</defs>\n<g clip-path=\"url(#CLIPPATH_0)\" >\n<g transform=\"matrix(1 0 0 1 200.5 200.5)\"  >\n<circle style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  cx=\"0\" cy=\"0\" r=\"200\" />\n</g>\n</g>\n</svg>';
-    assert.equal(svg, expectedSVG, 'SVG with clipPath should match');
+    assert.equalSVG(svg, expectedSVG, 'SVG with clipPath should match');
   });
 
   QUnit.test('toSVG with exclude from export background', function(assert) {
@@ -993,12 +992,12 @@
     canvas.overlayImage = imageOL;
     var expectedSVG = '<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" width=\"200\" height=\"200\" viewBox=\"0 0 200 200\" xml:space=\"preserve\">\n<desc>Created with Fabric.js ' + fabric.version + '</desc>\n<defs>\n</defs>\n<g transform=\"matrix(1 0 0 1 0 0)\"  >\n\t<image style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  xlink:href=\"\" x=\"0\" y=\"0\" width=\"0\" height=\"0\"></image>\n</g>\n<g transform=\"matrix(1 0 0 1 0 0)\"  >\n\t<image style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  xlink:href=\"\" x=\"0\" y=\"0\" width=\"0\" height=\"0\"></image>\n</g>\n</svg>';
     var svg1 = canvas.toSVG();
-    assert.equal(svg1, expectedSVG, 'svg with bg and overlay do not match');
+    assert.equalSVG(svg1, expectedSVG, 'svg with bg and overlay do not match');
     imageBG.excludeFromExport = true;
     imageOL.excludeFromExport = true;
     var expectedSVG2 = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="200" height="200" viewBox="0 0 200 200" xml:space="preserve">\n<desc>Created with Fabric.js ' + fabric.version + '</desc>\n<defs>\n</defs>\n</svg>';
     var svg2 = canvas.toSVG();
-    assert.equal(svg2, expectedSVG2, 'svg without bg and overlay do not match');
+    assert.equalSVG(svg2, expectedSVG2, 'svg without bg and overlay do not match');
     canvas.backgroundImage = null;
     canvas.overlayImage = null;
     canvas.renderOnAddRemove = true;
@@ -1917,7 +1916,7 @@
     canvas2.backgroundColor = 'red';
     var svg = canvas2.toSVG();
     var expectedSVG = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="300" height="150" viewBox="0 0 300 150" xml:space="preserve">\n<desc>Created with Fabric.js ' + fabric.version + '</desc>\n<defs>\n</defs>\n<rect x="0" y="0" width="100%" height="100%" fill="red"></rect>\n</svg>';
-    assert.equal(svg, expectedSVG, 'svg is as expected');
+    assert.equalSVG(svg, expectedSVG, 'svg is as expected');
   });
 
   QUnit.test('toSVG with background and zoom and svgViewportTransformation', function(assert) {
@@ -1927,11 +1926,10 @@
     canvas2.viewportTransform = [3, 0, 0, 3, 60, 30];
     var svg = canvas2.toSVG();
     var expectedSVG = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="300" height="150" viewBox="-20 -10 100 50" xml:space="preserve">\n<desc>Created with Fabric.js ' + fabric.version + '</desc>\n<defs>\n</defs>\n<rect x="0" y="0" width="100%" height="100%" fill="blue"></rect>\n</svg>';
-    assert.equal(svg, expectedSVG, 'svg is as expected');
+    assert.equalSVG(svg, expectedSVG, 'svg is as expected');
   });
 
   QUnit.test('toSVG with background gradient', function(assert) {
-    fabric.Object.__uid = 0;
     var canvas2 = new fabric.StaticCanvas();
     canvas2.backgroundColor = new fabric.Gradient({
       type: 'linear',
@@ -1948,11 +1946,10 @@
     });
     var svg = canvas2.toSVG();
     var expectedSVG = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="300" height="150" viewBox="0 0 300 150" xml:space="preserve">\n<desc>Created with Fabric.js ' + fabric.version + '</desc>\n<defs>\n<linearGradient id=\"SVGID_0\" gradientUnits=\"userSpaceOnUse\" gradientTransform=\"matrix(1 0 0 1 0 0) matrix(1 0 0 1 -150 -75)\"  x1=\"0\" y1=\"0\" x2=\"300\" y2=\"0\">\n<stop offset="0%" style="stop-color:black;"/>\n<stop offset="100%" style="stop-color:white;"/>\n</linearGradient>\n</defs>\n<rect transform="matrix(1 0 0 1 0 0) translate(150,75)" x="-150" y="-75" width="300" height="150" fill="url(#SVGID_0)"></rect>\n</svg>';
-    assert.equal(svg, expectedSVG, 'svg is as expected');
+    assert.equalSVG(svg, expectedSVG, 'svg is as expected');
   });
 
   QUnit.test('toSVG with background gradient and transforms', function(assert) {
-    fabric.Object.__uid = 0;
     var canvas2 = new fabric.StaticCanvas();
     canvas2.viewportTransform = [1, 2, 3, 4, 5, 6];
     canvas2.backgroundColor = new fabric.Gradient({
@@ -1971,11 +1968,10 @@
     });
     var svg = canvas2.toSVG();
     var expectedSVG = '<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" width=\"300\" height=\"150\" viewBox=\"-5 -1.5 300 37.5\" xml:space=\"preserve\">\n<desc>Created with Fabric.js ' + fabric.version + '</desc>\n<defs>\n<linearGradient id=\"SVGID_0\" gradientUnits=\"userSpaceOnUse\" gradientTransform=\"matrix(1 2 3 4 5 6) matrix(0.2 0.3 0.4 0.5 -153 -23.75)\"  x1=\"0\" y1=\"0\" x2=\"300\" y2=\"0\">\n<stop offset=\"0%\" style=\"stop-color:black;\"/>\n<stop offset=\"100%\" style=\"stop-color:white;\"/>\n</linearGradient>\n</defs>\n<rect transform=\"matrix(-2 1 1.5 -0.5 1 -2) translate(150,75)\" x=\"-150\" y=\"-75\" width=\"300\" height=\"150\" fill=\"url(#SVGID_0)\"></rect>\n</svg>';
-    assert.equal(svg, expectedSVG, 'svg is as expected');
+    assert.equalSVG(svg, expectedSVG, 'svg is as expected');
   });
 
   QUnit.test('toSVG with background pattern', function(assert) {
-    fabric.Object.__uid = 0;
     var canvas2 = new fabric.StaticCanvas();
 
     var img = fabric.document.createElement('img');
@@ -1986,7 +1982,7 @@
     });
     var svg = canvas2.toSVG();
     var expectedSVG = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="300" height="150" viewBox="0 0 300 150" xml:space="preserve">\n<desc>Created with Fabric.js ' + fabric.version + '</desc>\n<defs>\n<pattern id="SVGID_0" x="0" y="0" width="0" height="0">\n<image x="0" y="0" width="0" height="0" xlink:href="' + img.src + '"></image>\n</pattern>\n</defs>\n<rect transform="matrix(1 0 0 1 0 0) translate(150,75)" x="-150" y="-75" width="300" height="150" fill="url(#SVGID_0)"></rect>\n</svg>';
-    assert.equal(svg, expectedSVG, 'svg is as expected');
+    assert.equalSVG(svg, expectedSVG, 'svg is as expected');
   });
 
   QUnit.test('requestRenderAll and cancelRequestedRender', function(assert) {

--- a/test/unit/ellipse.js
+++ b/test/unit/ellipse.js
@@ -1,9 +1,7 @@
 (function(){
 
   QUnit.module('fabric.Ellipse', {
-    beforeEach: function() {
-      fabric.Object.__uid = 0;
-    }
+
   });
 
   QUnit.test('constructor', function(assert) {
@@ -97,21 +95,21 @@
 
   QUnit.test('toSVG', function(assert) {
     var ellipse = new fabric.Ellipse({ rx: 100, ry: 12, fill: 'red', stroke: 'blue' });
-    assert.equal(ellipse.toSVG(), '<g transform=\"matrix(1 0 0 1 100.5 12.5)\"  >\n<ellipse style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  cx=\"0\" cy=\"0\" rx=\"100\" ry=\"12\" />\n</g>\n', 'SVG should match');
-    assert.equal(ellipse.toClipPathSVG(), '\t<ellipse transform=\"matrix(1 0 0 1 100.5 12.5)\" cx=\"0\" cy=\"0\" rx=\"100\" ry=\"12\" />\n', 'SVG clippath should match');
+    assert.equalSVG(ellipse.toSVG(), '<g transform=\"matrix(1 0 0 1 100.5 12.5)\"  >\n<ellipse style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  cx=\"0\" cy=\"0\" rx=\"100\" ry=\"12\" />\n</g>\n', 'SVG should match');
+    assert.equalSVG(ellipse.toClipPathSVG(), '\t<ellipse transform=\"matrix(1 0 0 1 100.5 12.5)\" cx=\"0\" cy=\"0\" rx=\"100\" ry=\"12\" />\n', 'SVG clippath should match');
   });
 
   QUnit.test('toSVG with a clipPath', function(assert) {
     var ellipse = new fabric.Ellipse({ rx: 100, ry: 12, fill: 'red', stroke: 'blue' });
     ellipse.clipPath = new fabric.Ellipse({ rx: 12, ry: 100, left: 60, top: -50 });
-    assert.equal(ellipse.toSVG(), '<g transform=\"matrix(1 0 0 1 100.5 12.5)\" clip-path=\"url(#CLIPPATH_0)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<ellipse transform=\"matrix(1 0 0 1 72.5 50.5)\" cx=\"0\" cy=\"0\" rx=\"12\" ry=\"100\" />\n</clipPath>\n<ellipse style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  cx=\"0\" cy=\"0\" rx=\"100\" ry=\"12\" />\n</g>\n', 'SVG with clipPath should match');
+    assert.equalSVG(ellipse.toSVG(), '<g transform=\"matrix(1 0 0 1 100.5 12.5)\" clip-path=\"url(#CLIPPATH_0)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<ellipse transform=\"matrix(1 0 0 1 72.5 50.5)\" cx=\"0\" cy=\"0\" rx=\"12\" ry=\"100\" />\n</clipPath>\n<ellipse style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  cx=\"0\" cy=\"0\" rx=\"100\" ry=\"12\" />\n</g>\n', 'SVG with clipPath should match');
   });
 
   QUnit.test('toSVG with a clipPath absolute positioned', function(assert) {
     var ellipse = new fabric.Ellipse({ rx: 100, ry: 12, fill: 'red', stroke: 'blue' });
     ellipse.clipPath = new fabric.Ellipse({ rx: 12, ry: 100, left: 60, top: -50 });
     ellipse.clipPath.absolutePositioned = true;
-    assert.equal(ellipse.toSVG(), '<g clip-path=\"url(#CLIPPATH_0)\"  >\n<g transform=\"matrix(1 0 0 1 100.5 12.5)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<ellipse transform=\"matrix(1 0 0 1 72.5 50.5)\" cx=\"0\" cy=\"0\" rx=\"12\" ry=\"100\" />\n</clipPath>\n<ellipse style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  cx=\"0\" cy=\"0\" rx=\"100\" ry=\"12\" />\n</g>\n</g>\n', 'SVG with clipPath should match');
+    assert.equalSVG(ellipse.toSVG(), '<g clip-path=\"url(#CLIPPATH_0)\"  >\n<g transform=\"matrix(1 0 0 1 100.5 12.5)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<ellipse transform=\"matrix(1 0 0 1 72.5 50.5)\" cx=\"0\" cy=\"0\" rx=\"12\" ry=\"100\" />\n</clipPath>\n<ellipse style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  cx=\"0\" cy=\"0\" rx=\"100\" ry=\"12\" />\n</g>\n</g>\n', 'SVG with clipPath should match');
   });
 
   QUnit.test('fromElement', function(assert) {

--- a/test/unit/gradient.js
+++ b/test/unit/gradient.js
@@ -666,49 +666,43 @@
   });
 
   QUnit.test('toSVG linear', function(assert) {
-    fabric.Object.__uid = 0;
     var gradient = createLinearGradient();
     var obj = new fabric.Object({ width: 100, height: 100 });
-    assert.equal(gradient.toSVG(obj), SVG_LINEAR);
+    assert.equalSVG(gradient.toSVG(obj), SVG_LINEAR);
   });
 
   QUnit.test('toSVG radial', function(assert) {
-    fabric.Object.__uid = 0;
     var gradient = createRadialGradient();
     var obj = new fabric.Object({ width: 100, height: 100 });
-    assert.equal(gradient.toSVG(obj), SVG_RADIAL);
+    assert.equalSVG(gradient.toSVG(obj), SVG_RADIAL);
   });
 
   QUnit.test('toSVG radial with r1 > 0', function(assert) {
-    fabric.Object.__uid = 0;
     var gradient = createRadialGradientWithInternalRadius();
     var obj = new fabric.Object({ width: 100, height: 100 });
-    assert.equal(gradient.toSVG(obj), SVG_INTERNALRADIUS);
+    assert.equalSVG(gradient.toSVG(obj), SVG_INTERNALRADIUS);
   });
 
   QUnit.test('toSVG radial with r1 > 0 swapped', function(assert) {
-    fabric.Object.__uid = 0;
     var gradient = createRadialGradientSwapped();
     var obj = new fabric.Object({ width: 100, height: 100 });
     const gradientColorStops = JSON.stringify(gradient.colorStops);
-    assert.equal(gradient.toSVG(obj), SVG_SWAPPED, 'it exports as expected');
+    assert.equalSVG(gradient.toSVG(obj), SVG_SWAPPED, 'it exports as expected');
     const gradientColorStopsAfterExport = JSON.stringify(gradient.colorStops);
-    assert.equal(gradient.toSVG(obj), SVG_SWAPPED, 'it exports as expected a second time');
-    assert.equal(gradientColorStops, gradientColorStopsAfterExport, 'colorstops do not change')
+    assert.equalSVG(gradient.toSVG(obj), SVG_SWAPPED, 'it exports as expected a second time');
+    assert.equalSVG(gradientColorStops, gradientColorStopsAfterExport, 'colorstops do not change')
   });
 
   QUnit.test('toSVG linear objectBoundingBox', function(assert) {
-    fabric.Object.__uid = 0;
     var gradient = createLinearGradient('percentage');
     var obj = new fabric.Object({ width: 100, height: 100 });
-    assert.equal(gradient.toSVG(obj), SVG_LINEAR_PERCENTAGE);
+    assert.equalSVG(gradient.toSVG(obj), SVG_LINEAR_PERCENTAGE);
   });
 
   QUnit.test('toSVG radial objectBoundingBox', function(assert) {
-    fabric.Object.__uid = 0;
     var gradient = createRadialGradient('percentage');
     var obj = new fabric.Object({ width: 100, height: 100 });
-    assert.equal(gradient.toSVG(obj), SVG_RADIAL_PERCENTAGE);
+    assert.equalSVG(gradient.toSVG(obj), SVG_RADIAL_PERCENTAGE);
   });
 
 })();

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -33,7 +33,6 @@
 
   QUnit.module('fabric.Group', {
     afterEach: function() {
-      fabric.Object.__uid = 0;
       canvas.clear();
       canvas.backgroundColor = fabric.Canvas.prototype.backgroundColor;
       canvas.calcOffset();
@@ -464,14 +463,14 @@
     var group = makeGroupWith2Objects();
     assert.ok(typeof group.toSVG === 'function');
     var expectedSVG = '<g transform=\"matrix(1 0 0 1 90 130)\"  >\n<g style=\"\"   >\n\t\t<g transform=\"matrix(1 0 0 1 25 -25)\"  >\n<rect style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-15\" y=\"-5\" rx=\"0\" ry=\"0\" width=\"30\" height=\"10\" />\n</g>\n\t\t<g transform=\"matrix(1 0 0 1 -35 10)\"  >\n<rect style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-5\" y=\"-20\" rx=\"0\" ry=\"0\" width=\"10\" height=\"40\" />\n</g>\n</g>\n</g>\n';
-    assert.equal(group.toSVG(), expectedSVG);
+    assert.equalSVG(group.toSVG(), expectedSVG);
   });
 
   QUnit.test('toSVG with a clipPath', function(assert) {
     var group = makeGroupWith2Objects();
     group.clipPath = new fabric.Rect({ width: 100, height: 100 });
     var expectedSVG = '<g transform=\"matrix(1 0 0 1 90 130)\" clip-path=\"url(#CLIPPATH_0)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<rect transform=\"matrix(1 0 0 1 50.5 50.5)\" x=\"-50\" y=\"-50\" rx=\"0\" ry=\"0\" width=\"100\" height=\"100\" />\n</clipPath>\n<g style=\"\"   >\n\t\t<g transform=\"matrix(1 0 0 1 25 -25)\"  >\n<rect style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-15\" y=\"-5\" rx=\"0\" ry=\"0\" width=\"30\" height=\"10\" />\n</g>\n\t\t<g transform=\"matrix(1 0 0 1 -35 10)\"  >\n<rect style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-5\" y=\"-20\" rx=\"0\" ry=\"0\" width=\"10\" height=\"40\" />\n</g>\n</g>\n</g>\n';
-    assert.equal(group.toSVG(), expectedSVG);
+    assert.equalSVG(group.toSVG(), expectedSVG);
   });
 
   QUnit.test('toSVG with a clipPath absolutePositioned', function(assert) {
@@ -479,14 +478,14 @@
     group.clipPath = new fabric.Rect({ width: 100, height: 100 });
     group.clipPath.absolutePositioned = true;
     var expectedSVG = '<g clip-path=\"url(#CLIPPATH_0)\"  >\n<g transform=\"matrix(1 0 0 1 90 130)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<rect transform=\"matrix(1 0 0 1 50.5 50.5)\" x=\"-50\" y=\"-50\" rx=\"0\" ry=\"0\" width=\"100\" height=\"100\" />\n</clipPath>\n<g style=\"\"   >\n\t\t<g transform=\"matrix(1 0 0 1 25 -25)\"  >\n<rect style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-15\" y=\"-5\" rx=\"0\" ry=\"0\" width=\"30\" height=\"10\" />\n</g>\n\t\t<g transform=\"matrix(1 0 0 1 -35 10)\"  >\n<rect style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-5\" y=\"-20\" rx=\"0\" ry=\"0\" width=\"10\" height=\"40\" />\n</g>\n</g>\n</g>\n</g>\n';
-    assert.equal(group.toSVG(), expectedSVG);
+    assert.equalSVG(group.toSVG(), expectedSVG);
   });
 
   QUnit.test('toSVG with a group as a clipPath', function(assert) {
     var group = makeGroupWith2Objects();
     group.clipPath = makeGroupWith2Objects();
     var expectedSVG = '<g transform=\"matrix(1 0 0 1 90 130)\" clip-path=\"url(#CLIPPATH_0)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t\t<rect transform=\"matrix(1 0 0 1 115 105)\" x=\"-15\" y=\"-5\" rx=\"0\" ry=\"0\" width=\"30\" height=\"10\" />\n\t\t<rect transform=\"matrix(1 0 0 1 55 140)\" x=\"-5\" y=\"-20\" rx=\"0\" ry=\"0\" width=\"10\" height=\"40\" />\n</clipPath>\n<g style=\"\"   >\n\t\t<g transform=\"matrix(1 0 0 1 25 -25)\"  >\n<rect style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-15\" y=\"-5\" rx=\"0\" ry=\"0\" width=\"30\" height=\"10\" />\n</g>\n\t\t<g transform=\"matrix(1 0 0 1 -35 10)\"  >\n<rect style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-5\" y=\"-20\" rx=\"0\" ry=\"0\" width=\"10\" height=\"40\" />\n</g>\n</g>\n</g>\n';
-    assert.equal(group.toSVG(), expectedSVG);
+    assert.equalSVG(group.toSVG(), expectedSVG);
   });
 
   QUnit.test('cloning group with 2 objects', function(assert) {

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -108,19 +108,6 @@
     return path.slice(Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/')) + 1);
   }
 
-  QUnit.assert.equalImageSVG = function (actual, expected) {
-    function extractBasename(s) {
-      var p = 'xlink:href', pos = s.indexOf(p) + p.length;
-      return basename(s.slice(pos, s.indexOf(' ', pos)));
-    }
-    this.pushResult({
-      result: extractBasename(actual) === extractBasename(expected),
-      actual: actual,
-      expected: expected,
-      message: 'svg is not equal to ref'
-    });
-  }
-
   /**
    *
    * @param {*} actual
@@ -308,9 +295,8 @@
       image.cropY = 1;
       image.width -= 2;
       image.height -= 2;
-      fabric.Object.__uid = 1;
       var expectedSVG = '<g transform=\"matrix(1 0 0 1 137 54)\"  >\n<clipPath id=\"imageCrop_1\">\n\t<rect x=\"-137\" y=\"-54\" width=\"274\" height=\"108\" />\n</clipPath>\n\t<image style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  xlink:href=\"' + IMG_SRC + '\" x=\"-138\" y=\"-55\" width=\"276\" height=\"110\" clip-path=\"url(#imageCrop_1)\" ></image>\n</g>\n';
-      assert.equalImageSVG(image.toSVG(), expectedSVG);
+      assert.equalSVG(image.toSVG(), expectedSVG);
       done();
     });
   });
@@ -339,7 +325,7 @@
     createImageObject(function(image) {
       assert.ok(typeof image.toSVG === 'function');
       var expectedSVG = '<g transform=\"matrix(1 0 0 1 138 55)\"  >\n\t<image style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  xlink:href=\"' + IMG_SRC + '\" x=\"-138\" y=\"-55\" width=\"276\" height=\"110\"></image>\n</g>\n';
-      assert.equalImageSVG(image.toSVG(), expectedSVG);
+      assert.equalSVG(image.toSVG(), expectedSVG);
       done();
     });
   });
@@ -350,7 +336,7 @@
       image.imageSmoothing = false;
       assert.ok(typeof image.toSVG === 'function');
       var expectedSVG = '<g transform="matrix(1 0 0 1 138 55)"  >\n\t<image style=\"stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  xlink:href=\"' + IMG_SRC + '\" x=\"-138\" y=\"-55\" width=\"276\" height=\"110\" image-rendering=\"optimizeSpeed\"></image>\n</g>\n';
-      assert.equalImageSVG(image.toSVG(), expectedSVG);
+      assert.equalSVG(image.toSVG(), expectedSVG);
       done();
     });
   });
@@ -361,7 +347,7 @@
       delete image._element;
       assert.ok(typeof image.toSVG === 'function');
       var expectedSVG = '<g transform="matrix(1 0 0 1 138 55)"  >\n</g>\n';
-      assert.equalImageSVG(image.toSVG(), expectedSVG);
+      assert.equalSVG(image.toSVG(), expectedSVG);
       done();
     });
   });

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -108,24 +108,6 @@
     return path.slice(Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/')) + 1);
   }
 
-  /**
-   *
-   * @param {*} actual
-   * @param {*} [expected]
-   */
-  QUnit.assert.sameImageObject = function (actual, expected) {
-    var a = {}, b = {};
-    expected = expected || REFERENCE_IMG_OBJECT;
-    Object.assign(a, actual, { src: basename(actual.src) });
-    Object.assign(b, expected, { src: basename(expected.src) });
-    this.pushResult({
-      result: QUnit.equiv(a, b),
-      actual: actual,
-      expected: expected,
-      message: 'image object equal to ref'
-    })
-  }
-
   QUnit.module('fabric.Image');
 
   QUnit.test('constructor', function(assert) {

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -65,9 +65,7 @@
   }
 
   QUnit.module('fabric.Path', {
-    beforeEach: function() {
-      fabric.Object.__uid = 0;
-    }
+
   });
 
   QUnit.test('constructor', function(assert) {
@@ -179,7 +177,7 @@
     var done = assert.async();
     makePathObject(function(path) {
       assert.ok(typeof path.toSVG === 'function');
-      assert.deepEqual(path.toSVG(), '<g transform=\"matrix(1 0 0 1 200.5 200.5)\"  >\n<path style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  transform=\" translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</g>\n');
+      assert.equalSVG(path.toSVG(), '<g transform=\"matrix(1 0 0 1 200.5 200.5)\"  >\n<path style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  transform=\" translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</g>\n');
       done();
     });
   });
@@ -189,7 +187,7 @@
     makePathObject(function(path) {
       makePathObject(function(path2) {
         path.clipPath = path2;
-        assert.deepEqual(path.toSVG(), '<g transform=\"matrix(1 0 0 1 200.5 200.5)\" clip-path=\"url(#CLIPPATH_0)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<path transform=\"matrix(1 0 0 1 200.5 200.5) translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</clipPath>\n<path style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  transform=\" translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</g>\n', 'path clipPath toSVG should match');
+        assert.equalSVG(path.toSVG(), '<g transform=\"matrix(1 0 0 1 200.5 200.5)\" clip-path=\"url(#CLIPPATH_0)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<path transform=\"matrix(1 0 0 1 200.5 200.5) translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</clipPath>\n<path style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  transform=\" translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</g>\n', 'path clipPath toSVG should match');
         done();
       });
     });
@@ -202,7 +200,7 @@
       makePathObject(function(path2) {
         path.clipPath = path2;
         path.clipPath.absolutePositioned = true;
-        assert.deepEqual(path.toSVG(), '<g clip-path=\"url(#CLIPPATH_0)\"  >\n<g transform=\"matrix(1 0 0 1 200.5 200.5)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<path transform=\"matrix(1 0 0 1 200.5 200.5) translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</clipPath>\n<path style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  transform=\" translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</g>\n</g>\n', 'path clipPath toSVG absolute should match');
+        assert.equalSVG(path.toSVG(), '<g clip-path=\"url(#CLIPPATH_0)\"  >\n<g transform=\"matrix(1 0 0 1 200.5 200.5)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t<path transform=\"matrix(1 0 0 1 200.5 200.5) translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</clipPath>\n<path style=\"stroke: rgb(0,0,255); stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1;\"  transform=\" translate(-200, -200)\" d=\"M 100 100 L 300 100 L 200 300 z\" stroke-linecap=\"round\" />\n</g>\n</g>\n', 'path clipPath toSVG absolute should match');
         done();
       });
     });

--- a/test/unit/pattern.js
+++ b/test/unit/pattern.js
@@ -111,46 +111,41 @@
   });
 
   QUnit.test('toSVG', function(assert) {
-    fabric.Object.__uid = 0;
     var pattern = createPattern();
     var rect = new fabric.Rect({ width: 500, height: 500 });
     var expectedSVG = '<pattern id="SVGID_0" x="0" y="0" width="0.3" height="0.248">\n<image x="0" y="0" width="150" height="124" xlink:href="' + img.src + '"></image>\n</pattern>\n';
     assert.ok(typeof pattern.toSVG === 'function');
-    assert.equal(pattern.toSVG(rect), expectedSVG, 'SVG match');
+    assert.equalSVG(pattern.toSVG(rect), expectedSVG, 'SVG match');
   });
 
   QUnit.test('toSVG repeat-y', function(assert) {
-    fabric.Object.__uid = 0;
     var pattern = createPattern();
     pattern.repeat = 'repeat-y';
     var rect = new fabric.Rect({ width: 500, height: 500 });
     var expectedSVG = '<pattern id="SVGID_0" x="0" y="0" width="1" height="0.248">\n<image x="0" y="0" width="150" height="124" xlink:href="' + img.src + '"></image>\n</pattern>\n';
     assert.ok(typeof pattern.toSVG === 'function');
-    assert.equal(pattern.toSVG(rect), expectedSVG, 'SVG match repeat-y');
+    assert.equalSVG(pattern.toSVG(rect), expectedSVG, 'SVG match repeat-y');
   });
 
   QUnit.test('toSVG repeat-x', function(assert) {
-    fabric.Object.__uid = 0;
     var pattern = createPattern();
     pattern.repeat = 'repeat-x';
     var rect = new fabric.Rect({ width: 500, height: 500 });
     var expectedSVG = '<pattern id="SVGID_0" x="0" y="0" width="0.3" height="1">\n<image x="0" y="0" width="150" height="124" xlink:href="' + img.src + '"></image>\n</pattern>\n';
     assert.ok(typeof pattern.toSVG === 'function');
-    assert.equal(pattern.toSVG(rect), expectedSVG, 'SVG match repeat-x');
+    assert.equalSVG(pattern.toSVG(rect), expectedSVG, 'SVG match repeat-x');
   });
 
   QUnit.test('toSVG no-repeat', function(assert) {
-    fabric.Object.__uid = 0;
     var pattern = createPattern();
     pattern.repeat = 'no-repeat';
     var rect = new fabric.Rect({ width: 500, height: 500 });
     var expectedSVG = '<pattern id="SVGID_0" x="0" y="0" width="1" height="1">\n<image x="0" y="0" width="150" height="124" xlink:href="' + img.src + '"></image>\n</pattern>\n';
     assert.ok(typeof pattern.toSVG === 'function');
-    assert.equal(pattern.toSVG(rect), expectedSVG, 'SVG match no-repeat');
+    assert.equalSVG(pattern.toSVG(rect), expectedSVG, 'SVG match no-repeat');
   });
 
   QUnit.test('toSVG no-repeat offsetX and offsetY', function(assert) {
-    fabric.Object.__uid = 0;
     var pattern = createPattern();
     pattern.repeat = 'no-repeat';
     pattern.offsetX = 50;
@@ -158,7 +153,7 @@
     var rect = new fabric.Rect({ width: 500, height: 500 });
     var expectedSVG = '<pattern id="SVGID_0" x="0.1" y="-0.1" width="1.1" height="1.1">\n<image x="0" y="0" width="150" height="124" xlink:href="' + img.src + '"></image>\n</pattern>\n';
     assert.ok(typeof pattern.toSVG === 'function');
-    assert.equal(pattern.toSVG(rect), expectedSVG, 'SVG match no-repat offsetX and offsetY');
+    assert.equalSVG(pattern.toSVG(rect), expectedSVG, 'SVG match no-repat offsetX and offsetY');
   });
 
   QUnit.test('initPattern from object', function(assert) {

--- a/test/unit/shadow.js
+++ b/test/unit/shadow.js
@@ -187,50 +187,38 @@
   });
 
   QUnit.test('toSVG', function(assert) {
-    // reset uid
-    fabric.Object.__uid = 0;
-
     var shadow = new fabric.Shadow({color: '#FF0000', offsetX: 10, offsetY: -10, blur: 2});
     var object = new fabric.Object({fill: '#FF0000'});
 
-    assert.equal(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="10" dy="-10" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
+    assert.equalSVG(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="10" dy="-10" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
 
     shadow.color = 'rgba(255,0,0,0.5)';
-    assert.equal(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="10" dy="-10" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="0.5"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
+    assert.equalSVG(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="10" dy="-10" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="0.5"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
 
     shadow.color = '#000000';
-    assert.equal(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="10" dy="-10" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(0,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
+    assert.equalSVG(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="10" dy="-10" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(0,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
   });
 
   QUnit.test('toSVG with flipped object', function(assert) {
-    // reset uid
-    fabric.Object.__uid = 0;
-
     var shadow = new fabric.Shadow({color: '#FF0000', offsetX: 10, offsetY: -10, blur: 2});
     var object = new fabric.Object({fill: '#FF0000', flipX: true, flipY: true});
 
-    assert.equal(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="-10" dy="10" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
+    assert.equalSVG(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="-10" dy="10" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
 
   });
 
   QUnit.test('toSVG with rotated object', function(assert) {
-    // reset uid
-    fabric.Object.__uid = 0;
-
     var shadow = new fabric.Shadow({color: '#FF0000', offsetX: 10, offsetY: 10, blur: 2});
     var object = new fabric.Object({fill: '#FF0000', angle: 45});
 
-    assert.equal(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="14.14" dy="0" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
+    assert.equalSVG(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="14.14" dy="0" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
   });
 
   QUnit.test('toSVG with rotated flipped object', function(assert) {
-    // reset uid
-    fabric.Object.__uid = 0;
-
     var shadow = new fabric.Shadow({color: '#FF0000', offsetX: 10, offsetY: 10, blur: 2});
     var object = new fabric.Object({fill: '#FF0000', angle: 45, flipX: true});
 
-    assert.equal(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="-14.14" dy="0" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
+    assert.equalSVG(shadow.toSVG(object), '<filter id="SVGID_0" y="-40%" height="180%" x="-40%" width="180%" >\n\t<feGaussianBlur in="SourceAlpha" stdDeviation="1"></feGaussianBlur>\n\t<feOffset dx="-14.14" dy="0" result="oBlur" ></feOffset>\n\t<feFlood flood-color="rgb(255,0,0)" flood-opacity="1"/>\n\t<feComposite in2="oBlur" operator="in" />\n\t<feMerge>\n\t\t<feMergeNode></feMergeNode>\n\t\t<feMergeNode in="SourceGraphic"></feMergeNode>\n\t</feMerge>\n</filter>\n');
   });
 
 })();

--- a/test/unit/text_to_svg.js
+++ b/test/unit/text_to_svg.js
@@ -3,19 +3,19 @@
     return str.replace(/matrix\(.*?\)/, '');
   }
   QUnit.module('fabric.Text SVG Export', {
-    before() {
+    beforeEach() {
       fabric.config.configure({ NUM_FRACTION_DIGITS: 2 });
     },
-    after() {
+    afterEach() {
       fabric.config.restoreDefaults();
     }
   });
   QUnit.test('toSVG', function(assert) {
     var TEXT_SVG = '<g transform=\"\" style=\"\"  >\n\t\t<text xml:space=\"preserve\" font-family=\"Times New Roman\" font-size=\"40\" font-style=\"normal\" font-weight=\"normal\" style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;\" ><tspan x=\"-10\" y=\"12.57\" >x</tspan></text>\n</g>\n';
     var text = new fabric.Text('x');
-    assert.equal(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG));
+    assert.equalSVG(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG));
     text.set('fontFamily', 'Arial');
-    assert.equal(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG.replace('font-family="Times New Roman"', 'font-family="Arial"')));
+    assert.equalSVG(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG.replace('font-family="Times New Roman"', 'font-family="Arial"')));
   });
   QUnit.test('toSVG justified', function(assert) {
     var TEXT_SVG_JUSTIFIED = '<g transform=\"\" style=\"\"  >\n\t\t<text xml:space=\"preserve\" font-family=\"Times New Roman\" font-size=\"40\" font-style=\"normal\" font-weight=\"normal\" style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;\" ><tspan x=\"-60\" y=\"-13.65\" >xxxxxx</tspan><tspan x=\"-60\" y=\"38.78\" style=\"white-space: pre; \">x </tspan><tspan x=\"40\" y=\"38.78\" >y</tspan></text>\n</g>\n';
@@ -23,12 +23,12 @@
       textAlign: 'justify',
     });
 
-    assert.equal(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG_JUSTIFIED));
+    assert.equalSVG(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG_JUSTIFIED));
   });
   QUnit.test('toSVG with multiple spaces', function(assert) {
     var TEXT_SVG_MULTIPLESPACES = '<g transform=\"\" style=\"\"  >\n\t\t<text xml:space=\"preserve\" font-family=\"Times New Roman\" font-size=\"40\" font-style=\"normal\" font-weight=\"normal\" style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;\" ><tspan x=\"-105\" y=\"12.57\" style=\"white-space: pre; \">x                 y</tspan></text>\n</g>\n';
     var text = new fabric.Text('x                 y');
-    assert.equal(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG_MULTIPLESPACES));
+    assert.equalSVG(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG_MULTIPLESPACES));
   });
   QUnit.test('toSVG with deltaY', function(assert) {
     fabric.config.configure({ NUM_FRACTION_DIGITS: 0 });
@@ -43,7 +43,7 @@
         }
       }
     });
-    assert.equal(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG));
+    assert.equalSVG(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG));
     fabric.config.configure({ NUM_FRACTION_DIGITS: 2 });
   });
 
@@ -60,16 +60,14 @@
         5: {fontFamily: 'Times New Roman'}
       }}
     });
-    assert.equal(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG_WITH_FONT));
+    assert.equalSVG(removeTranslate(text.toSVG()), removeTranslate(TEXT_SVG_WITH_FONT));
   });
   QUnit.test('toSVG with text as a clipPath', function(assert) {
     fabric.config.configure({ NUM_FRACTION_DIGITS: 0 });
-    fabric.Object.__uid = 0;
     var EXPECTED = '<g transform=\"\" clip-path=\"url(#CLIPPATH_0)\"  >\n<clipPath id=\"CLIPPATH_0\" >\n\t\t\t<text xml:space=\"preserve\" font-family=\"Times New Roman\" font-size=\"40\" font-style=\"normal\" font-weight=\"normal\" style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;\" ><tspan x=\"-122\" y=\"13\" >text as clipPath</tspan></text>\n</clipPath>\n<rect style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x=\"-100\" y=\"-50\" rx=\"0\" ry=\"0\" width=\"200\" height=\"100\" />\n</g>\n';
     var clipPath = new fabric.Text('text as clipPath');
     var rect = new fabric.Rect({ width: 200, height: 100 });
     rect.clipPath = clipPath;
-    assert.equal(removeTranslate(rect.toSVG()), removeTranslate(EXPECTED));
-    fabric.config.configure({ NUM_FRACTION_DIGITS: 2 });
+    assert.equalSVG(removeTranslate(rect.toSVG()), removeTranslate(EXPECTED));
   });
 })();


### PR DESCRIPTION
## Motivation

Cleanup for v6 
remove the import cycle
closes #8471 

## Description

Nothing interesting
I suggest merging this before working on canvas

## Changes

Changed svg test assertions to remove the uid from comparison

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
