### PR TITLE
fix(): `_initRetinaScaling`  initializaing the scaling regardless of settings in Canvas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): `_initRetinaScaling` regression
 - fix(): regression of canvas migration with pointer and sendPointToPlane [#8563](https://github.com/fabricjs/fabric.js/pull/8563)
 - chore(TS): Use exports from files to build fabricJS, get rid of HEADER.js [#8549](https://github.com/fabricjs/fabric.js/pull/8549)
 - chore(): rm `fabric.filterBackend` => `getFilterBackend` [#8487](https://github.com/fabricjs/fabric.js/pull/8487)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- fix(): `_initRetinaScaling` regression
+- fix(): `_initRetinaScaling`  initializaing the scaling regardless of settings in Canvas. [#8565](https://github.com/fabricjs/fabric.js/pull/8565)
 - fix(): regression of canvas migration with pointer and sendPointToPlane [#8563](https://github.com/fabricjs/fabric.js/pull/8563)
 - chore(TS): Use exports from files to build fabricJS, get rid of HEADER.js [#8549](https://github.com/fabricjs/fabric.js/pull/8549)
 - chore(): rm `fabric.filterBackend` => `getFilterBackend` [#8487](https://github.com/fabricjs/fabric.js/pull/8487)

--- a/src/canvas/canvas.class.ts
+++ b/src/canvas/canvas.class.ts
@@ -516,7 +516,7 @@ export class SelectableCanvas<
     this._createUpperCanvas();
     // @ts-ignore
     this._initEventListeners();
-    this._initRetinaScaling();
+    this._isRetinaScaling() && this._initRetinaScaling();
     this.calcOffset();
     this._createCacheCanvas();
   }

--- a/src/canvas/static_canvas.class.ts
+++ b/src/canvas/static_canvas.class.ts
@@ -346,7 +346,7 @@ export class StaticCanvas<
     this.renderAndResetBound = this.renderAndReset.bind(this);
     this.requestRenderAllBound = this.requestRenderAll.bind(this);
     this._initStatic(el, options);
-    this._initRetinaScaling();
+    this._isRetinaScaling() && this._initRetinaScaling();
     this.calcViewportBoundaries();
   }
 
@@ -382,9 +382,6 @@ export class StaticCanvas<
    * @private
    */
   _initRetinaScaling() {
-    if (!this._isRetinaScaling()) {
-      return;
-    }
     this.__initRetinaScaling(this.lowerCanvasEl, this.contextContainer);
   }
 
@@ -536,7 +533,7 @@ export class StaticCanvas<
       }
     });
 
-    this._initRetinaScaling();
+    this._isRetinaScaling() && this._initRetinaScaling();
     this.calcOffset();
 
     if (!cssOnly) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -1958,35 +1958,43 @@
     assert.equal(aGroup._objects[3], circle2);
   });
 
-  QUnit.test('set dimensions', async function (assert) {
-    var el = fabric.getDocument().createElement('canvas'),
-      parentEl = fabric.getDocument().createElement('div');
-    el.width = 200; el.height = 200;
-    parentEl.className = 'rootNode';
-    parentEl.appendChild(el);
+  [true, false].forEach(enableRetinaScaling => {
+    QUnit.test(`set dimensions, enableRetinaScaling ${enableRetinaScaling}`, async function (assert) {
+      var el = fabric.getDocument().createElement('canvas'),
+        parentEl = fabric.getDocument().createElement('div');
+      el.width = 200; el.height = 200;
+      parentEl.className = 'rootNode';
+      parentEl.appendChild(el);
 
-    fabric.config.configure({ devicePixelRatio: 1.25 });
+      const dpr = 1.25;
+      fabric.config.configure({ devicePixelRatio: dpr });
 
-    assert.equal(parentEl.firstChild, el, 'canvas should be appended at partentEl');
-    assert.equal(parentEl.childNodes.length, 1, 'parentEl has 1 child only');
+      assert.equal(parentEl.firstChild, el, 'canvas should be appended at partentEl');
+      assert.equal(parentEl.childNodes.length, 1, 'parentEl has 1 child only');
 
-    el.style.position = 'relative';
-    var elStyle = el.style.cssText;
-    assert.equal(elStyle, 'position: relative;', 'el style should not be empty');
+      el.style.position = 'relative';
+      var elStyle = el.style.cssText;
+      assert.equal(elStyle, 'position: relative;', 'el style should not be empty');
 
-    var canvas = new fabric.Canvas(el, { enableRetinaScaling: true, renderOnAddRemove: false });
+      var canvas = new fabric.Canvas(el, { enableRetinaScaling, renderOnAddRemove: false });
 
-    canvas.setDimensions({ width: 500, height: 500 });
-    assert.equal(canvas._originalCanvasStyle, elStyle, 'saved original canvas style for disposal');
-    assert.notEqual(el.style.cssText, canvas._originalCanvasStyle, 'canvas el style has been changed');
+      canvas.setDimensions({ width: 500, height: 500 });
+      assert.equal(canvas._originalCanvasStyle, elStyle, 'saved original canvas style for disposal');
+      assert.notEqual(el.style.cssText, canvas._originalCanvasStyle, 'canvas el style has been changed');
+      assert.equal(el.width, 500 * (enableRetinaScaling ? dpr : 1), 'expected width');
+      assert.equal(el.height, 500 * (enableRetinaScaling ? dpr : 1), 'expected height');
+      assert.equal(canvas.upperCanvasEl.width, 500 * (enableRetinaScaling ? dpr : 1), 'expected width');
+      assert.equal(canvas.upperCanvasEl.height, 500 * (enableRetinaScaling ? dpr : 1), 'expected height');
 
-    await canvas.dispose();
-    assert.equal(canvas._originalCanvasStyle, undefined, 'removed original canvas style');
-    assert.equal(el.style.cssText, elStyle, 'restored original canvas style');
-    assert.equal(el.width, 500, 'restored width');
-    assert.equal(el.height, 500, 'restored height');
+      await canvas.dispose();
+      assert.equal(canvas._originalCanvasStyle, undefined, 'removed original canvas style');
+      assert.equal(el.style.cssText, elStyle, 'restored original canvas style');
+      assert.equal(el.width, 500, 'restored width');
+      assert.equal(el.height, 500, 'restored height');
 
+    });
   });
+
 
   QUnit.test('clone', function(assert) {
     var done = assert.async();


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

<!--
        📣 IMPORTANT NOTICE - PR LOCK DOWN 🔒    04/2022
        We are excited to announce that fabric is migrating to modern typescript/javascript 🤩.
        This means we will ⛔ not be accepting any PRs out of scope with the migration.
        We understand this might be annoying but wasted work is ever more so.
        The migration will be extreme on the source code so PRs from before will probably become stale to the point of death after the migration.
        It hurts us the throw away good work, effort and time put into fabric so please stay patient.
        You are welcome to join the migration effort 🔨
        https://github.com/fabricjs/fabric.js/issues/7596

        If you remain strong minded about PRing and the fix is small you can submit a PR to the 5.x branch
        During the migration we will port these changes to master
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

fixes the regression from #8510 
I decided to open this PR to have a pure scope for this fix cause I guess that is what you want, instead of fixing as part of #8520 

Decide if you want to close this and merge #8520 or merge this and then that. Anyways if you do the second when dealing with conflict #8520 should win.

## Changes

now `_initRetinaScaling` should be called only if `isRetinaScaling` (doesn't check in the method as previously did)

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
