### PR TITLE
fix(test): Textbox fromObject test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- test(): Textbox `fromObject` test not to pass an instance
+- fix(test): Textbox `fromObject` test is incorrectly trying to restore an instance [#8686](https://github.com/fabricjs/fabric.js/pull/8686)
 - TS(): Moved cache properties to static properties on classes [#xxxx](https://github.com/fabricjs/fabric.js/pull/xxxx)
 - refactor(): Moved cache properties to static properties on classes [#8662](https://github.com/fabricjs/fabric.js/pull/8662)
 - docs(): v6 announcements [#8664](https://github.com/fabricjs/fabric.js/issues/8664)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- test(): Textbox `fromObject` test not to pass an instance
 - TS(): Moved cache properties to static properties on classes [#xxxx](https://github.com/fabricjs/fabric.js/pull/xxxx)
 - refactor(): Moved cache properties to static properties on classes [#8662](https://github.com/fabricjs/fabric.js/pull/8662)
 - docs(): v6 announcements [#8664](https://github.com/fabricjs/fabric.js/issues/8664)

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -98,7 +98,7 @@
     assert.equal(textbox.text, 'test');
     assert.equal(textbox.type, 'textbox');
     assert.deepEqual(textbox.styles, { });
-    assert.ok(textbox.cacheProperties.indexOf('width') > -1, 'width is in cacheProperties');
+    assert.ok(fabric.Textbox.cacheProperties.indexOf('width') > -1, 'width is in cacheProperties');
   });
 
   QUnit.test('toObject', function(assert) {

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -98,7 +98,7 @@
     assert.equal(textbox.text, 'test');
     assert.equal(textbox.type, 'textbox');
     assert.deepEqual(textbox.styles, { });
-    assert.ok(fabric.Textbox.cacheProperties.indexOf('width') > -1, 'width is in cacheProperties');
+    assert.ok(textbox.cacheProperties.indexOf('width') > -1, 'width is in cacheProperties');
   });
 
   QUnit.test('toObject', function(assert) {
@@ -178,8 +178,11 @@
       assert.deepEqual(obj.styles[2], textbox.styles[2], 'styles match at line 2');
       assert.deepEqual(obj.styles[2][0], textbox.styles[2][0], 'styles match at index 0');
       assert.deepEqual(obj.styles[2][1], textbox.styles[2][1], 'styles match at index 1');
-      fabric.Textbox.fromObject(obj).then(function(obj2) {
+      const out = obj.toObject();
+      fabric.Textbox.fromObject(out).then(function(obj2) {
+        assert.notEqual(out.styles, obj2.styles, 'styles copy is a different object after initialization');
         assert.notEqual(obj.styles, obj2.styles, 'styles copy is a different object after initialization');
+        assert.deepEqual(obj.styles, obj2.styles, 'styles copy is a different object after initialization');
         done();
       });
     });
@@ -530,7 +533,7 @@
     var styles = {};
     for (var index = 0; index < text.length; index++) {
       styles[index] = { fontSize: 4 };
-
+      
     }
     var textbox = new fabric.Textbox(text, {
       styles: { 0: styles },

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -532,8 +532,7 @@
     var text = 'aaa aaq ggg gg oee eee';
     var styles = {};
     for (var index = 0; index < text.length; index++) {
-      styles[index] = { fontSize: 4 };
-      
+      styles[index] = { fontSize: 4 };      
     }
     var textbox = new fabric.Textbox(text, {
       styles: { 0: styles },


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

This test is blocking me while working on features and makes me think my fixes are buggy 

You asked for scoped PRs so here it is.
Blocking control set fix.

## Description

this test was causing a lot of problems
it took me a lot of time to understand what was wrong
because we spread the input arg in `Text.fromObject` passing instance to `fromObject` pollutes the created instance with class props that are enumerable strangly. This might be a node/QUnit thing.

I don't think we should care about it, though it is an edge case. 
No sense in passing a live instance to `fromObject` but if you think differently then we can safeguard it by running `cloneDeep` before spreading it


## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
