### PR TITLE
fix(): set/discard active object return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- fix(): set/discard active object return value [#8672](https://github.com/fabricjs/fabric.js/issues/8672)
+- fix(): BREAKING set/discard active object return value, discard active object now return false if no discard happened [#8672](https://github.com/fabricjs/fabric.js/issues/8672)
 - TS(): Moved cache properties to static properties on classes [#xxxx](https://github.com/fabricjs/fabric.js/pull/xxxx)
 - refactor(): Moved cache properties to static properties on classes [#8662](https://github.com/fabricjs/fabric.js/pull/8662)
 - docs(): v6 announcements [#8664](https://github.com/fabricjs/fabric.js/issues/8664)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): set/discard active object return value [#8672](https://github.com/fabricjs/fabric.js/issues/8672)
 - TS(): Moved cache properties to static properties on classes [#xxxx](https://github.com/fabricjs/fabric.js/pull/xxxx)
 - refactor(): Moved cache properties to static properties on classes [#8662](https://github.com/fabricjs/fabric.js/pull/8662)
 - docs(): v6 announcements [#8664](https://github.com/fabricjs/fabric.js/issues/8664)

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -1383,7 +1383,7 @@ export class SelectableCanvas<
    * Sets given object as the only active object on canvas
    * @param {FabricObject} object Object to set as an active one
    * @param {TPointerEvent} [e] Event (passed along when firing "object:selected")
-   * @return {Boolean} true if occurred
+   * @return {Boolean} true if the object has been selected
    */
   setActiveObject(
     object: FabricObject,
@@ -1397,16 +1397,14 @@ export class SelectableCanvas<
   }
 
   /**
-   * This is a private method for now.
    * This is supposed to be equivalent to setActiveObject but without firing
    * any event. There is commitment to have this stay this way.
    * This is the functional part of setActiveObject.
-   * @private
    * @param {Object} object to set as active
    * @param {Event} [e] Event (passed along when firing "object:selected")
-   * @return {Boolean} true if occurred
+   * @return {Boolean} true if the object has been selected
    */
-  protected _setActiveObject(
+  _setActiveObject(
     object: FabricObject,
     e?: TPointerEvent
   ): this is AssertKeys<this, '_activeObject'> {
@@ -1425,16 +1423,14 @@ export class SelectableCanvas<
   }
 
   /**
-   * This is a private method for now.
    * This is supposed to be equivalent to discardActiveObject but without firing
    * any selection events ( can still fire object transformation events ). There is commitment to have this stay this way.
    * This is the functional part of discardActiveObject.
    * @param {Event} [e] Event (passed along when firing "object:deselected")
    * @param {Object} object the next object to set as active, reason why we are discarding this
-   * @return {Boolean} true if occurred
-   * @private
+   * @return {Boolean} true if the active object has been discarded
    */
-  protected _discardActiveObject(e?: TPointerEvent, object?: FabricObject) {
+  _discardActiveObject(e?: TPointerEvent, object?: FabricObject) {
     const obj = this._activeObject;
     if (obj) {
       // onDeselect return TRUE to cancel selection;
@@ -1457,7 +1453,7 @@ export class SelectableCanvas<
    * sent to the fire function for the custom events. When used as a method the
    * e param does not have any application.
    * @param {event} e
-   * @return {Boolean} true if occurred
+   * @return {Boolean} true if the active object has been discarded
    */
   discardActiveObject(e?: TPointerEvent) {
     const currentActives = this.getActiveObjects(),

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -1524,8 +1524,10 @@ export class SelectableCanvas<
    * Clears all contexts (background, main, top) of an instance
    */
   clear() {
-    // this.discardActiveGroup();
+    // discard active object and fire events
     this.discardActiveObject();
+    // make sure we clear the active object in case it refused to be discarded
+    this._activeObject = undefined;
     this.clearContext(this.contextTop);
     super.clear();
   }

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -1430,7 +1430,10 @@ export class SelectableCanvas<
    * @param {Object} object the next object to set as active, reason why we are discarding this
    * @return {Boolean} true if the active object has been discarded
    */
-  _discardActiveObject(e?: TPointerEvent, object?: FabricObject) {
+  _discardActiveObject(
+    e?: TPointerEvent,
+    object?: FabricObject
+  ): this is { _activeObject: undefined } {
     const obj = this._activeObject;
     if (obj) {
       // onDeselect return TRUE to cancel selection;
@@ -1455,7 +1458,7 @@ export class SelectableCanvas<
    * @param {event} e
    * @return {Boolean} true if the active object has been discarded
    */
-  discardActiveObject(e?: TPointerEvent) {
+  discardActiveObject(e?: TPointerEvent): this is { _activeObject: undefined } {
     const currentActives = this.getActiveObjects(),
       activeObject = this.getActiveObject();
     if (currentActives.length) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -106,7 +106,6 @@
     afterEach: function () {
       fabric.config.configure({ devicePixelRatio: ORIGINAL_DPR });
       canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
-      canvas._activeObject = undefined;
       canvas.clear();
       canvas.cancelRequestedRender();
       canvas.backgroundColor = fabric.Canvas.prototype.backgroundColor;
@@ -1910,6 +1909,8 @@
     canvas.setActiveObject(rect);
     assert.ok(!canvas.discardActiveObject(), 'no effect');
     assert.ok(canvas.getActiveObject() === rect, 'active object');
+    canvas.clear();
+    assert.ok(!canvas.getActiveObject(), 'cleared the stubborn ref');
   })
 
   QUnit.test('complexity', function(assert) {


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

Working on #8665 made me need return values and then I encountered strange behavior

## Description

`setActiveObject` and `discardActiveObject` were chainable. We removed that but didn't return the needed values from `_setActiveObject` and `_discardActiveObject`.
Then I saw that `_discardActiveObject` return a value that is different than what is documented (true if deselected) and not aligned with `_setActiveObject` so I fixed it.
That surfaced another edge case when clearing canvas and having an active object that refuses to deselect clear can't discard it. So I fixed that as well and added tests.

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
