### PR TITLE
fix(): restore js extension for the website fabricjs.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): keep browser files as .js [#8690](https://github.com/fabricjs/fabric.js/issues/8690)
 - fix(): object dispose removes canvas/event refs [#8673](https://github.com/fabricjs/fabric.js/issues/8673)
 - fix(test): Textbox `fromObject` test is incorrectly trying to restore an instance [#8686](https://github.com/fabricjs/fabric.js/pull/8686)
 - TS(): Moved cache properties to static properties on classes [#xxxx](https://github.com/fabricjs/fabric.js/pull/xxxx)

--- a/package.json
+++ b/package.json
@@ -129,8 +129,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "default": "./dist/index.cjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js",
       "node": null,
       "types": "./dist/index.d.ts"
     },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -62,7 +62,7 @@ export default [
         sourcemap: true,
       },
       {
-        file: path.resolve(dirname, `${basename}.node.js`),
+        file: path.resolve(dirname, `${basename}.node.cjs`),
         name: 'fabric',
         format: 'cjs',
         sourcemap: true,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -36,7 +36,7 @@ export default [
         sourcemap: true,
       },
       {
-        file: path.resolve(dirname, `${basename}.cjs`),
+        file: path.resolve(dirname, `${basename}.js`),
         name: 'fabric',
         format: 'umd',
         sourcemap: true,
@@ -62,7 +62,7 @@ export default [
         sourcemap: true,
       },
       {
-        file: path.resolve(dirname, `${basename}.node.cjs`),
+        file: path.resolve(dirname, `${basename}.node.js`),
         name: 'fabric',
         format: 'cjs',
         sourcemap: true,

--- a/scripts/index.mjs
+++ b/scripts/index.mjs
@@ -160,7 +160,7 @@ function copy(from, to) {
   }
 }
 
-const BUILD_SOURCE = ['src', 'lib', 'HEADER.js'];
+const BUILD_SOURCE = ['src', 'lib'];
 
 function exportBuildToWebsite(options = {}) {
   _.defaultsDeep(options, { gestures: true });

--- a/test/testem.config.js
+++ b/test/testem.config.js
@@ -6,7 +6,7 @@
 module.exports = {
   framework: 'qunit',
   serve_files: [
-    'dist/index.cjs',
+    'dist/index.js',
     'test/lib/assert.js'
   ],
   styles: [

--- a/test/unit/env.js
+++ b/test/unit/env.js
@@ -18,8 +18,8 @@ QUnit.module('env', (hooks) => {
 
         QUnit.test('SSR: importing fabric before window/document are defined', async assert => {
             const done = assert.async();
-            const imported = await import('../../dist/index.cjs');
-            const required = require('../../dist/index.cjs');
+            const imported = await import('../../dist/index.js');
+            const required = require('../../dist/index.js');
             assert.notOk(global.window, 'no window');
             assert.notOk(global.document, 'no document');
             const win = { devicePixelRatio: 1.25 };
@@ -29,12 +29,12 @@ QUnit.module('env', (hooks) => {
             [imported, required].forEach(fabric => {
                 assert.equal(fabric.getEnv().window, win, 'window should match');
                 assert.equal(fabric.getEnv().document, doc, 'document should match');
-            });            
+            });
             done();
         });
     });
 
-    (!isNode() ? QUnit.module : QUnit.module.skip)('browser', (hooks) => { 
+    (!isNode() ? QUnit.module : QUnit.module.skip)('browser', (hooks) => {
         QUnit.test('env', assert => {
             assert.equal(fabric.getWindow(), window, 'window should be set');
             assert.equal(fabric.getDocument(), document, 'window should be set');


### PR DESCRIPTION
This is the simplest way to restore the website npm start command
Other points around removal of cjs extension is that probably the only bundle we will have is the umd.js + sourcemaps, and the rest can stay as unbundled files.

I don't think this needs more discussions till we have time to finish that other build playground i have in the other PR that for now is parked as `not time for it`. When that PR is ready we can re-review the names.