### PR TITLE
fix(test): remove bad node config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(test): remove bad node config [#8694](https://github.com/fabricjs/fabric.js/issues/8694)
 - fix(): keep browser files as .js [#8690](https://github.com/fabricjs/fabric.js/issues/8690)
 - fix(): object dispose removes canvas/event refs [#8673](https://github.com/fabricjs/fabric.js/issues/8673)
 - fix(test): Textbox `fromObject` test is incorrectly trying to restore an instance [#8686](https://github.com/fabricjs/fabric.js/pull/8686)

--- a/test/node_test_setup.js
+++ b/test/node_test_setup.js
@@ -123,39 +123,3 @@ fabric.StaticCanvas.prototype.initialize = function () {
   canvasInit.apply(this, arguments);
   this.testID = `Canvas#${++testID}`;
 }
-
-function getLoggingRepresentation(input) {
-  return typeof input === 'object' && input && input.testID ?
-    input.testID :
-    input;
-}
-
-//  https://api.qunitjs.com/extension/QUnit.dump.parse/
-QUnit.dump.maxDepth = 1;
-//  https://github.com/qunitjs/qunit/blob/main/src/assert.js
-QUnit.assert.deepEqual = function (actual, expected, message) {
-  actual = QUnit.dump.parse(actual);
-  expected = QUnit.dump.parse(expected);
-  this.pushResult({
-    result: QUnit.equiv(actual, expected),
-    message: `${message}\ndiff:\n${diff(actual, expected)}`,
-    actual,
-    expected
-  });
-};
-QUnit.assert.equal = function (actual, expected, message) {
-  this.pushResult({
-    result: actual == expected,
-    actual: getLoggingRepresentation(actual),
-    expected: getLoggingRepresentation(expected),
-    message
-  });
-};
-QUnit.assert.strictEqual = function (actual, expected, message) {
-  this.pushResult({
-    result: actual === expected,
-    actual: getLoggingRepresentation(actual),
-    expected: getLoggingRepresentation(expected),
-    message
-  });
-};


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

`deepEqual` reports a false positive. I know this because browser tests fail where node tests don't
Removing this config fixes it

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
