### PR TITLE
fix(scaleObject): keep last sign when over origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(scaleObject): handle when scale is 0 to not bug flip [#8490](https://github.com/fabricjs/fabric.js/pull/8490)
 - chore(): refactor `Object.__uid++` => `uid()` [#8482](https://github.com/fabricjs/fabric.js/pull/8482)
 - chore(TS): migrate object mixins to TS [#8414](https://github.com/fabricjs/fabric.js/pull/8414)
 - chore(TS): migrate filters [#8474](https://github.com/fabricjs/fabric.js/pull/8474)

--- a/src/controls/scale.ts
+++ b/src/controls/scale.ts
@@ -145,14 +145,8 @@ function scaleObject(
     // by center and scaling using one middle control ( default: mr, mt, ml, mb), the mouse movement can easily
     // cross many time the origin point and flip the object. so we need a way to filter out the noise.
     // This ternary here should be ok to filter out X scaling when we want Y only and vice versa.
-    signX =
-      by !== 'y'
-        ? Math.sign(newPoint.x === 0 ? transform.signX || 1 : newPoint.x)
-        : 1;
-    signY =
-      by !== 'x'
-        ? Math.sign(newPoint.y === 0 ? transform.signY || 1 : newPoint.y)
-        : 1;
+    signX = by !== 'y' ? Math.sign(newPoint.x || transform.signX || 1) : 1;
+    signY = by !== 'x' ? Math.sign(newPoint.y || transform.signY || 1) : 1;
     if (!transform.signX) {
       transform.signX = signX;
     }

--- a/src/controls/scale.ts
+++ b/src/controls/scale.ts
@@ -145,8 +145,14 @@ function scaleObject(
     // by center and scaling using one middle control ( default: mr, mt, ml, mb), the mouse movement can easily
     // cross many time the origin point and flip the object. so we need a way to filter out the noise.
     // This ternary here should be ok to filter out X scaling when we want Y only and vice versa.
-    signX = by !== 'y' ? Math.sign(newPoint.x) : 1;
-    signY = by !== 'x' ? Math.sign(newPoint.y) : 1;
+    signX =
+      by !== 'y'
+        ? Math.sign(newPoint.x === 0 ? transform.signX || 1 : newPoint.x)
+        : 1;
+    signY =
+      by !== 'x'
+        ? Math.sign(newPoint.y === 0 ? transform.signY || 1 : newPoint.y)
+        : 1;
     if (!transform.signX) {
       transform.signX = signX;
     }

--- a/test/unit/controls_handlers.js
+++ b/test/unit/controls_handlers.js
@@ -8,7 +8,8 @@
       eventData = {};
       transform = prepareTransform(target, 'mr');
     });
-    hooks.afterEach(function() {
+    hooks.afterEach(function () {
+      canvas.off();
       canvas.clear();
     });
     function prepareTransform(target, corner) {
@@ -262,21 +263,26 @@
       );
       wrapped(eventData, transform, x, y);
     });
-    QUnit.test.only('scaling X or Y keeps the same sign when scale = 0', function(assert) {
-      ['signX', 'signY'].forEach(sign => {
-        const isX = sign === 'signX',
-          fn = isX ? fabric.controlsUtils.scalingX : fabric.controlsUtils.scalingY,
-          point = new fabric.Point(
-            isX ? 0 : 10,
-            isX? 10 : 0
-          );
-        transform[sign] = 1;
+    ['X', 'Y'].forEach(axis => {
+      const signKey = `sign${axis}`;
+      const scaleKey = `scale${axis}`;
+      const isX = signKey === 'signX';
+      QUnit.test(`scaling ${axis} keeps the same sign when scale = 0`, function (assert) {
+        transform = prepareTransform(transform.target, isX ? 'mr' : 'mb');
+        const fn = fabric.controlsUtils[`scaling${axis}`];
+        const point = new fabric.Point(
+          isX ? 0 : 10,
+          isX ? 10 : 0
+        );
+        transform[signKey] = 1;
         fn(eventData, transform, point.x, point.y);
-        assert.equal(transform[sign], 1);
-        transform[sign] = -1;
+        assert.equal(transform[signKey], 1, `${signKey} value after scaling`);
+        assert.equal(transform.target[`${scaleKey}`], 0.0001, `${scaleKey} value after scaling`);
+        transform[signKey] = -1;
         fn(eventData, transform, point.x, point.y);
-        assert.equal(transform[sign], -1);
-      })
+        assert.equal(transform.target[`${scaleKey}`], 0.0001, `${scaleKey} value after scaling`);
+        assert.equal(transform[signKey], -1);
+      });
     });
   });
 })();

--- a/test/unit/controls_handlers.js
+++ b/test/unit/controls_handlers.js
@@ -262,5 +262,21 @@
       );
       wrapped(eventData, transform, x, y);
     });
+    QUnit.test.only('scaling X or Y keeps the same sign when scale = 0', function(assert) {
+      ['signX', 'signY'].forEach(sign => {
+        const isX = sign === 'signX',
+          fn = isX ? fabric.controlsUtils.scalingX : fabric.controlsUtils.scalingY,
+          point = new fabric.Point(
+            isX ? 0 : 10,
+            isX? 10 : 0
+          );
+        transform[sign] = 1;
+        fn(eventData, transform, point.x, point.y);
+        assert.equal(transform[sign], 1);
+        transform[sign] = -1;
+        fn(eventData, transform, point.x, point.y);
+        assert.equal(transform[sign], -1);
+      })
+    });
   });
 })();


### PR DESCRIPTION
## Motivation

When we cross the axis, `newPoint.x` or `newPoint.y` = 0, this makes `Math.sign` = 0 and bugs the `flip` property. 

Behavior in a master build: https://codesandbox.io/s/bug-flip-fpzk7b

(We cross the origin, `flipX` = true, but when we cross back it stays true instead of false)

![bug 2 flip](https://user-images.githubusercontent.com/65685842/205504969-6afddd2d-05c8-4ab8-8bde-96812d25ed95.gif)

## Changes

If `newPoint.x` or `newPoint.y` = 0 we use the `transform.signX` or `transform.signY`  (from what I understand this is the last sign), otherwise it arbitrarily assigns 1 (lack of information to know where it's coming from).


## In Action

With the fix: https://codesandbox.io/s/fix-flip-9m0jsh

![fix flip](https://user-images.githubusercontent.com/65685842/205499146-1363231f-11f8-4ac1-bb38-b65863d255b0.gif)

