### PR TITLE
WIP Use the mouse or pointer offsetX/offsetY instead of clientX/clientY

### DIFF
--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -1144,9 +1144,6 @@ export class SelectableCanvas<
       }
     }
 
-    this.calcOffset();
-    pointer.x = pointer.x - this._offset.left;
-    pointer.y = pointer.y - this._offset.top;
     if (!ignoreVpt) {
       pointer = this.restorePointerVpt(pointer);
     }

--- a/src/util/dom_event.ts
+++ b/src/util/dom_event.ts
@@ -17,7 +17,7 @@ export const getPointer = (event) => {
     // write code for safari < 13
     return new Point(0,0);
   }
-  return new Point(_evt.offsetX, _evt.offsetY);
+  return new Point(event.offsetX, event.offsetY);
 };
 
 export const isTouchEvent = (event) =>

--- a/src/util/dom_event.ts
+++ b/src/util/dom_event.ts
@@ -1,6 +1,6 @@
 //@ts-nocheck
 import { Point } from '../Point';
-
+import { getElementOffset } from './dom_misc';
 const touchEvents = ['touchstart', 'touchmove', 'touchend'];
 
 function getTouchInfo(event) {
@@ -15,7 +15,8 @@ export const getPointer = (event) => {
   if (isTouchEvent(event)) {
     const _evt = getTouchInfo(event);
     // write code for safari < 13
-    return new Point(0,0);
+    const { left, top } = getElementOffset(event.target);
+    return new Point(_evt.clientX, _evt.clientY).subtract(new Point(left, top));
   }
   return new Point(event.offsetX, event.offsetY);
 };

--- a/src/util/dom_event.ts
+++ b/src/util/dom_event.ts
@@ -1,6 +1,5 @@
 //@ts-nocheck
 import { Point } from '../Point';
-import { getScrollLeftTop } from './dom_misc';
 
 const touchEvents = ['touchstart', 'touchmove', 'touchend'];
 
@@ -13,10 +12,12 @@ function getTouchInfo(event) {
 }
 
 export const getPointer = (event) => {
-  const element = event.target,
-    scroll = getScrollLeftTop(element),
-    _evt = getTouchInfo(event);
-  return new Point(_evt.clientX + scroll.left, _evt.clientY + scroll.top);
+  if (isTouchEvent(event)) {
+    const _evt = getTouchInfo(event);
+    // write code for safari < 13
+    return new Point(0,0);
+  }
+  return new Point(_evt.offsetX, _evt.offsetY);
 };
 
 export const isTouchEvent = (event) =>

--- a/src/util/dom_event.ts
+++ b/src/util/dom_event.ts
@@ -12,13 +12,12 @@ function getTouchInfo(event) {
 }
 
 export const getPointer = (event) => {
+  let _evt = event;
   if (isTouchEvent(event)) {
-    const _evt = getTouchInfo(event);
-    // write code for safari < 13
-    const { left, top } = getElementOffset(event.target);
-    return new Point(_evt.clientX, _evt.clientY).subtract(new Point(left, top));
+    _evt = getTouchInfo(event);
   }
-  return new Point(event.offsetX, event.offsetY);
+  const { left, top } = getElementOffset(event.target);
+  return new Point(_evt.clientX, _evt.clientY).subtract(new Point(left, top));
 };
 
 export const isTouchEvent = (event) =>

--- a/src/util/dom_misc.ts
+++ b/src/util/dom_misc.ts
@@ -1,4 +1,4 @@
-import { getDocument } from '../env';
+import { getWindow } from '../env';
 
 /**
  * Wraps element with another element
@@ -19,39 +19,13 @@ export function wrapElement(element: HTMLElement, wrapper: HTMLDivElement) {
  * Returns offset for a given element
  * @param {HTMLElement} element Element to get offset for
  * @return {Object} Object with "left" and "top" properties
- * TODO convert to getBoundingClientRect + window.scrollX/Y
  */
 export function getElementOffset(element: HTMLElement) {
-
-  let box = { left: 0, top: 0 };
-  const doc = element && element.ownerDocument,
-    offset = { left: 0, top: 0 },
-    offsetAttributes = {
-      borderLeftWidth: 'left',
-      borderTopWidth: 'top',
-      paddingLeft: 'left',
-      paddingTop: 'top',
-    } as const;
-
-  if (!doc) {
-    return offset;
-  }
-  const elemStyle = getDocument().defaultView!.getComputedStyle(element, null);
-  for (const attr in offsetAttributes) {
-    // @ts-expect-error TS learn to iterate!
-    offset[offsetAttributes[attr]] += parseInt(elemStyle[attr], 10) || 0;
-  }
-
-  const docElem = doc.documentElement;
-  if (typeof element.getBoundingClientRect !== 'undefined') {
-    box = element.getBoundingClientRect();
-  }
-
+  const box = element.getBoundingClientRect();
   return {
-    left:
-      box.left - (docElem.clientLeft || 0) + offset.left,
-    top: box.top - (docElem.clientTop || 0) + offset.top,
-  };
+    top: box.top + getWindow().scrollY,
+    left: box.left + getWindow().scrollX,
+  }
 }
 
 /**

--- a/src/util/dom_misc.ts
+++ b/src/util/dom_misc.ts
@@ -16,51 +16,13 @@ export function wrapElement(element: HTMLElement, wrapper: HTMLDivElement) {
 }
 
 /**
- * Returns element scroll offsets
- * @param {HTMLElement} element Element to operate on
- * @return {Object} Object with left/top values
- */
-export function getScrollLeftTop(element: HTMLElement) {
-  let left = 0,
-    top = 0;
-
-  const docElement = getDocument().documentElement,
-    body = getDocument().body || {
-      scrollLeft: 0,
-      scrollTop: 0,
-    };
-  // While loop checks (and then sets element to) .parentNode OR .host
-  //  to account for ShadowDOM. We still want to traverse up out of ShadowDOM,
-  //  but the .parentNode of a root ShadowDOM node will always be null, instead
-  //  it should be accessed through .host. See http://stackoverflow.com/a/24765528/4383938
-  // @ts-ignore
-  while (element && (element.parentNode || element.host)) {
-    // Set element to element parent, or 'host' in case of ShadowDOM
-    // @ts-ignore
-    element = element.parentNode || element.host;
-    // @ts-expect-error because element is typed as HTMLElement but it can go up to document
-    if (element === getDocument()) {
-      left = body.scrollLeft || docElement.scrollLeft || 0;
-      top = body.scrollTop || docElement.scrollTop || 0;
-    } else {
-      left += element.scrollLeft || 0;
-      top += element.scrollTop || 0;
-    }
-
-    if (element.nodeType === 1 && element.style.position === 'fixed') {
-      break;
-    }
-  }
-
-  return { left, top };
-}
-
-/**
  * Returns offset for a given element
  * @param {HTMLElement} element Element to get offset for
  * @return {Object} Object with "left" and "top" properties
+ * TODO convert to getBoundingClientRect + window.scrollX/Y
  */
 export function getElementOffset(element: HTMLElement) {
+
   let box = { left: 0, top: 0 };
   const doc = element && element.ownerDocument,
     offset = { left: 0, top: 0 },
@@ -85,12 +47,10 @@ export function getElementOffset(element: HTMLElement) {
     box = element.getBoundingClientRect();
   }
 
-  const scrollLeftTop = getScrollLeftTop(element);
-
   return {
     left:
-      box.left + scrollLeftTop.left - (docElem.clientLeft || 0) + offset.left,
-    top: box.top + scrollLeftTop.top - (docElem.clientTop || 0) + offset.top,
+      box.left - (docElem.clientLeft || 0) + offset.left,
+    top: box.top - (docElem.clientTop || 0) + offset.top,
   };
 }
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -80,7 +80,6 @@ export {
 export { setStyle } from './dom_style';
 export { isTouchEvent, getPointer } from './dom_event';
 export {
-  // getScrollLeftTop,
   getElementOffset,
   makeElementUnselectable,
   makeElementSelectable,


### PR DESCRIPTION
## Motivation

Code simplification.

## Description

Took a break from types to tackle this thing it was in my head since long.

Today for historical reasons we check for mouse coordinates in client space, and then we subtract the current position of the canvas recursively calculating our position inspecting various css rules.
This code is old, and probably was done in thise way because older browsers didn't suppor getBoundingClientRect.

Unfortunately touch events ( that are still supported ) do not offer this property and for those browsers we will need to do a similar calculation, possibly using non custom code but a couple of browser api.

It is also to be investigated the whole `calcOffset` code that as of now would be needed only for text area positioning.

It would be great to remove `calcOffset` from canvas domain and simply relegate it to a hiddenTextarea and editable text concern.

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
