### PR TITLE
Update settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,6 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": false
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
     "../../**"
   ],
   "editor.formatOnSave": true,
-  "editor.formatOnPaste": true
+  "editor.formatOnPaste": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  }
 }


### PR DESCRIPTION


## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

let vscode fix import order on save

## Changes

<!-- before the fix vs. after -->

## Gist

There is a prettier plugin as well:
https://www.npmjs.com/package/prettier-plugin-organize-imports:

> This is the same as using the "Organize Imports" action in VS Code.

> This plugin inherits, extends and overrides the built-in Prettier parsers for babel, babel-ts, typescript and vue, i. e., it's incompatible with other plugins that do the same... so only the last loaded plugin that exports one of those parsers will function.

So no to that

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
