### PR TITLE
fix(): Env patch

### DIFF
--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -42,6 +42,7 @@ import { pick } from '../util/misc/pick';
 import { matrixToSVG } from '../util/misc/svgParsing';
 import { toFixed } from '../util/misc/toFixed';
 import { isCollection, isFiller, isPattern, isTextObject } from '../util/types';
+import type { JpegConfig, PngConfig } from 'canvas';
 
 const CANVAS_INIT_ERROR = 'Could not initialize `canvas` element';
 
@@ -1693,6 +1694,24 @@ export class StaticCanvas<
       this._objects.length
     } }>`;
   }
+
+  /**
+   * node only method
+   * @throws when called from a browser environment
+   */
+  createPNGStream(opts?: PngConfig) {
+    const impl = getNodeCanvas(this.lowerCanvasEl);
+    return impl && impl.createPNGStream(opts);
+  }
+
+  /**
+   * node only method
+   * @throws when called from a browser environment
+   */
+  createJPEGStream(opts?: JpegConfig) {
+    const impl = getNodeCanvas(this.lowerCanvasEl);
+    return impl && impl.createJPEGStream(opts);
+  }
 }
 
 Object.assign(StaticCanvas.prototype, {
@@ -1713,20 +1732,3 @@ Object.assign(StaticCanvas.prototype, {
   skipOffscreen: true,
   clipPath: undefined,
 });
-
-if (getEnv().isLikelyNode) {
-  Object.assign(StaticCanvas.prototype, {
-    createPNGStream() {
-      const impl = getNodeCanvas(
-        (this as unknown as StaticCanvas).lowerCanvasEl
-      );
-      return impl && impl.createPNGStream();
-    },
-    createJPEGStream(opts: any) {
-      const impl = getNodeCanvas(
-        (this as unknown as StaticCanvas).lowerCanvasEl
-      );
-      return impl && impl.createJPEGStream(opts);
-    },
-  });
-}

--- a/src/env.ts
+++ b/src/env.ts
@@ -52,7 +52,6 @@ function setupEnv() {
     nodeCanvas = require('jsdom/lib/jsdom/utils').Canvas;
     isLikelyNode = true;
     fabricWindow = virtualWindow;
-    global.DOMParser = (fabricWindow as any).DOMParser;
   }
   isTouchSupported =
     'ontouchstart' in fabricWindow ||

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,6 +11,7 @@ type TFabricEnv = {
   jsdomImplForWrapper: any;
 };
 
+let initialized = false;
 let fabricDocument: Document;
 let fabricWindow: Window;
 let isTouchSupported: boolean;
@@ -19,6 +20,7 @@ let nodeCanvas: Canvas;
 let jsdomImplForWrapper: any;
 
 function setupEnv() {
+  initialized = true;
   if (typeof document !== 'undefined' && typeof window !== 'undefined') {
     if (
       document instanceof
@@ -63,9 +65,8 @@ function setupEnv() {
   });
 }
 
-setupEnv();
-
 export const getEnv = (): TFabricEnv => {
+  !initialized && setupEnv();
   return {
     document: fabricDocument,
     window: fabricWindow,

--- a/src/util/animation/AnimationFrameProvider.ts
+++ b/src/util/animation/AnimationFrameProvider.ts
@@ -1,13 +1,7 @@
 import { getEnv } from '../../env';
 
-const _requestAnimFrame: AnimationFrameProvider['requestAnimationFrame'] =
-  getEnv().window.requestAnimationFrame ||
-  function (callback: FrameRequestCallback) {
-    return getEnv().window.setTimeout(callback, 1000 / 60);
-  };
-
-const _cancelAnimFrame: AnimationFrameProvider['cancelAnimationFrame'] =
-  getEnv().window.cancelAnimationFrame || getEnv().window.clearTimeout;
+let _requestAnimFrame: AnimationFrameProvider['requestAnimationFrame'];
+let _cancelAnimFrame: AnimationFrameProvider['cancelAnimationFrame'];
 
 /**
  * requestAnimationFrame polyfill based on http://paulirish.com/2011/requestanimationframe-for-smart-animating/
@@ -15,9 +9,20 @@ const _cancelAnimFrame: AnimationFrameProvider['cancelAnimationFrame'] =
  * @param {Function} callback Callback to invoke
  */
 export function requestAnimFrame(callback: FrameRequestCallback): number {
+  if (!_requestAnimFrame) {
+    _requestAnimFrame =
+      getEnv().window.requestAnimationFrame ||
+      function requestAnimationFramePolyfill(callback: FrameRequestCallback) {
+        return getEnv().window.setTimeout(callback, 1000 / 60);
+      };
+  }
   return _requestAnimFrame.call(getEnv().window, callback);
 }
 
 export function cancelAnimFrame(handle: number): void {
+  if (!_cancelAnimFrame) {
+    _cancelAnimFrame =
+      getEnv().window.cancelAnimationFrame || getEnv().window.clearTimeout;
+  }
   return _cancelAnimFrame.call(getEnv().window, handle);
 }


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

<!--
        📣 IMPORTANT NOTICE - PR LOCK DOWN 🔒    04/2022
        We are excited to announce that fabric is migrating to modern typescript/javascript 🤩.
        This means we will ⛔ not be accepting any PRs out of scope with the migration.
        We understand this might be annoying but wasted work is ever more so.
        The migration will be extreme on the source code so PRs from before will probably become stale to the point of death after the migration.
        It hurts us the throw away good work, effort and time put into fabric so please stay patient.
        You are welcome to join the migration effort 🔨
        https://github.com/fabricjs/fabric.js/issues/7596

        If you remain strong minded about PRing and the fix is small you can submit a PR to the 5.x branch
        During the migration we will port these changes to master
-->

## Motivation

Make env setup lazy so it runs when classes are initialized instead of when fabric is imported

## Description

As far as I can tell 
https://github.com/fabricjs/fabric.js/blob/028fd89bbcaea2a6193abf805637082bddd3eb30/src/shapes/Object/defaultValues.ts#L100
is the last `getEnv` call that runs from import and once we refactor default values to a static method that should go away

## Changes

- StaticCanvas node streaming methods are now part of the class no matter what. Not sure I like it but I don't think is that bad for now. Once we have a bundle for node we can refactor
- `setupEnv` is called lazily
- DOMParser is not needed on the global scope

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
