### PR TITLE
refactor(): `getRegularPolygonPath` => `Polygon.getRegularPolygonPoints`, `Polygon.createRegularPolygon`

### DIFF
--- a/src/shapes/polygon.class.ts
+++ b/src/shapes/polygon.class.ts
@@ -1,10 +1,46 @@
 import { fabric } from '../../HEADER';
+import { halfPI } from '../constants';
+import { Point } from '../point.class';
 import { TClassProperties } from '../typedefs';
+import { cos } from '../util/misc/cos';
+import { sin } from '../util/misc/sin';
 import { Polyline, polylineDefaultValues } from './polyline.class';
 
 export class Polygon extends Polyline {
   protected isOpen() {
     return false;
+  }
+
+  static getRegularPolygonPoints({
+    numVertexes,
+    radius,
+  }: {
+    numVertexes: number;
+    radius: number;
+  }) {
+    const interiorAngle = (Math.PI * 2) / numVertexes;
+    // rotate the polygon by 1/2 the interior angle so that the polygon always has a flat side on the bottom
+    const rotationAdjustment =
+      -halfPI + (numVertexes % 2 === 0 ? interiorAngle / 2 : 0);
+    return new Array(numVertexes).fill(0).map((_, i) => {
+      const rad = i * interiorAngle + rotationAdjustment;
+      return new Point(cos(rad), sin(rad)).scalarMultiply(radius);
+    });
+  }
+
+  static createRegularPolygon({
+    numVertexes,
+    radius,
+    ...options
+  }: {
+    numVertexes: number;
+    radius: number;
+  } & Record<string, unknown>) {
+    return new this(this.getRegularPolygonPoints({ numVertexes, radius }), {
+      left: 0,
+      top: 0,
+      ...options,
+    });
   }
 }
 

--- a/src/util/misc/misc.ts
+++ b/src/util/misc/misc.ts
@@ -71,7 +71,6 @@ import {
   getBoundsOfCurve,
   getPointOnPath,
   transformPath,
-  getRegularPolygonPath,
 } from '../path';
 import { setStyle } from '../dom_style';
 import { request } from '../dom_request';
@@ -172,7 +171,6 @@ fabric.util = {
   getBoundsOfCurve,
   getPointOnPath,
   transformPath,
-  getRegularPolygonPath,
   request,
   setStyle,
   isTouchEvent,

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -909,30 +909,6 @@ export const transformPath = (
 };
 
 /**
- * Returns an array of path commands to create a regular polygon
- * @param {number} radius
- * @param {number} numVertexes
- * @returns {(string|number)[][]} An array of SVG path commands
- */
-export const getRegularPolygonPath = (numVertexes, radius) => {
-  const interiorAngle = (Math.PI * 2) / numVertexes;
-  // rotationAdjustment rotates the path by 1/2 the interior angle so that the polygon always has a flat side on the bottom
-  // This isn't strictly necessary, but it's how we tend to think of and expect polygons to be drawn
-  let rotationAdjustment = -halfPI;
-  if (numVertexes % 2 === 0) {
-    rotationAdjustment += interiorAngle / 2;
-  }
-  const d = new Array(numVertexes + 1);
-  for (let i = 0; i < numVertexes; i++) {
-    const rad = i * interiorAngle + rotationAdjustment;
-    const { x, y } = new Point(cos(rad), sin(rad)).scalarMultiply(radius);
-    d[i] = [i === 0 ? 'M' : 'L', x, y];
-  }
-  d[numVertexes] = ['Z'];
-  return d;
-};
-
-/**
  * Join path commands to go back to svg format
  * @param {Array} pathData fabricJS parsed path commands
  * @return {String} joined path 'M 0 0 L 20 30'

--- a/test/unit/path_utils.js
+++ b/test/unit/path_utils.js
@@ -59,39 +59,4 @@
     assert.deepEqual(infos[4].length, 20, 'the command 4 a Z has length 20');
   });
 
-  QUnit.test('fabric.util.getRegularPolygonPath', function (assert) {
-
-    const roundDecimals = (commands) => commands.map(([cmd, x, y]) => {
-      if (cmd !== 'Z') {
-        return [cmd, x.toFixed(4), y.toFixed(4)];
-      }
-      return ['Z'];
-    })
-
-    assert.ok(typeof fabric.util.getRegularPolygonPath === 'function');
-    var penta = fabric.util.getRegularPolygonPath(5, 50);
-    var hexa = fabric.util.getRegularPolygonPath(6, 50);
-
-    var expetedPenta = [
-      ["M", 3.061616997868383e-15, -50],
-      ["L", 47.552825814757675, -15.450849718747369],
-      ["L", 29.389262614623657, 40.45084971874737],
-      ["L", -29.38926261462365, 40.45084971874737],
-      ["L", -47.55282581475768, -15.450849718747364],
-      ["Z"]
-    ];
-
-    var expetedHexa = [
-      ["M", 24.999999999999993, -43.30127018922194],
-      ["L", 50, -1.1102230246251565e-14],
-      ["L", 25.000000000000018, 43.301270189221924],
-      ["L", -24.99999999999999, 43.30127018922194],
-      ["L", -50, 2.8327694488239898e-14],
-      ["L", -25.00000000000006, -43.301270189221896],
-      ["Z"]
-    ];
-
-    assert.deepEqual(roundDecimals(penta), roundDecimals(expetedPenta), 'regualr pentagon should match');
-    assert.deepEqual(roundDecimals(hexa), roundDecimals(expetedHexa), 'regualr hexagon should match');
-  });
 })();

--- a/test/unit/polygon.js
+++ b/test/unit/polygon.js
@@ -255,4 +255,45 @@
       assert.equal(polygon, null);
     });
   });
+
+  QUnit.test('Regular Polygon', function (assert) {
+
+    const roundDecimals = (points) => points.map(({ x, y }) => {
+      return new fabric.Point(x.toFixed(4), y.toFixed(4));
+    });
+
+    assert.ok(typeof fabric.Polygon.getRegularPolygonPoints === 'function');
+    var penta = fabric.Polygon.getRegularPolygonPoints({ numVertexes: 5, radius: 50 });
+    var hexa = fabric.Polygon.getRegularPolygonPoints({ numVertexes: 6, radius: 50 });
+
+    var expectedPenta = [
+      new fabric.Point( 3.061616997868383e-15, -50),
+      new fabric.Point(47.552825814757675, -15.450849718747369),
+      new fabric.Point(29.389262614623657, 40.45084971874737),
+      new fabric.Point(-29.38926261462365, 40.45084971874737),
+      new fabric.Point(-47.55282581475768, -15.450849718747364),
+    ];
+
+    var expectedHexa = [
+      new fabric.Point(24.999999999999993, -43.30127018922194),
+      new fabric.Point(50, -1.1102230246251565e-14),
+      new fabric.Point(25.000000000000018, 43.301270189221924),
+      new fabric.Point(-24.99999999999999, 43.30127018922194),
+      new fabric.Point(-50, 2.8327694488239898e-14),
+      new fabric.Point(-25.00000000000006, -43.301270189221896),
+    ];
+
+    assert.deepEqual(roundDecimals(penta), roundDecimals(expectedPenta), 'regualr pentagon should match');
+    assert.deepEqual(roundDecimals(hexa), roundDecimals(expectedHexa), 'regualr hexagon should match');
+    assert.deepEqual(
+      fabric.Polygon.createRegularPolygon({ numVertexes: 5, radius: 50 }).toObject(),
+      new fabric.Polygon(expectedPenta, { left: 0, top: 0 }).toObject(),
+      'same polygon'
+    );
+    assert.deepEqual(
+      fabric.Polygon.createRegularPolygon({ numVertexes: 6, radius: 50 }).toObject(),
+      new fabric.Polygon(expectedHexa, { left: 0, top: 0 }).toObject(),
+      'same polygon'
+    );
+  });
 })();


### PR DESCRIPTION


## Motivation

I will need this bit soon and it seems wasted as a path util and more relevant as part of polygon.

## Description

I have refactored `getRegularPolygonPath` into `Polygon.getRegularPolygonPoints`, returning points instead of path commands. Anyone needing path commands can easily iterate over the points and create it.


## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
