### PR TITLE
feat(): Control set

### DIFF
--- a/fabric.ts
+++ b/fabric.ts
@@ -284,6 +284,7 @@ import {
 import { getLocalPoint } from './src/controls/util';
 import { wrapWithFireEvent } from './src/controls/wrapWithFireEvent';
 import { wrapWithFixedAnchor } from './src/controls/wrapWithFixedAnchor';
+import { createControlSet } from './src/controls/default_controls';
 
 /**
  * @todo remove as unused
@@ -310,6 +311,7 @@ const controlsUtils = {
   getLocalPoint,
   renderCircleControl,
   renderSquareControl,
+  createControlSet,
 };
 
 // EXPORTS

--- a/fabric.ts
+++ b/fabric.ts
@@ -363,8 +363,6 @@ import { parsePointsAttribute } from './src/parser/parsePointsAttribute';
 import { parseTransformAttribute } from './src/parser/parseTransformAttribute';
 import { getCSSRules } from './src/parser/getCSSRules';
 
-import './src/controls/default_controls';
-
 export {
   parseElements,
   parseAttributes,

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -856,7 +856,7 @@ export class Canvas extends SelectableCanvas {
         this.setActiveObject(target, e);
         shouldRender = true;
       } else {
-        const control = target.controls[corner as string];
+        const control = target.controls.resolve(corner);
         const mouseUpHandler =
           control && control.getMouseUpHandler(e, target, control);
         if (mouseUpHandler) {
@@ -873,7 +873,8 @@ export class Canvas extends SelectableCanvas {
       (transform.target !== target || transform.corner !== corner)
     ) {
       const originalControl =
-          transform.target && transform.target.controls[transform.corner],
+          transform.target &&
+          transform.target.controls.resolve(transform.corner),
         originalMouseUpHandler =
           originalControl &&
           originalControl.getMouseUpHandler(
@@ -1139,7 +1140,7 @@ export class Canvas extends SelectableCanvas {
       );
       if (target === this._activeObject && (corner || !shouldGroup)) {
         this._setupCurrentTransform(e, target, alreadySelected);
-        const control = target.controls[corner],
+        const control = target.controls.resolve(corner),
           pointer = this.getPointer(e),
           mouseDownHandler =
             control && control.getMouseDownHandler(e, target, control);
@@ -1452,7 +1453,7 @@ export class Canvas extends SelectableCanvas {
       }
       this.setCursor(hoverCursor);
     } else {
-      const control = target.controls[corner];
+      const control = target.controls.resolve(corner)!;
       this.setCursor(control.cursorStyleHandler(e, control, target));
     }
   }

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -822,7 +822,7 @@ export class SelectableCanvas<
         )
       : this.getPointer(e);
     const corner = target.__corner || '',
-      control = !!corner && target.controls[corner],
+      control = !!corner && target.controls.resolve(corner),
       actionHandler =
         alreadySelected && control
           ? control.getActionHandler(e, target, control)

--- a/src/controls/default_controls.ts
+++ b/src/controls/default_controls.ts
@@ -123,12 +123,12 @@ export function createControlSet<T extends TControlSet, S extends TControlSet>(
     },
     resolve: {
       value(key: string) {
-        return (
-          this[key] ||
-          (this.source && this.source.resolve
-            ? this.source.resolve(key)
-            : this.source[key])
-        );
+        return (this[key] ||
+          (this.source &&
+            (this.source[key] ||
+              (this.source.resolve && this.source.resolve(key))))) as
+          | Control
+          | undefined;
       },
       configurable: true,
       enumerable: false,

--- a/src/controls/polyControl.ts
+++ b/src/controls/polyControl.ts
@@ -10,6 +10,7 @@ import {
   TransformActionHandler,
 } from '../EventTypeDefs';
 import { getLocalPoint } from './util';
+import { createControlSet } from './default_controls';
 
 type TTransformAnchor = Transform & { pointIndex: number };
 
@@ -131,5 +132,5 @@ export function createPolyControls(
       ...options,
     });
   }
-  return controls;
+  return createControlSet(controls);
 }

--- a/src/controls/util.ts
+++ b/src/controls/util.ts
@@ -31,7 +31,7 @@ export const getActionFromCorner = (
   if (!corner || !alreadySelected) {
     return 'drag';
   }
-  const control = target.controls[corner];
+  const control = target.controls.resolve(corner);
   return control.getActionName(e, control, target);
 };
 
@@ -132,7 +132,7 @@ export function getLocalPoint(
   x: number,
   y: number
 ) {
-  const control = target.controls[corner],
+  const control = target.controls.resolve(corner),
     zoom = target.canvas?.getZoom() || 1,
     padding = target.padding / zoom,
     localPoint = normalizePoint(target, new Point(x, y), originX, originY);

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -306,9 +306,7 @@ export class InteractiveFabricObject<
       fabricObject: InteractiveFabricObject
     ) => any
   ) {
-    for (const key in this.controls) {
-      fn(this.controls.resolve(key), key, this);
-    }
+    this.controls.forEach((control, key) => fn(control, key, this));
   }
 
   /**

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -2,6 +2,10 @@
 import { TClassProperties } from '../typedefs';
 import { IText } from './IText/IText';
 import { classRegistry } from '../util/class_registry';
+import {
+  createControlSet,
+  textboxDefaultControls,
+} from '../controls/default_controls';
 
 /**
  * Textbox class, based on IText, allows the user to resize the text rectangle
@@ -33,6 +37,8 @@ export class Textbox extends IText {
    * @since 2.6.0
    */
   declare splitByGrapheme: boolean;
+
+  controls = createControlSet({}, textboxDefaultControls);
 
   static textLayoutProperties = [...IText.textLayoutProperties, 'width'];
 


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

Long have we been discussing (and disputing about) shared controls.
The reason I was against it all along was because setting `rect.controls.br = new Control()` would change all fabric and it is absolutely an anti pattern. No one can expect that unless they are acquainted with fabric, with is a bad practice.
However you said there are benefits in a shared control set (and I found it hard to swallow because of this).
Another reason was Textbox controls. Saying fabric shares controls is not correct because of this edge case, so the benefits of the shared concept were missed out here.

With this clarity I now understand your point.
So if we handle what disturbs me I am for shared controls.
This PR does that exactly.
I wish to dedicate in to you @asturur as a gift from me.


## Description

fill out soon

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
