### PR TITLE
feat(): Add Textbox overflowBreakWord option

### DIFF
--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -1,4 +1,4 @@
-(function () {
+(function() {
   var canvas = this.canvas = new fabric.Canvas();
   QUnit.module('fabric.Textbox', {
     before() {
@@ -77,24 +77,24 @@
     pathAlign: 'baseline'
   };
 
-  QUnit.test('constructor', function (assert) {
+  QUnit.test('constructor', function(assert) {
     var textbox = new fabric.Textbox('test');
     assert.ok(textbox instanceof fabric.Textbox);
     assert.ok(textbox instanceof fabric.IText);
     assert.ok(textbox instanceof fabric.Text);
   });
 
-  QUnit.test('constructor with width', function (assert) {
+  QUnit.test('constructor with width', function(assert) {
     var textbox = new fabric.Textbox('test', { width: 400 });
     assert.equal(textbox.width, 400, 'width is taken by contstructor');
   });
 
-  QUnit.test('constructor with width too small', function (assert) {
+  QUnit.test('constructor with width too small', function(assert) {
     var textbox = new fabric.Textbox('test', { width: 5 });
     assert.equal(Math.round(textbox.width), 56, 'width is calculated by constructor');
   });
 
-  QUnit.test('initial properties', function (assert) {
+  QUnit.test('initial properties', function(assert) {
     var textbox = new fabric.Textbox('test');
     assert.equal(textbox.text, 'test');
     assert.equal(textbox.type, 'textbox');
@@ -102,7 +102,7 @@
     assert.ok(textbox.cacheProperties.indexOf('width') > -1, 'width is in cacheProperties');
   });
 
-  QUnit.test('toObject', function (assert) {
+  QUnit.test('toObject', function(assert) {
     var textbox = new fabric.Textbox('The quick \nbrown \nfox', {
       width: 120,
       styles: {
@@ -132,16 +132,16 @@
     assert.deepEqual(obj.styles[1].style, TEXTBOX_OBJECT.styles[1].style, 'style properties match at second index');
   });
 
-  QUnit.test('fromObject', function (assert) {
+  QUnit.test('fromObject', function(assert) {
     var done = assert.async();
-    fabric.Textbox.fromObject(TEXTBOX_OBJECT).then(function (textbox) {
+    fabric.Textbox.fromObject(TEXTBOX_OBJECT).then(function(textbox) {
       assert.equal(textbox.text, 'The quick \nbrown \nfox', 'properties are respected');
       assert.ok(textbox instanceof fabric.Textbox, 'the generated object is a textbox');
       done();
     });
   });
 
-  QUnit.test('fromObjectWithStyles', function (assert) {
+  QUnit.test('fromObjectWithStyles', function(assert) {
     var done = assert.async();
     var textbox = new fabric.Textbox('The quick \nbrown \nfox', {
       width: 120,
@@ -163,7 +163,7 @@
         }
       }
     });
-    fabric.Textbox.fromObject(TEXTBOX_OBJECT).then(function (obj) {
+    fabric.Textbox.fromObject(TEXTBOX_OBJECT).then(function(obj) {
       assert.notEqual(obj.styles, textbox.styles, 'styles is a different object after initialization');
       assert.deepEqual(obj.styles, textbox.styles, 'stylesFromArray output matches');
       assert.deepEqual(obj.styles[0], textbox.styles[0], 'styles match at line 0');
@@ -179,14 +179,14 @@
       assert.deepEqual(obj.styles[2], textbox.styles[2], 'styles match at line 2');
       assert.deepEqual(obj.styles[2][0], textbox.styles[2][0], 'styles match at index 0');
       assert.deepEqual(obj.styles[2][1], textbox.styles[2][1], 'styles match at index 1');
-      fabric.Textbox.fromObject(obj).then(function (obj2) {
+      fabric.Textbox.fromObject(obj).then(function(obj2) {
         assert.notEqual(obj.styles, obj2.styles, 'styles copy is a different object after initialization');
         done();
       });
     });
   });
 
-  QUnit.test('isEndOfWrapping', function (assert) {
+  QUnit.test('isEndOfWrapping', function(assert) {
     var textbox = new fabric.Textbox('a q o m s g\np q r s t w', {
       width: 70,
     });
@@ -198,7 +198,7 @@
     assert.equal(textbox.isEndOfWrapping(5), true, 'last line is end of wrapping');
   });
 
-  QUnit.test('_removeExtraneousStyles', function (assert) {
+  QUnit.test('_removeExtraneousStyles', function(assert) {
     var textbox = new fabric.Textbox('a q o m s g\np q r s t w', {
       width: 40,
       styles: {
@@ -220,7 +220,7 @@
     assert.equal(textbox.styles[5], undefined, 'style line 5 has been removed');
   });
 
-  QUnit.test('isEmptyStyles', function (assert) {
+  QUnit.test('isEmptyStyles', function(assert) {
     var textbox = new fabric.Textbox('x x', { width: 5, styles: { 0: { 0: { fill: 'red' } } } });
     assert.equal(textbox._textLines.length, 2, 'lines are wrapped');
     assert.equal(textbox._unwrappedTextLines.length, 1, 'there is only one text line');
@@ -229,7 +229,7 @@
     assert.equal(textbox.isEmptyStyles(1), true, 'style is empty at line 1');
   });
 
-  QUnit.test('isEmptyStyles does not crash on null styles', function (assert) {
+  QUnit.test('isEmptyStyles does not crash on null styles', function(assert) {
     var textbox = new fabric.Textbox('x x', { width: 5 });
     textbox.styles = null;
     assert.equal(textbox._textLines.length, 2, 'lines are wrapped');
@@ -237,7 +237,7 @@
     assert.equal(textbox.isEmptyStyles(1), true, 'style is empty');
   });
 
-  QUnit.test('isEmptyStyles alternate lines', function (assert) {
+  QUnit.test('isEmptyStyles alternate lines', function(assert) {
     var textbox = new fabric.Textbox('xa xb xc xd xe\nya yb', {
       width: 5,
       styles: {
@@ -256,7 +256,7 @@
     assert.equal(textbox.isEmptyStyles(5), true, 'style is empty at line 5');
     assert.equal(textbox.isEmptyStyles(6), false, 'style is empty at line 6');
   });
-  QUnit.test('wrapping with charspacing', function (assert) {
+  QUnit.test('wrapping with charspacing', function(assert) {
     var textbox = new fabric.Textbox('xa xb xc xd xe ya yb id', {
       width: 190,
     });
@@ -271,7 +271,7 @@
     textbox.initDimensions();
     assert.equal(textbox.textLines[0], 'xa', 'first line match expectations spacing 800');
   });
-  QUnit.test('wrapping with charspacing and splitByGrapheme positive', function (assert) {
+  QUnit.test('wrapping with charspacing and splitByGrapheme positive', function(assert) {
     var textbox = new fabric.Textbox('xaxbxcxdeyaybid', {
       width: 190,
       splitByGrapheme: true,
@@ -283,7 +283,7 @@
       'lines match splitByGrapheme charSpacing 400'
     );
   });
-  QUnit.test('wrapping with charspacing and splitByGrapheme negative', function (assert) {
+  QUnit.test('wrapping with charspacing and splitByGrapheme negative', function(assert) {
     var textbox = new fabric.Textbox('xaxbxcxdeyaybid', {
       width: 190,
       splitByGrapheme: true,
@@ -295,7 +295,7 @@
       'lines match splitByGrapheme charSpacing -100'
     );
   });
-  QUnit.test('wrapping with charspacing and overflowBreakWord positive', function (assert) {
+  QUnit.test('wrapping with charspacing and overflowBreakWord positive', function(assert) {
     var textbox = new fabric.Textbox('xaxbxcxdeyaybid', {
       width: 190,
       overflowBreakWord: true,
@@ -307,7 +307,7 @@
       'lines match overflowBreakWord charSpacing 400'
     );
   });
-  QUnit.test('wrapping with charspacing and overflowBreakWord negative', function (assert) {
+  QUnit.test('wrapping with charspacing and overflowBreakWord negative', function(assert) {
     var textbox = new fabric.Textbox('xaxbxcxdeyaybid', {
       width: 190,
       overflowBreakWord: true,
@@ -319,7 +319,7 @@
       'lines match overflowBreakWord charSpacing -100'
     );
   });
-  QUnit.test('wrapping with different things', function (assert) {
+  QUnit.test('wrapping with different things', function(assert) {
     var textbox = new fabric.Textbox('xa xb\txc\rxd xe ya yb id', {
       width: 16,
     });
@@ -331,7 +331,7 @@
     assert.equal(textbox.textLines[5], 'ya', '5 line match expectations');
     assert.equal(textbox.textLines[6], 'yb', '6 line match expectations');
   });
-  QUnit.test('wrapping with splitByGrapheme', function (assert) {
+  QUnit.test('wrapping with splitByGrapheme', function(assert) {
     var textbox = new fabric.Textbox('xaxbxcxdxeyaybid', {
       width: 1,
       splitByGrapheme: true,
@@ -343,7 +343,7 @@
     assert.equal(textbox.textLines[4], 'x', '4 line match expectations splitByGrapheme');
     assert.equal(textbox.textLines[5], 'c', '5 line match expectations splitByGrapheme');
   });
-  QUnit.test('wrapping with overflowBreakWord', function (assert) {
+  QUnit.test('wrapping with overflowBreakWord', function(assert) {
     var textbox = new fabric.Textbox('xaxbxcxdxeyaybid', {
       width: 1,
       splitByGrapheme: true,
@@ -355,7 +355,7 @@
     assert.equal(textbox.textLines[4], 'x', '4 line match expectations splitByGrapheme');
     assert.equal(textbox.textLines[5], 'c', '5 line match expectations splitByGrapheme');
   });
-  QUnit.test('wrapping with custom space', function (assert) {
+  QUnit.test('wrapping with custom space', function(assert) {
     var textbox = new fabric.Textbox('xa xb xc xd xe ya yb id', {
       width: 2000,
     });
@@ -380,7 +380,7 @@
     assert.deepEqual(line2, expected2, 'wrapping without reserved');
     assert.deepEqual(textbox.dynamicMinWidth, 90, 'wrapping without reserved');
   });
-  QUnit.test('wrapping an empty line', function (assert) {
+  QUnit.test('wrapping an empty line', function(assert) {
     var textbox = new fabric.Textbox('', {
       width: 10,
     });
@@ -393,7 +393,7 @@
     var line3 = textbox._wrapLineOfWordBreak('', 0, 100, 0);
     assert.deepEqual(line3, [[]], 'wrapping with overflowBreakWord');
   });
-  QUnit.test('texbox will change width from the mr corner', function (assert) {
+  QUnit.test('texbox will change width from the mr corner', function(assert) {
     var text = new fabric.Textbox('xa xb xc xd xe ya yb id', { strokeWidth: 0 });
     canvas.add(text);
     canvas.setActiveObject(text);
@@ -418,7 +418,7 @@
     });
     assert.equal(text.width, originalWidth + 20, 'width increased');
   });
-  QUnit.test('texbox will change width from the ml corner', function (assert) {
+  QUnit.test('texbox will change width from the ml corner', function(assert) {
     var text = new fabric.Textbox('xa xb xc xd xe ya yb id', { strokeWidth: 0, left: 40 });
     canvas.add(text);
     canvas.setActiveObject(text);
@@ -443,7 +443,7 @@
     });
     assert.equal(text.width, originalWidth + 20, 'width increased');
   });
-  QUnit.test('_removeExtraneousStyles', function (assert) {
+  QUnit.test('_removeExtraneousStyles', function(assert) {
     var iText = new fabric.Textbox('a\nq\qo', {
       styles: {
         0: { 0: { fontSize: 4 } },
@@ -460,7 +460,7 @@
     assert.equal(iText.styles[4], undefined, 'style line 4 has been removed');
   });
 
-  QUnit.test('get2DCursorLocation with splitByGrapheme', function (assert) {
+  QUnit.test('get2DCursorLocation with splitByGrapheme', function(assert) {
     var iText = new fabric.Textbox('aaaaaaaaaaaaaaaaaaaaaaaa',
       { width: 60, splitByGrapheme: true });
     var loc = iText.get2DCursorLocation();
@@ -498,7 +498,7 @@
     assert.equal(loc.charIndex, 2, 'selection end 14 char 2');
   });
 
-  QUnit.test('get2DCursorLocation with overflowBreakWord', function (assert) {
+  QUnit.test('get2DCursorLocation with overflowBreakWord', function(assert) {
     var iText = new fabric.Textbox('aaaaaaaaaaaaaaaaaaaaaaaa',
       { width: 60, overflowBreakWord: true });
     var loc = iText.get2DCursorLocation();
@@ -536,7 +536,7 @@
     assert.equal(loc.charIndex, 2, 'selection end 14 char 2');
   });
 
-  QUnit.test('missingNewlineOffset with splitByGrapheme', function (assert) {
+  QUnit.test('missingNewlineOffset with splitByGrapheme', function(assert) {
     var textbox = new fabric.Textbox('aaa\naaaaaa\na\naaaaaaaaaaaa\naaa',
       { width: 80, splitByGrapheme: true });
 
@@ -556,7 +556,7 @@
     assert.equal(offset, 0, 'line 1 is wrapped without a \n so it does have an extra char count');
   });
 
-  QUnit.test('missingNewlineOffset with normal split', function (assert) {
+  QUnit.test('missingNewlineOffset with normal split', function(assert) {
     var texbox = new fabric.Textbox('aaa\naaaaaa\na\naaaaaaaaaaaa\naaa',
       { width: 160 });
 
@@ -568,7 +568,7 @@
     assert.equal(offset, 1, 'it returns always 1');
   });
 
-  QUnit.test('missingNewlineOffset with overflowBreakWord', function (assert) {
+  QUnit.test('missingNewlineOffset with overflowBreakWord', function(assert) {
     var textbox = new fabric.Textbox('aaa\naaaaaa\na\naaaaaaaaaaaa\naaa',
       { width: 80, overflowBreakWord: true });
 
@@ -589,7 +589,7 @@
     assert.equal(offset, 0, 'line 1 is wrapped without a \n so it does have an extra char count');
   });
 
-  QUnit.test('_getLineStyle', function (assert) {
+  QUnit.test('_getLineStyle', function(assert) {
     var textbox = new fabric.Textbox('aaa aaq ggg gg\noee eee', {
       styles: {
         1: { 0: { fontSize: 4 } },
@@ -602,7 +602,7 @@
     assert.equal(textbox._getLineStyle(4), true, 'wrapped line 2 has style');
   });
 
-  QUnit.test('_setLineStyle', function (assert) {
+  QUnit.test('_setLineStyle', function(assert) {
     var textbox = new fabric.Textbox('aaa aaq ggg gg\noee eee', {
       styles: {
         1: { 0: { fontSize: 4 } },
@@ -626,7 +626,7 @@
     assert.deepEqual(textbox.styles[0], {}, 'style is an empty object');
   });
 
-  QUnit.test('_deleteStyleDeclaration', function (assert) {
+  QUnit.test('_deleteStyleDeclaration', function(assert) {
     var text = 'aaa aaq ggg gg oee eee';
     var styles = {};
     for (var index = 0; index < text.length; index++) {
@@ -642,7 +642,7 @@
     assert.equal(textbox.styles[0][10], undefined, 'style has been removed');
   });
 
-  QUnit.test('_setStyleDeclaration', function (assert) {
+  QUnit.test('_setStyleDeclaration', function(assert) {
     var text = 'aaa aaq ggg gg oee eee';
     var styles = {};
     for (var index = 0; index < text.length; index++) {
@@ -659,7 +659,7 @@
     assert.equal(textbox.styles[0][10], newStyle, 'style has been changed');
   });
 
-  QUnit.test('styleHas', function (assert) {
+  QUnit.test('styleHas', function(assert) {
     var textbox = new fabric.Textbox('aaa aaq ggg gg oee eee', {
       styles: {
         0: {
@@ -681,7 +681,7 @@
     assert.equal(textbox.styleHas('fontFamily', 1), true, 'style has fontFamily on line 1');
   });
 
-  QUnit.test('The same text does not need to be wrapped.', function (assert) {
+  QUnit.test('The same text does not need to be wrapped.', function(assert) {
     var str = '0123456789';
     var measureTextbox = new fabric.Textbox(str, {
       fontSize: 20,
@@ -694,7 +694,7 @@
     });
     assert.equal(newTextbox.textLines.length, measureTextbox.textLines.length, 'The same text is not wrapped');
   });
-  QUnit.test('The same text does not need to be wrapped.', function (assert) {
+  QUnit.test('The same text does not need to be wrapped.', function(assert) {
     var str = '0123456789';
     var measureTextbox = new fabric.Textbox(str, {
       fontSize: 20,

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
   var canvas = this.canvas = new fabric.Canvas();
   QUnit.module('fabric.Textbox', {
     before() {
@@ -68,6 +68,7 @@
     ],
     minWidth: 20,
     splitByGrapheme: false,
+    overflowBreakWord: false,
     strokeUniform: false,
     path: null,
     direction: 'ltr',
@@ -76,49 +77,49 @@
     pathAlign: 'baseline'
   };
 
-  QUnit.test('constructor', function(assert) {
+  QUnit.test('constructor', function (assert) {
     var textbox = new fabric.Textbox('test');
     assert.ok(textbox instanceof fabric.Textbox);
     assert.ok(textbox instanceof fabric.IText);
     assert.ok(textbox instanceof fabric.Text);
   });
 
-  QUnit.test('constructor with width', function(assert) {
+  QUnit.test('constructor with width', function (assert) {
     var textbox = new fabric.Textbox('test', { width: 400 });
     assert.equal(textbox.width, 400, 'width is taken by contstructor');
   });
 
-  QUnit.test('constructor with width too small', function(assert) {
+  QUnit.test('constructor with width too small', function (assert) {
     var textbox = new fabric.Textbox('test', { width: 5 });
     assert.equal(Math.round(textbox.width), 56, 'width is calculated by constructor');
   });
 
-  QUnit.test('initial properties', function(assert) {
+  QUnit.test('initial properties', function (assert) {
     var textbox = new fabric.Textbox('test');
     assert.equal(textbox.text, 'test');
     assert.equal(textbox.type, 'textbox');
-    assert.deepEqual(textbox.styles, { });
+    assert.deepEqual(textbox.styles, {});
     assert.ok(textbox.cacheProperties.indexOf('width') > -1, 'width is in cacheProperties');
   });
 
-  QUnit.test('toObject', function(assert) {
+  QUnit.test('toObject', function (assert) {
     var textbox = new fabric.Textbox('The quick \nbrown \nfox', {
       width: 120,
       styles: {
-        "0":{
-          "5":{fill:"red"},
-          "6":{fill:"red"},
-          "7":{fill:"red"},
-          "8":{fill:"red"}
+        "0": {
+          "5": { fill: "red" },
+          "6": { fill: "red" },
+          "7": { fill: "red" },
+          "8": { fill: "red" }
         },
-        "1":{
-          "3":{underline:true},
-          "4":{underline:true},
-          "5":{underline:true}
+        "1": {
+          "3": { underline: true },
+          "4": { underline: true },
+          "5": { underline: true }
         },
-        "2":{
-          "0":{underline:true},
-          "1":{underline:true}
+        "2": {
+          "0": { underline: true },
+          "1": { underline: true }
         }
       }
     });
@@ -131,38 +132,38 @@
     assert.deepEqual(obj.styles[1].style, TEXTBOX_OBJECT.styles[1].style, 'style properties match at second index');
   });
 
-  QUnit.test('fromObject', function(assert) {
+  QUnit.test('fromObject', function (assert) {
     var done = assert.async();
-    fabric.Textbox.fromObject(TEXTBOX_OBJECT).then(function(textbox) {
+    fabric.Textbox.fromObject(TEXTBOX_OBJECT).then(function (textbox) {
       assert.equal(textbox.text, 'The quick \nbrown \nfox', 'properties are respected');
       assert.ok(textbox instanceof fabric.Textbox, 'the generated object is a textbox');
       done();
     });
   });
 
-  QUnit.test('fromObjectWithStyles', function(assert) {
+  QUnit.test('fromObjectWithStyles', function (assert) {
     var done = assert.async();
     var textbox = new fabric.Textbox('The quick \nbrown \nfox', {
       width: 120,
       styles: {
-        "0":{
-          "5":{fill:"red"},
-          "6":{fill:"red"},
-          "7":{fill:"red"},
-          "8":{fill:"red"}
+        "0": {
+          "5": { fill: "red" },
+          "6": { fill: "red" },
+          "7": { fill: "red" },
+          "8": { fill: "red" }
         },
-        "1":{
-          "3":{underline:true},
-          "4":{underline:true},
-          "5":{underline:true}
+        "1": {
+          "3": { underline: true },
+          "4": { underline: true },
+          "5": { underline: true }
         },
-        "2":{
-          "0":{underline:true},
-          "1":{underline:true}
+        "2": {
+          "0": { underline: true },
+          "1": { underline: true }
         }
       }
     });
-    fabric.Textbox.fromObject(TEXTBOX_OBJECT).then(function(obj) {
+    fabric.Textbox.fromObject(TEXTBOX_OBJECT).then(function (obj) {
       assert.notEqual(obj.styles, textbox.styles, 'styles is a different object after initialization');
       assert.deepEqual(obj.styles, textbox.styles, 'stylesFromArray output matches');
       assert.deepEqual(obj.styles[0], textbox.styles[0], 'styles match at line 0');
@@ -178,14 +179,14 @@
       assert.deepEqual(obj.styles[2], textbox.styles[2], 'styles match at line 2');
       assert.deepEqual(obj.styles[2][0], textbox.styles[2][0], 'styles match at index 0');
       assert.deepEqual(obj.styles[2][1], textbox.styles[2][1], 'styles match at index 1');
-      fabric.Textbox.fromObject(obj).then(function(obj2) {
+      fabric.Textbox.fromObject(obj).then(function (obj2) {
         assert.notEqual(obj.styles, obj2.styles, 'styles copy is a different object after initialization');
         done();
       });
     });
   });
 
-  QUnit.test('isEndOfWrapping', function(assert) {
+  QUnit.test('isEndOfWrapping', function (assert) {
     var textbox = new fabric.Textbox('a q o m s g\np q r s t w', {
       width: 70,
     });
@@ -197,7 +198,7 @@
     assert.equal(textbox.isEndOfWrapping(5), true, 'last line is end of wrapping');
   });
 
-  QUnit.test('_removeExtraneousStyles', function(assert) {
+  QUnit.test('_removeExtraneousStyles', function (assert) {
     var textbox = new fabric.Textbox('a q o m s g\np q r s t w', {
       width: 40,
       styles: {
@@ -219,7 +220,7 @@
     assert.equal(textbox.styles[5], undefined, 'style line 5 has been removed');
   });
 
-  QUnit.test('isEmptyStyles', function(assert) {
+  QUnit.test('isEmptyStyles', function (assert) {
     var textbox = new fabric.Textbox('x x', { width: 5, styles: { 0: { 0: { fill: 'red' } } } });
     assert.equal(textbox._textLines.length, 2, 'lines are wrapped');
     assert.equal(textbox._unwrappedTextLines.length, 1, 'there is only one text line');
@@ -228,7 +229,7 @@
     assert.equal(textbox.isEmptyStyles(1), true, 'style is empty at line 1');
   });
 
-  QUnit.test('isEmptyStyles does not crash on null styles', function(assert) {
+  QUnit.test('isEmptyStyles does not crash on null styles', function (assert) {
     var textbox = new fabric.Textbox('x x', { width: 5 });
     textbox.styles = null;
     assert.equal(textbox._textLines.length, 2, 'lines are wrapped');
@@ -236,7 +237,7 @@
     assert.equal(textbox.isEmptyStyles(1), true, 'style is empty');
   });
 
-  QUnit.test('isEmptyStyles alternate lines', function(assert) {
+  QUnit.test('isEmptyStyles alternate lines', function (assert) {
     var textbox = new fabric.Textbox('xa xb xc xd xe\nya yb', {
       width: 5,
       styles: {
@@ -255,7 +256,7 @@
     assert.equal(textbox.isEmptyStyles(5), true, 'style is empty at line 5');
     assert.equal(textbox.isEmptyStyles(6), false, 'style is empty at line 6');
   });
-  QUnit.test('wrapping with charspacing', function(assert) {
+  QUnit.test('wrapping with charspacing', function (assert) {
     var textbox = new fabric.Textbox('xa xb xc xd xe ya yb id', {
       width: 190,
     });
@@ -270,7 +271,7 @@
     textbox.initDimensions();
     assert.equal(textbox.textLines[0], 'xa', 'first line match expectations spacing 800');
   });
-  QUnit.test('wrapping with charspacing and splitByGrapheme positive', function(assert) {
+  QUnit.test('wrapping with charspacing and splitByGrapheme positive', function (assert) {
     var textbox = new fabric.Textbox('xaxbxcxdeyaybid', {
       width: 190,
       splitByGrapheme: true,
@@ -282,7 +283,7 @@
       'lines match splitByGrapheme charSpacing 400'
     );
   });
-  QUnit.test('wrapping with charspacing and splitByGrapheme negative', function(assert) {
+  QUnit.test('wrapping with charspacing and splitByGrapheme negative', function (assert) {
     var textbox = new fabric.Textbox('xaxbxcxdeyaybid', {
       width: 190,
       splitByGrapheme: true,
@@ -294,7 +295,31 @@
       'lines match splitByGrapheme charSpacing -100'
     );
   });
-  QUnit.test('wrapping with different things', function(assert) {
+  QUnit.test('wrapping with charspacing and overflowBreakWord positive', function (assert) {
+    var textbox = new fabric.Textbox('xaxbxcxdeyaybid', {
+      width: 190,
+      overflowBreakWord: true,
+      charSpacing: 400
+    });
+    assert.deepEqual(
+      textbox.textLines,
+      ['xaxbx', 'cxdey', 'aybid'],
+      'lines match overflowBreakWord charSpacing 400'
+    );
+  });
+  QUnit.test('wrapping with charspacing and overflowBreakWord negative', function (assert) {
+    var textbox = new fabric.Textbox('xaxbxcxdeyaybid', {
+      width: 190,
+      overflowBreakWord: true,
+      charSpacing: -100
+    });
+    assert.deepEqual(
+      textbox.textLines,
+      ['xaxbxcxdeyay', 'bid'],
+      'lines match overflowBreakWord charSpacing -100'
+    );
+  });
+  QUnit.test('wrapping with different things', function (assert) {
     var textbox = new fabric.Textbox('xa xb\txc\rxd xe ya yb id', {
       width: 16,
     });
@@ -306,7 +331,7 @@
     assert.equal(textbox.textLines[5], 'ya', '5 line match expectations');
     assert.equal(textbox.textLines[6], 'yb', '6 line match expectations');
   });
-  QUnit.test('wrapping with splitByGrapheme', function(assert) {
+  QUnit.test('wrapping with splitByGrapheme', function (assert) {
     var textbox = new fabric.Textbox('xaxbxcxdxeyaybid', {
       width: 1,
       splitByGrapheme: true,
@@ -318,12 +343,24 @@
     assert.equal(textbox.textLines[4], 'x', '4 line match expectations splitByGrapheme');
     assert.equal(textbox.textLines[5], 'c', '5 line match expectations splitByGrapheme');
   });
-  QUnit.test('wrapping with custom space', function(assert) {
+  QUnit.test('wrapping with overflowBreakWord', function (assert) {
+    var textbox = new fabric.Textbox('xaxbxcxdxeyaybid', {
+      width: 1,
+      splitByGrapheme: true,
+    });
+    assert.equal(textbox.textLines[0], 'x', '0 line match expectations splitByGrapheme');
+    assert.equal(textbox.textLines[1], 'a', '1 line match expectations splitByGrapheme');
+    assert.equal(textbox.textLines[2], 'x', '2 line match expectations splitByGrapheme');
+    assert.equal(textbox.textLines[3], 'b', '3 line match expectations splitByGrapheme');
+    assert.equal(textbox.textLines[4], 'x', '4 line match expectations splitByGrapheme');
+    assert.equal(textbox.textLines[5], 'c', '5 line match expectations splitByGrapheme');
+  });
+  QUnit.test('wrapping with custom space', function (assert) {
     var textbox = new fabric.Textbox('xa xb xc xd xe ya yb id', {
       width: 2000,
     });
     var line1 = textbox._wrapLine('xa xb xc xd xe ya yb id', 0, 100, 0);
-    var expected1 =  [
+    var expected1 = [
       ['x', 'a', ' ', 'x', 'b'],
       ['x', 'c', ' ', 'x', 'd'],
       ['x', 'e', ' ', 'y', 'a'],
@@ -331,7 +368,7 @@
     assert.deepEqual(line1, expected1, 'wrapping without reserved');
     assert.deepEqual(textbox.dynamicMinWidth, 40, 'wrapping without reserved');
     var line2 = textbox._wrapLine('xa xb xc xd xe ya yb id', 0, 100, 50);
-    var expected2 =  [
+    var expected2 = [
       ['x', 'a'],
       ['x', 'b'],
       ['x', 'c'],
@@ -343,7 +380,7 @@
     assert.deepEqual(line2, expected2, 'wrapping without reserved');
     assert.deepEqual(textbox.dynamicMinWidth, 90, 'wrapping without reserved');
   });
-  QUnit.test('wrapping an empty line', function(assert) {
+  QUnit.test('wrapping an empty line', function (assert) {
     var textbox = new fabric.Textbox('', {
       width: 10,
     });
@@ -352,13 +389,16 @@
     textbox.splitByGrapheme = true;
     var line2 = textbox._wrapLine('', 0, 100, 0);
     assert.deepEqual(line2, [[]], 'wrapping with splitByGrapheme');
+    textbox.overflowBreakWord = true;
+    var line3 = textbox._wrapLineOfWordBreak('', 0, 100, 0);
+    assert.deepEqual(line3, [[]], 'wrapping with overflowBreakWord');
   });
-  QUnit.test('texbox will change width from the mr corner', function(assert) {
+  QUnit.test('texbox will change width from the mr corner', function (assert) {
     var text = new fabric.Textbox('xa xb xc xd xe ya yb id', { strokeWidth: 0 });
     canvas.add(text);
     canvas.setActiveObject(text);
     var canvasEl = canvas.getElement(),
-        canvasOffset = fabric.util.getElementOffset(canvasEl);
+      canvasOffset = fabric.util.getElementOffset(canvasEl);
     var eventStub = {
       clientX: canvasOffset.left + text.width,
       clientY: canvasOffset.top + text.oCoords.mr.corner.tl.y + 1,
@@ -378,12 +418,12 @@
     });
     assert.equal(text.width, originalWidth + 20, 'width increased');
   });
-  QUnit.test('texbox will change width from the ml corner', function(assert) {
+  QUnit.test('texbox will change width from the ml corner', function (assert) {
     var text = new fabric.Textbox('xa xb xc xd xe ya yb id', { strokeWidth: 0, left: 40 });
     canvas.add(text);
     canvas.setActiveObject(text);
     var canvasEl = canvas.getElement(),
-        canvasOffset = fabric.util.getElementOffset(canvasEl);
+      canvasOffset = fabric.util.getElementOffset(canvasEl);
     var eventStub = {
       clientX: canvasOffset.left + text.left,
       clientY: canvasOffset.top + text.oCoords.ml.corner.tl.y + 2,
@@ -403,14 +443,16 @@
     });
     assert.equal(text.width, originalWidth + 20, 'width increased');
   });
-  QUnit.test('_removeExtraneousStyles', function(assert) {
-    var iText = new fabric.Textbox('a\nq\qo', { styles: {
-      0: { 0: { fontSize: 4 } },
-      1: { 0: { fontSize: 4 } },
-      2: { 0: { fontSize: 4 } },
-      3: { 0: { fontSize: 4 } },
-      4: { 0: { fontSize: 4 } },
-    } });
+  QUnit.test('_removeExtraneousStyles', function (assert) {
+    var iText = new fabric.Textbox('a\nq\qo', {
+      styles: {
+        0: { 0: { fontSize: 4 } },
+        1: { 0: { fontSize: 4 } },
+        2: { 0: { fontSize: 4 } },
+        3: { 0: { fontSize: 4 } },
+        4: { 0: { fontSize: 4 } },
+      }
+    });
     assert.deepEqual(iText.styles[3], { 0: { fontSize: 4 } }, 'style line 3 exists');
     assert.deepEqual(iText.styles[4], { 0: { fontSize: 4 } }, 'style line 4 exists');
     iText._removeExtraneousStyles();
@@ -418,7 +460,7 @@
     assert.equal(iText.styles[4], undefined, 'style line 4 has been removed');
   });
 
-  QUnit.test('get2DCursorLocation with splitByGrapheme', function(assert) {
+  QUnit.test('get2DCursorLocation with splitByGrapheme', function (assert) {
     var iText = new fabric.Textbox('aaaaaaaaaaaaaaaaaaaaaaaa',
       { width: 60, splitByGrapheme: true });
     var loc = iText.get2DCursorLocation();
@@ -456,7 +498,45 @@
     assert.equal(loc.charIndex, 2, 'selection end 14 char 2');
   });
 
-  QUnit.test('missingNewlineOffset with splitByGrapheme', function(assert) {
+  QUnit.test('get2DCursorLocation with overflowBreakWord', function (assert) {
+    var iText = new fabric.Textbox('aaaaaaaaaaaaaaaaaaaaaaaa',
+      { width: 60, overflowBreakWord: true });
+    var loc = iText.get2DCursorLocation();
+
+    // [ [ '由', '石', '墨' ],
+    //   [ '分', '裂', '的' ],
+    //   [ '石', '墨', '分' ],
+    //   [ '裂', '由', '石' ],
+    //   [ '墨', '分', '裂' ],
+    //   [ '由', '石', '墨' ],
+    //   [ '分', '裂', '的' ],
+    //   [ '石', '墨', '分' ],
+    //   [ '裂' ] ]
+
+    assert.equal(loc.lineIndex, 0);
+    assert.equal(loc.charIndex, 0);
+
+    // '由石墨|分裂的石墨分裂由石墨分裂由石墨分裂的石墨分裂'
+    iText.selectionStart = iText.selectionEnd = 4;
+    loc = iText.get2DCursorLocation();
+
+    assert.equal(loc.lineIndex, 1, 'selection end 4 line 1');
+    assert.equal(loc.charIndex, 1, 'selection end 4 char 1');
+
+    iText.selectionStart = iText.selectionEnd = 7;
+    loc = iText.get2DCursorLocation();
+
+    assert.equal(loc.lineIndex, 2, 'selection end 7 line 2');
+    assert.equal(loc.charIndex, 1, 'selection end 7 char 1');
+
+    iText.selectionStart = iText.selectionEnd = 14;
+    loc = iText.get2DCursorLocation();
+
+    assert.equal(loc.lineIndex, 4, 'selection end 14 line 4');
+    assert.equal(loc.charIndex, 2, 'selection end 14 char 2');
+  });
+
+  QUnit.test('missingNewlineOffset with splitByGrapheme', function (assert) {
     var textbox = new fabric.Textbox('aaa\naaaaaa\na\naaaaaaaaaaaa\naaa',
       { width: 80, splitByGrapheme: true });
 
@@ -476,7 +556,7 @@
     assert.equal(offset, 0, 'line 1 is wrapped without a \n so it does have an extra char count');
   });
 
-  QUnit.test('missingNewlineOffset with normal split', function(assert) {
+  QUnit.test('missingNewlineOffset with normal split', function (assert) {
     var texbox = new fabric.Textbox('aaa\naaaaaa\na\naaaaaaaaaaaa\naaa',
       { width: 160 });
 
@@ -488,7 +568,28 @@
     assert.equal(offset, 1, 'it returns always 1');
   });
 
-  QUnit.test('_getLineStyle', function(assert) {
+  QUnit.test('missingNewlineOffset with overflowBreakWord', function (assert) {
+    var textbox = new fabric.Textbox('aaa\naaaaaa\na\naaaaaaaaaaaa\naaa',
+      { width: 80, overflowBreakWord: true });
+
+    // Same behavior as splitByGrapheme in this case
+    // [ [ 'a', 'a', 'a' ],
+    //   [ 'a', 'a', 'a', 'a' ],
+    //   [ 'a', 'a' ],
+    //   [ 'a' ],
+    //   [ 'a', 'a', 'a', 'a' ],
+    //   [ 'a', 'a', 'a', 'a' ],
+    //   [ 'a', 'a', 'a', 'a' ],
+    //   [ 'a', 'a', 'a' ] ]
+
+    var offset = textbox.missingNewlineOffset(0);
+    assert.equal(offset, 1, 'line 0 is interrupted by a \n so has an offset of 1');
+
+    offset = textbox.missingNewlineOffset(1);
+    assert.equal(offset, 0, 'line 1 is wrapped without a \n so it does have an extra char count');
+  });
+
+  QUnit.test('_getLineStyle', function (assert) {
     var textbox = new fabric.Textbox('aaa aaq ggg gg\noee eee', {
       styles: {
         1: { 0: { fontSize: 4 } },
@@ -501,7 +602,7 @@
     assert.equal(textbox._getLineStyle(4), true, 'wrapped line 2 has style');
   });
 
-  QUnit.test('_setLineStyle', function(assert) {
+  QUnit.test('_setLineStyle', function (assert) {
     var textbox = new fabric.Textbox('aaa aaq ggg gg\noee eee', {
       styles: {
         1: { 0: { fontSize: 4 } },
@@ -530,7 +631,7 @@
     var styles = {};
     for (var index = 0; index < text.length; index++) {
       styles[index] = { fontSize: 4 };
-      
+
     }
     var textbox = new fabric.Textbox(text, {
       styles: { 0: styles },
@@ -541,7 +642,7 @@
     assert.equal(textbox.styles[0][10], undefined, 'style has been removed');
   });
 
-  QUnit.test('_setStyleDeclaration', function(assert) {
+  QUnit.test('_setStyleDeclaration', function (assert) {
     var text = 'aaa aaq ggg gg oee eee';
     var styles = {};
     for (var index = 0; index < text.length; index++) {
@@ -558,7 +659,7 @@
     assert.equal(textbox.styles[0][10], newStyle, 'style has been changed');
   });
 
-  QUnit.test('styleHas', function(assert) {
+  QUnit.test('styleHas', function (assert) {
     var textbox = new fabric.Textbox('aaa aaq ggg gg oee eee', {
       styles: {
         0: {
@@ -580,7 +681,7 @@
     assert.equal(textbox.styleHas('fontFamily', 1), true, 'style has fontFamily on line 1');
   });
 
-  QUnit.test('The same text does not need to be wrapped.', function(assert) {
+  QUnit.test('The same text does not need to be wrapped.', function (assert) {
     var str = '0123456789';
     var measureTextbox = new fabric.Textbox(str, {
       fontSize: 20,
@@ -590,6 +691,19 @@
       width: measureTextbox.width,
       fontSize: 20,
       splitByGrapheme: true,
+    });
+    assert.equal(newTextbox.textLines.length, measureTextbox.textLines.length, 'The same text is not wrapped');
+  });
+  QUnit.test('The same text does not need to be wrapped.', function (assert) {
+    var str = '0123456789';
+    var measureTextbox = new fabric.Textbox(str, {
+      fontSize: 20,
+      overflowBreakWord: false,
+    });
+    var newTextbox = new fabric.Textbox(str, {
+      width: measureTextbox.width,
+      fontSize: 20,
+      overflowBreakWord: true,
     });
     assert.equal(newTextbox.textLines.length, measureTextbox.textLines.length, 'The same text is not wrapped');
   });


### PR DESCRIPTION
## Motivation

Textbox option `splitByGrapheme` does not meet my needs

## Description

The Textbox adds an `overflowBreakWord` option to achieve a result similar to the css property `overflow-wrap: break-word`. Unlike the default, the width can be adjusted, and unlike `splitByGrapheme: true`, the word will be kept as complete as possible.

[MDN: overflow-wrap](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->

#### Textbox default


https://user-images.githubusercontent.com/6262240/208657448-7d1afca7-65db-4515-a6f5-8748598a0e81.mp4


#### Textbox with `splitByGrapheme: true`


https://user-images.githubusercontent.com/6262240/208657487-fa1bc625-7fed-4758-b36e-084bdbeb6771.mp4


#### Textbox with `overflowBreakWord: true`


https://user-images.githubusercontent.com/6262240/208657522-11d627df-d207-4a94-abff-fac6526c223c.mp4



