### PR TITLE
Fix() safeguard access to possibly undefined canvas

### DIFF
--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -212,7 +212,7 @@
       styleOverride = styleOverride || {};
       ctx.save();
       var retinaScaling = 1, matrix, p;
-      if(this.canvas) {
+      if (this.canvas) {
         retinaScaling = this.canvas.getRetinaScaling();
       }
       ctx.setTransform(retinaScaling, 0, 0, retinaScaling, 0, 0);

--- a/src/mixins/object_interactivity.mixin.js
+++ b/src/mixins/object_interactivity.mixin.js
@@ -211,7 +211,10 @@
     drawControls: function(ctx, styleOverride) {
       styleOverride = styleOverride || {};
       ctx.save();
-      var retinaScaling = this.canvas.getRetinaScaling(), matrix, p;
+      var retinaScaling = 1, matrix, p;
+      if(this.canvas) {
+        retinaScaling = this.canvas.getRetinaScaling();
+      }
       ctx.setTransform(retinaScaling, 0, 0, retinaScaling, 0, 0);
       ctx.strokeStyle = ctx.fillStyle = styleOverride.cornerColor || this.cornerColor;
       if (!this.transparentCorners) {


### PR DESCRIPTION
## Motivation

Fix unguarded reference for `object.canvas`

## Description
`this.canvas.getRetinaScaling()` call can cause TypeError in current release in some cases. It happened with us few times.
Would be really helpful to get this fix as soon as possible. I saw it already fixed in @beta, but I don't see it coming at the nearest future.

## Changes

Enhance `.drawControls` method with guard for `.getRetinaScaling` call. Set default retinaScaling to 1.

## In Action

Smallest example to represent an issue. This is a bit far-fetched but represents edge cases which could happen in huge variety of race conditions.

Steps: Try to move object on canvas.
https://codesandbox.io/s/fabricjs-playground-forked-hpodkw

