### PR TITLE
chore(): use context in static constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): use context in static constructors [#8522](https://github.com/fabricjs/fabric.js/issues/8522)
 - chore(TS): Convert Canvas class #8510
 - chore(TS): Move object classes #8511
 - chore(TS): polish text [#8489](https://github.com/fabricjs/fabric.js/pull/8489)

--- a/src/gradient/gradient.class.ts
+++ b/src/gradient/gradient.class.ts
@@ -368,7 +368,7 @@ export class Gradient<
     svgOptions: SVGOptions
   ): Gradient<GradientType> {
     const gradientUnits = parseGradientUnits(el);
-    return new Gradient({
+    return new this({
       id: el.getAttribute('id') || undefined,
       type: parseType(el),
       coords: parseCoords(el, {

--- a/src/pattern.class.ts
+++ b/src/pattern.class.ts
@@ -203,7 +203,7 @@ export class Pattern {
       ...options,
       crossOrigin: serialized.crossOrigin,
     });
-    return new Pattern({ ...serialized, source: img });
+    return new this({ ...serialized, source: img });
   }
 }
 

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -1974,25 +1974,18 @@ export class FabricObject<
    * @param {AbortSignal} [options.signal] handle aborting, see https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal
    * @returns {Promise<FabricObject>}
    */
-  static _fromObject<
-    T extends FabricObject,
-    X,
-    K extends X extends keyof T
-      ? { new (arg0: T[X], ...args: any[]): T }
-      : { new (...args: any[]): T }
-  >(
-    klass: K,
+  static _fromObject(
     object: Record<string, unknown>,
     { extraParam, ...options }: { extraParam?: X; signal?: AbortSignal } = {}
   ) {
-    return enlivenObjectEnlivables<InstanceType<K>>(
+    return enlivenObjectEnlivables<InstanceType<this>>(
       clone(object, true),
       options
     ).then((enlivedMap) => {
       // from the resulting enlived options, extract options.extraParam to arg0
       // to avoid accidental overrides later
       const { [extraParam]: arg0, ...rest } = { ...options, ...enlivedMap };
-      return extraParam ? new klass(arg0, rest) : new klass(rest);
+      return extraParam ? new this(arg0, rest) : new this(rest);
     });
   }
 
@@ -2007,7 +2000,7 @@ export class FabricObject<
     object: Record<string, unknown>,
     options?: { signal?: AbortSignal }
   ) {
-    return FabricObject._fromObject(FabricObject, object, options);
+    return this._fromObject(object, options);
   }
 }
 

--- a/src/shapes/active_selection.class.ts
+++ b/src/shapes/active_selection.class.ts
@@ -1,9 +1,8 @@
 import { fabric } from '../../HEADER';
 import { ControlRenderingStyleOverride } from '../controls';
 import { TClassProperties } from '../typedefs';
-import { enlivenObjects } from '../util/misc/objectEnlive';
-import { FabricObject } from './Object/FabricObject';
 import { Group, groupDefaultValues } from './group.class';
+import { FabricObject } from './Object/FabricObject';
 
 export class ActiveSelection extends Group {
   constructor(
@@ -143,19 +142,6 @@ export class ActiveSelection extends Group {
       this._objects[i]._renderControls(ctx, options);
     }
     ctx.restore();
-  }
-
-  /**
-   * Returns {@link ActiveSelection} instance from an object representation
-   * @static
-   * @memberOf ActiveSelection
-   * @param {Object} object Object to create a group from
-   * @returns {Promise<ActiveSelection>}
-   */
-  static fromObject({ objects = [], ...options }) {
-    return enlivenObjects(objects).then(
-      (enlivenedObjects) => new ActiveSelection(enlivenedObjects, options, true)
-    );
   }
 }
 

--- a/src/shapes/active_selection.class.ts
+++ b/src/shapes/active_selection.class.ts
@@ -2,7 +2,7 @@ import { fabric } from '../../HEADER';
 import { ControlRenderingStyleOverride } from '../controls';
 import { TClassProperties } from '../typedefs';
 import { Group, groupDefaultValues } from './group.class';
-import { FabricObject } from './Object/FabricObject';
+import type { FabricObject } from './Object/FabricObject';
 
 export class ActiveSelection extends Group {
   constructor(

--- a/src/shapes/circle.class.ts
+++ b/src/shapes/circle.class.ts
@@ -167,7 +167,7 @@ export class Circle extends FabricObject {
       top = 0,
       radius,
       ...otherParsedAttributes
-    } = parseAttributes(element, Circle.ATTRIBUTE_NAMES);
+    } = parseAttributes(element, this.ATTRIBUTE_NAMES);
 
     if (!radius || radius < 0) {
       throw new Error(
@@ -177,7 +177,7 @@ export class Circle extends FabricObject {
 
     // this probably requires to be fixed for default origins not being top/left.
     callback(
-      new Circle({
+      new this({
         ...otherParsedAttributes,
         radius,
         left: left - radius,
@@ -187,17 +187,6 @@ export class Circle extends FabricObject {
   }
 
   /* _FROM_SVG_END_ */
-
-  /**
-   * Returns {@link Circle} instance from an object representation
-   * @static
-   * @memberOf Circle
-   * @param {Object} object Object to create an instance from
-   * @returns {Promise<Circle>}
-   */
-  static fromObject(object: Record<string, unknown>): Promise<Circle> {
-    return FabricObject._fromObject(Circle, object);
-  }
 }
 
 export const circleDefaultValues: Partial<TClassProperties<Circle>> = {

--- a/src/shapes/ellipse.class.ts
+++ b/src/shapes/ellipse.class.ts
@@ -131,25 +131,14 @@ export class Ellipse extends FabricObject {
     element: SVGElement,
     callback: (ellipse: Ellipse) => void
   ) {
-    const parsedAttributes = parseAttributes(element, Ellipse.ATTRIBUTE_NAMES);
+    const parsedAttributes = parseAttributes(element, this.ATTRIBUTE_NAMES);
 
     parsedAttributes.left = (parsedAttributes.left || 0) - parsedAttributes.rx;
     parsedAttributes.top = (parsedAttributes.top || 0) - parsedAttributes.ry;
-    callback(new Ellipse(parsedAttributes));
+    callback(new this(parsedAttributes));
   }
 
   /* _FROM_SVG_END_ */
-
-  /**
-   * Returns {@link Ellipse} instance from an object representation
-   * @static
-   * @memberOf Ellipse
-   * @param {Object} object Object to create an instance from
-   * @returns {Promise<Ellipse>}
-   */
-  static fromObject(object: any) {
-    return FabricObject._fromObject(Ellipse, object);
-  }
 }
 
 export const ellipseDefaultValues: Partial<TClassProperties<Ellipse>> = {

--- a/src/shapes/group.class.ts
+++ b/src/shapes/group.class.ts
@@ -1052,7 +1052,7 @@ export class Group extends createCollectionMixin(FabricObject<GroupEvents>) {
       enlivenObjectEnlivables(options),
     ]).then(
       ([objects, hydratedOptions]) =>
-        new Group(objects, { ...options, ...hydratedOptions }, true)
+        new this(objects, { ...options, ...hydratedOptions }, true)
     );
   }
 }

--- a/src/shapes/image.class.ts
+++ b/src/shapes/image.class.ts
@@ -733,7 +733,7 @@ export class Image extends FabricObject {
       resizeFilter && enlivenObjects([resizeFilter], filterOptions),
       enlivenObjectEnlivables(object, options),
     ]).then(([el, filters = [], [resizeFilter] = [], hydratedProps = {}]) => {
-      return new Image(el, {
+      return new this(el, {
         ...object,
         src,
         crossOrigin,
@@ -752,7 +752,7 @@ export class Image extends FabricObject {
    * @returns {Promise<Image>}
    */
   static fromURL(url: string, options: LoadImageOptions = {}): Promise<Image> {
-    return loadImage(url, options).then((img) => new Image(img, options));
+    return loadImage(url, options).then((img) => new this(img, options));
   }
 
   /**
@@ -768,8 +768,8 @@ export class Image extends FabricObject {
     callback: (image: Image) => any,
     options: { signal?: AbortSignal } = {}
   ) {
-    const parsedAttributes = parseAttributes(element, Image.ATTRIBUTE_NAMES);
-    Image.fromURL(parsedAttributes['xlink:href'], {
+    const parsedAttributes = parseAttributes(element, this.ATTRIBUTE_NAMES);
+    this.fromURL(parsedAttributes['xlink:href'], {
       ...options,
       ...parsedAttributes,
     }).then(callback);

--- a/src/shapes/itext.class.ts
+++ b/src/shapes/itext.class.ts
@@ -2,15 +2,13 @@
 import { fabric } from '../../HEADER';
 import { ObjectEvents, TransformEvent } from '../EventTypeDefs';
 import { ITextClickBehaviorMixin } from '../mixins/itext_click_behavior.mixin';
-import { TClassProperties, TFiller } from '../typedefs';
-import { stylesFromArray } from '../util/misc/textStyles';
-import { FabricObject } from './Object/FabricObject';
 import {
-  keysMap,
-  keysMapRtl,
   ctrlKeysMapDown,
   ctrlKeysMapUp,
+  keysMap,
+  keysMapRtl,
 } from '../mixins/itext_key_const';
+import { TClassProperties, TFiller } from '../typedefs';
 
 export type ITextEvents = ObjectEvents & {
   'selection:changed': never;
@@ -625,26 +623,6 @@ export class IText extends ITextClickBehaviorMixin<ITextEvents> {
       charIndex =
         cursorPosition.charIndex > 0 ? cursorPosition.charIndex - 1 : 0;
     return { l: cursorPosition.lineIndex, c: charIndex };
-  }
-
-  /**
-   * Returns IText instance from an object representation
-   * @static
-   * @memberOf IText
-   * @param {Object} object Object to create an instance from
-   * @returns {Promise<IText>}
-   */
-  static fromObject(object: object): Promise<IText> {
-    return FabricObject._fromObject(
-      IText,
-      {
-        ...object,
-        styles: stylesFromArray(object.styles, object.text),
-      },
-      {
-        extraParam: 'text',
-      }
-    );
   }
 }
 

--- a/src/shapes/line.class.ts
+++ b/src/shapes/line.class.ts
@@ -276,14 +276,14 @@ export class Line extends FabricObject {
    */
   static fromElement(element, callback, options) {
     options = options || {};
-    const parsedAttributes = parseAttributes(element, Line.ATTRIBUTE_NAMES),
+    const parsedAttributes = parseAttributes(element, this.ATTRIBUTE_NAMES),
       points = [
         parsedAttributes.x1 || 0,
         parsedAttributes.y1 || 0,
         parsedAttributes.x2 || 0,
         parsedAttributes.y2 || 0,
       ];
-    callback(new Line(points, { ...parsedAttributes, ...options }));
+    callback(new this(points, { ...parsedAttributes, ...options }));
   }
 
   /* _FROM_SVG_END_ */
@@ -298,9 +298,9 @@ export class Line extends FabricObject {
   static fromObject(object) {
     const options = clone(object, true);
     options.points = [object.x1, object.y1, object.x2, object.y2];
-    return FabricObject._fromObject(Line, options, {
+    return this._fromObject(options, {
       extraParam: 'points',
-    }).then(function (fabricLine) {
+    }).then((fabricLine) => {
       delete fabricLine.points;
       return fabricLine;
     });

--- a/src/shapes/path.class.ts
+++ b/src/shapes/path.class.ts
@@ -353,7 +353,7 @@ export class Path extends FabricObject {
    * @returns {Promise<Path>}
    */
   static fromObject(object) {
-    return FabricObject._fromObject(Path, object, {
+    return this._fromObject(object, {
       extraParam: 'path',
     });
   }
@@ -368,9 +368,9 @@ export class Path extends FabricObject {
    * @param {Function} [callback] Options callback invoked after parsing is finished
    */
   static fromElement(element, callback, options) {
-    const parsedAttributes = parseAttributes(element, Path.ATTRIBUTE_NAMES);
+    const parsedAttributes = parseAttributes(element, this.ATTRIBUTE_NAMES);
     callback(
-      new Path(parsedAttributes.d, {
+      new this(parsedAttributes.d, {
         ...parsedAttributes,
         ...options,
         // we pass undefined to instruct the constructor to position the object using the bbox

--- a/src/shapes/polygon.class.ts
+++ b/src/shapes/polygon.class.ts
@@ -1,48 +1,10 @@
 import { fabric } from '../../HEADER';
 import { TClassProperties } from '../typedefs';
-import { FabricObject } from './Object/FabricObject';
-import {
-  polyFromElement,
-  Polyline,
-  polylineDefaultValues,
-} from './polyline.class';
+import { Polyline, polylineDefaultValues } from './polyline.class';
 
 export class Polygon extends Polyline {
   protected isOpen() {
     return false;
-  }
-
-  /* _FROM_SVG_START_ */
-
-  /**
-   * Returns {@link Polygon} instance from an SVG element
-   * @static
-   * @memberOf Polygon
-   * @param {SVGElement} element Element to parse
-   * @param {Function} callback callback function invoked after parsing
-   * @param {Object} [options] Options object
-   */
-  static fromElement(
-    element: SVGElement,
-    callback: (poly: Polygon | null) => any,
-    options?: any
-  ) {
-    return polyFromElement(Polygon, element, callback, options);
-  }
-
-  /* _FROM_SVG_END_ */
-
-  /**
-   * Returns Polygon instance from an object representation
-   * @static
-   * @memberOf Polygon
-   * @param {Object} object Object to create an instance from
-   * @returns {Promise<Polygon>}
-   */
-  static fromObject(object: Record<string, unknown>): Promise<Polygon> {
-    return FabricObject._fromObject(Polygon, object, {
-      extraParam: 'points',
-    });
   }
 }
 

--- a/src/shapes/polyline.class.ts
+++ b/src/shapes/polyline.class.ts
@@ -11,36 +11,6 @@ import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { toFixed } from '../util/misc/toFixed';
 import { FabricObject, fabricObjectDefaultValues } from './Object/FabricObject';
 
-export function polyFromElement<
-  T extends {
-    new (points: IPoint[], options: any): any;
-    ATTRIBUTE_NAMES: string[];
-  }
->(
-  klass: T,
-  element: SVGElement,
-  callback: (poly: InstanceType<T> | null) => any,
-  options = {}
-) {
-  if (!element) {
-    return callback(null);
-  }
-  const points = parsePointsAttribute(element.getAttribute('points')),
-    // we omit left and top to instruct the constructor to position the object using the bbox
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    { left, top, ...parsedAttributes } = parseAttributes(
-      element,
-      klass.ATTRIBUTE_NAMES
-    );
-  callback(
-    new klass(points || [], {
-      ...parsedAttributes,
-      ...options,
-      fromSVG: true,
-    })
-  );
-}
-
 export class Polyline extends FabricObject {
   /**
    * Points array
@@ -305,7 +275,23 @@ export class Polyline extends FabricObject {
     callback: (poly: Polyline | null) => any,
     options?: any
   ) {
-    return polyFromElement(Polyline, element, callback, options);
+    if (!element) {
+      return callback(null);
+    }
+    const points = parsePointsAttribute(element.getAttribute('points')),
+      // we omit left and top to instruct the constructor to position the object using the bbox
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      { left, top, ...parsedAttributes } = parseAttributes(
+        element,
+        this.ATTRIBUTE_NAMES
+      );
+    callback(
+      new this(points || [], {
+        ...parsedAttributes,
+        ...options,
+        fromSVG: true,
+      })
+    );
   }
 
   /* _FROM_SVG_END_ */
@@ -317,8 +303,8 @@ export class Polyline extends FabricObject {
    * @param {Object} object Object to create an instance from
    * @returns {Promise<Polyline>}
    */
-  static fromObject(object: Record<string, unknown>): Promise<Polyline> {
-    return FabricObject._fromObject(Polyline, object, {
+  static fromObject(object: Record<string, unknown>) {
+    return this._fromObject(object, {
       extraParam: 'points',
     });
   }

--- a/src/shapes/rect.class.ts
+++ b/src/shapes/rect.class.ts
@@ -142,17 +142,6 @@ export class Rect extends FabricObject {
     'height',
   ];
 
-  /**
-   * Returns {@link Rect} instance from an object representation
-   * @static
-   * @memberOf Rect
-   * @param {Object} object Object to create an instance from
-   * @returns {Promise<Rect>}
-   */
-  static fromObject(object: any) {
-    return FabricObject._fromObject(Rect, object);
-  }
-
   /* _FROM_SVG_START_ */
 
   /**
@@ -178,9 +167,9 @@ export class Rect extends FabricObject {
       height = 0,
       visible = true,
       ...restOfparsedAttributes
-    } = parseAttributes(element, Rect.ATTRIBUTE_NAMES);
+    } = parseAttributes(element, this.ATTRIBUTE_NAMES);
 
-    const rect = new Rect({
+    const rect = new this({
       ...options,
       ...restOfparsedAttributes,
       left,

--- a/src/shapes/text.class.ts
+++ b/src/shapes/text.class.ts
@@ -1823,7 +1823,7 @@ export class Text<
     const originalStrokeWidth = options.strokeWidth;
     options.strokeWidth = 0;
 
-    const text = new Text(textContent, options),
+    const text = new this(textContent, options),
       textHeightScaleFactor = text.getScaledHeight() / text.height,
       lineHeightDiff =
         (text.height + text.strokeWidth) * text.lineHeight - text.height,
@@ -1858,14 +1858,11 @@ export class Text<
 
   /**
    * Returns Text instance from an object representation
-   * @static
-   * @memberOf Text
    * @param {Object} object plain js Object to create an instance from
    * @returns {Promise<Text>}
    */
   static fromObject(object: Record<string, any>): Promise<Text> {
-    return FabricObject._fromObject(
-      Text,
+    return this._fromObject(
       {
         ...object,
         styles: stylesFromArray(object.styles, object.text),

--- a/src/shapes/textbox.class.ts
+++ b/src/shapes/textbox.class.ts
@@ -2,9 +2,7 @@
 
 import { fabric } from '../../HEADER';
 import { TClassProperties } from '../typedefs';
-import { stylesFromArray } from '../util/misc/textStyles';
 import { IText } from './itext.class';
-import { FabricObject } from './Object/FabricObject';
 import { textDefaultValues } from './text.class';
 
 /**
@@ -457,26 +455,6 @@ export class Textbox extends IText {
   toObject(propertiesToInclude: Array<any>): object {
     return super.toObject(
       ['minWidth', 'splitByGrapheme'].concat(propertiesToInclude)
-    );
-  }
-
-  /**
-   * Returns Textbox instance from an object representation
-   * @static
-   * @memberOf Textbox
-   * @param {Object} object Object to create an instance from
-   * @returns {Promise<Textbox>}
-   */
-  static fromObject(object: object): Promise<Textbox> {
-    return FabricObject._fromObject(
-      Textbox,
-      {
-        ...object,
-        styles: stylesFromArray(object.styles, object.text),
-      },
-      {
-        extraParam: 'text',
-      }
     );
   }
 }

--- a/src/shapes/triangle.class.ts
+++ b/src/shapes/triangle.class.ts
@@ -31,17 +31,6 @@ export class Triangle extends FabricObject {
       points = `${-widthBy2} ${heightBy2},0 ${-heightBy2},${widthBy2} ${heightBy2}`;
     return ['<polygon ', 'COMMON_PARTS', 'points="', points, '" />'];
   }
-
-  /**
-   * Returns {@link Triangle} instance from an object representation
-   * @static
-   * @memberOf Triangle
-   * @param {Object} object Object to create an instance from
-   * @returns {Promise<Triangle>}
-   */
-  static fromObject(object: any) {
-    return FabricObject._fromObject(Triangle, object);
-  }
 }
 
 export const triangleDefaultValues: Partial<TClassProperties<Triangle>> = {


### PR DESCRIPTION

## Motivation

Using `this` in static constructors makes it very easy to subclass because the subclass won't have to impl its own static constructors. And it relieves fabric from redundancies.
The dev will need to register the class not matter what.

## Description

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
