### PR TITLE
chores(TS) Remove more empty declarations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
               size: { fabric: { minified: fs.statSync('dist/fabric.min.js').size, bundled: fs.statSync('dist/fabric.js').size } }
             });
       - name: checkout src files
-        run: git checkout origin/master -- src index.js
+        run: git checkout origin/master -- src index.ts
       - name: upstream build stats
         run: npm run build -- -s
       - name: persist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [next]
 
-- refactor(Animation): modernize IText cursor animation based on animation API changes (and fix minor regression) plus leftovers from #8547 [#8583](https://github.com/fabricjs/fabric.js/pull/8583)
+- chore(TS): remove all remaining empty declarations [#8593](https://github.com/fabricjs/fabric.js/pull/8593)
+- refactor(IText): modernize IText cursor animation based on animation API changes (and fix minor regression) plus leftovers from #8547 [#8583](https://github.com/fabricjs/fabric.js/pull/8583)
 - refactor(Canvas, IText): Handle cross instance text editing states to an EditingManager class [#8543](https://github.com/fabricjs/fabric.js/pull/8543)
 - chore(TS): move to export, babel, new rollup, change import statement for fabric. [#8585](https://github.com/fabricjs/fabric.js/pull/8585);
 - chore(TS): Add declare in front of properties that are type definitions. [#8574](https://github.com/fabricjs/fabric.js/pull/8574)

--- a/src/brushes/base_brush.class.ts
+++ b/src/brushes/base_brush.class.ts
@@ -72,7 +72,7 @@ export abstract class BaseBrush {
   /**
    * @todo add type
    */
-  canvas: Canvas;
+  declare canvas: Canvas;
 
   constructor(canvas: Canvas) {
     this.canvas = canvas;

--- a/src/brushes/circle_brush.class.ts
+++ b/src/brushes/circle_brush.class.ts
@@ -22,7 +22,7 @@ export class CircleBrush extends BaseBrush {
    */
   width = 10;
 
-  points: CircleBrushPoint[];
+  declare points: CircleBrushPoint[];
 
   constructor(canvas: Canvas) {
     super(canvas);

--- a/src/brushes/pattern_brush.class.ts
+++ b/src/brushes/pattern_brush.class.ts
@@ -5,7 +5,7 @@ import type { Canvas } from '../canvas/canvas_events';
 import { PencilBrush } from './pencil_brush.class';
 
 export class PatternBrush extends PencilBrush {
-  source?: CanvasImageSource;
+  declare source?: CanvasImageSource;
 
   constructor(canvas: Canvas) {
     super(canvas);

--- a/src/brushes/pencil_brush.class.ts
+++ b/src/brushes/pencil_brush.class.ts
@@ -40,9 +40,9 @@ export class PencilBrush extends BaseBrush {
    */
   straightLineKey: ModifierKey | undefined | null = 'shiftKey';
 
-  private _points: Point[];
-  private _hasStraightLine: boolean;
-  private oldEnd?: Point;
+  declare private _points: Point[];
+  declare private _hasStraightLine: boolean;
+  declare private oldEnd?: Point;
 
   constructor(canvas: Canvas) {
     super(canvas);

--- a/src/brushes/pencil_brush.class.ts
+++ b/src/brushes/pencil_brush.class.ts
@@ -40,9 +40,9 @@ export class PencilBrush extends BaseBrush {
    */
   straightLineKey: ModifierKey | undefined | null = 'shiftKey';
 
-  declare private _points: Point[];
-  declare private _hasStraightLine: boolean;
-  declare private oldEnd?: Point;
+  private declare _points: Point[];
+  private declare _hasStraightLine: boolean;
+  private declare oldEnd?: Point;
 
   constructor(canvas: Canvas) {
     super(canvas);

--- a/src/brushes/spray_brush.class.ts
+++ b/src/brushes/spray_brush.class.ts
@@ -76,9 +76,9 @@ export class SprayBrush extends BaseBrush {
    */
   optimizeOverlapping = true;
 
-  declare private sprayChunks: SprayBrushPoint[][];
+  private declare sprayChunks: SprayBrushPoint[][];
 
-  declare private sprayChunk: SprayBrushPoint[];
+  private declare sprayChunk: SprayBrushPoint[];
 
   /**
    * Constructor

--- a/src/brushes/spray_brush.class.ts
+++ b/src/brushes/spray_brush.class.ts
@@ -76,9 +76,9 @@ export class SprayBrush extends BaseBrush {
    */
   optimizeOverlapping = true;
 
-  private sprayChunks: SprayBrushPoint[][];
+  declare private sprayChunks: SprayBrushPoint[][];
 
-  private sprayChunk: SprayBrushPoint[];
+  declare private sprayChunk: SprayBrushPoint[];
 
   /**
    * Constructor

--- a/src/canvas/TextEditingManager.ts
+++ b/src/canvas/TextEditingManager.ts
@@ -8,7 +8,7 @@ import { removeFromArray } from '../util/internals';
  */
 export class TextEditingManager {
   private targets: (IText | Textbox)[] = [];
-  private target?: IText | Textbox;
+  declare private target?: IText | Textbox;
 
   exitTextEditing() {
     this.target = undefined;

--- a/src/canvas/TextEditingManager.ts
+++ b/src/canvas/TextEditingManager.ts
@@ -8,7 +8,7 @@ import { removeFromArray } from '../util/internals';
  */
 export class TextEditingManager {
   private targets: (IText | Textbox)[] = [];
-  declare private target?: IText | Textbox;
+  private declare target?: IText | Textbox;
 
   exitTextEditing() {
     this.target = undefined;

--- a/src/color/color.class.ts
+++ b/src/color/color.class.ts
@@ -24,7 +24,7 @@ export type TColorArg = string | TRGBColorSource | TRGBAColorSource | Color;
  * @tutorial {@link http://fabricjs.com/fabric-intro-part-2/#colors colors}
  */
 export class Color {
-  declare private _source: TRGBAColorSource;
+  private declare _source: TRGBAColorSource;
 
   /**
    *

--- a/src/color/color.class.ts
+++ b/src/color/color.class.ts
@@ -24,7 +24,7 @@ export type TColorArg = string | TRGBColorSource | TRGBAColorSource | Color;
  * @tutorial {@link http://fabricjs.com/fabric-intro-part-2/#colors colors}
  */
 export class Color {
-  private _source: TRGBAColorSource;
+  declare private _source: TRGBAColorSource;
 
   /**
    *

--- a/src/controls/control.class.ts
+++ b/src/controls/control.class.ts
@@ -150,7 +150,7 @@ export class Control {
    * @param {Number} y y position of the cursor
    * @return {Boolean} true if the action/event modified the object
    */
-  actionHandler: TransformActionHandler;
+  declare actionHandler: TransformActionHandler;
 
   /**
    * The control handler for mouse down, provide one to handle mouse down on control
@@ -160,7 +160,7 @@ export class Control {
    * @param {Number} y y position of the cursor
    * @return {Boolean} true if the action/event modified the object
    */
-  mouseDownHandler?: ControlActionHandler;
+  declare mouseDownHandler?: ControlActionHandler;
 
   /**
    * The control mouseUpHandler, provide one to handle an effect on mouse up.
@@ -170,7 +170,7 @@ export class Control {
    * @param {Number} y y position of the cursor
    * @return {Boolean} true if the action/event modified the object
    */
-  mouseUpHandler?: ControlActionHandler;
+  declare mouseUpHandler?: ControlActionHandler;
 
   /**
    * Returns control actionHandler

--- a/src/util/animation/AnimationBase.ts
+++ b/src/util/animation/AnimationBase.ts
@@ -15,24 +15,24 @@ const defaultAbort = () => false;
 export abstract class AnimationBase<
   T extends number | number[] = number | number[]
 > {
-  readonly startValue: T;
-  readonly endValue: T;
-  readonly duration: number;
-  readonly delay: number;
+  declare readonly startValue: T;
+  declare readonly endValue: T;
+  declare readonly duration: number;
+  declare readonly delay: number;
 
-  protected readonly byValue: T;
-  protected readonly easing: TEasingFunction<T>;
+  declare protected readonly byValue: T;
+  declare protected readonly easing: TEasingFunction<T>;
 
-  private readonly _onStart: VoidFunction;
-  private readonly _onChange: TOnAnimationChangeCallback<T, void>;
-  private readonly _onComplete: TOnAnimationChangeCallback<T, void>;
-  private readonly _abort: TAbortCallback<T>;
+  declare private readonly _onStart: VoidFunction;
+  declare private readonly _onChange: TOnAnimationChangeCallback<T, void>;
+  declare private readonly _onComplete: TOnAnimationChangeCallback<T, void>;
+  declare private readonly _abort: TAbortCallback<T>;
 
   /**
    * Used to register the animation to a target object
    * so that it can be cancelled within the object context
    */
-  readonly target?: unknown;
+  declare readonly target?: unknown;
 
   private _state: AnimationState = 'pending';
   /**
@@ -47,11 +47,11 @@ export abstract class AnimationBase<
   /**
    * Current value
    */
-  value: T;
+  declare value: T;
   /**
    * Animation start time ms
    */
-  private startTime!: number;
+  declare private startTime: number;
 
   constructor({
     startValue,

--- a/src/util/animation/AnimationBase.ts
+++ b/src/util/animation/AnimationBase.ts
@@ -20,13 +20,13 @@ export abstract class AnimationBase<
   declare readonly duration: number;
   declare readonly delay: number;
 
-  declare protected readonly byValue: T;
-  declare protected readonly easing: TEasingFunction<T>;
+  protected declare readonly byValue: T;
+  protected declare readonly easing: TEasingFunction<T>;
 
-  declare private readonly _onStart: VoidFunction;
-  declare private readonly _onChange: TOnAnimationChangeCallback<T, void>;
-  declare private readonly _onComplete: TOnAnimationChangeCallback<T, void>;
-  declare private readonly _abort: TAbortCallback<T>;
+  private declare readonly _onStart: VoidFunction;
+  private declare readonly _onChange: TOnAnimationChangeCallback<T, void>;
+  private declare readonly _onComplete: TOnAnimationChangeCallback<T, void>;
+  private declare readonly _abort: TAbortCallback<T>;
 
   /**
    * Used to register the animation to a target object
@@ -51,7 +51,7 @@ export abstract class AnimationBase<
   /**
    * Animation start time ms
    */
-  declare private startTime: number;
+  private declare startTime: number;
 
   constructor({
     startValue,

--- a/src/util/misc/projectStroke/StrokeLineCapProjections.ts
+++ b/src/util/misc/projectStroke/StrokeLineCapProjections.ts
@@ -20,11 +20,11 @@ export class StrokeLineCapProjections extends StrokeProjectionsBase {
   /**
    * edge point
    */
-  A: Point;
+  declare A: Point;
   /**
    * point next to edge point
    */
-  T: Point;
+  declare T: Point;
 
   constructor(A: IPoint, T: IPoint, options: TProjectStrokeOnPointsOptions) {
     super(options);

--- a/src/util/misc/projectStroke/StrokeLineJoinProjections.ts
+++ b/src/util/misc/projectStroke/StrokeLineJoinProjections.ts
@@ -20,19 +20,19 @@ export class StrokeLineJoinProjections extends StrokeProjectionsBase {
   /**
    * The point being projected (the angle ∠BAC)
    */
-  A: Point;
+  declare A: Point;
   /**
    * The point before A
    */
-  B: Point;
+  declare B: Point;
   /**
    * The point after A
    */
-  C: Point;
+  declare C: Point;
   /**
    * The bisector of A (∠BAC)
    */
-  bisector: ReturnType<typeof getBisector>;
+  declare bisector: ReturnType<typeof getBisector>;
 
   constructor(
     A: IPoint,

--- a/src/util/misc/projectStroke/StrokeProjectionsBase.ts
+++ b/src/util/misc/projectStroke/StrokeProjectionsBase.ts
@@ -12,10 +12,10 @@ import { TProjectStrokeOnPointsOptions, TProjection } from './types';
  * @see https://github.com/fabricjs/fabric.js/pull/8344
  */
 export abstract class StrokeProjectionsBase {
-  options: TProjectStrokeOnPointsOptions;
-  scale: Point;
-  strokeUniformScalar: Point;
-  strokeProjectionMagnitude: number;
+  declare options: TProjectStrokeOnPointsOptions;
+  declare scale: Point;
+  declare strokeUniformScalar: Point;
+  declare strokeProjectionMagnitude: number;
 
   static getAcuteAngleFactor(vector1: Point, vector2?: Point) {
     const angle = vector2


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

<!--
        📣 IMPORTANT NOTICE - PR LOCK DOWN 🔒    04/2022
        We are excited to announce that fabric is migrating to modern typescript/javascript 🤩.
        This means we will ⛔ not be accepting any PRs out of scope with the migration.
        We understand this might be annoying but wasted work is ever more so.
        The migration will be extreme on the source code so PRs from before will probably become stale to the point of death after the migration.
        It hurts us the throw away good work, effort and time put into fabric so please stay patient.
        You are welcome to join the migration effort 🔨
        https://github.com/fabricjs/fabric.js/issues/7596

        If you remain strong minded about PRing and the fix is small you can submit a PR to the 5.x branch
        During the migration we will port these changes to master
-->

## Motivation

Consistency in property declaration in classes.
Avoid transpilers to pre-define and override definitions with undefined of certain props.

The issue to recap was:
```js
class A {
  constructor(options) {
    ...setOptions
  }
}

class B extends A {
 
  myProperty: boolean;
  constructor(options) {
    super(...optionsB ...optionsA);
    // at this point myProperty has been set by the constructor of A
    // this below line is killing the work of constructor A
    defineProp(myProperty, undefined)
  }
}
```

This may be because our setOptions or other constructor practices are bad patterns, but we are not drilling into that now, this is a simpe way to be safe.
On top of that babel is doing this transpilation, so actually adding a property without declare or without a default value is a TS error that we are avoiding because we a flag in the compiler turned down.
So maybe turning that flag up is another thing we want to do.
<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

Make all property initialization the same.
If a property needs to be defined in the constructor at runtime, we will need to add declare in front of it, regardless that tests aren't failing.
At least we are consistent and we don't have unexpected behaviours only for some properties.
<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
