### PR TITLE
Fix index issue

### DIFF
--- a/scripts/index.mjs
+++ b/scripts/index.mjs
@@ -487,6 +487,7 @@ program
   .name('fabric.js')
   .description('fabric.js DEV CLI tools')
   .version(process.env.npm_package_version)
+program
   .showSuggestionAfterError();
 
 program

--- a/scripts/index.mjs
+++ b/scripts/index.mjs
@@ -486,9 +486,8 @@ async function runInteractiveTestSuite(options) {
 program
   .name('fabric.js')
   .description('fabric.js DEV CLI tools')
-  .version(process.env.npm_package_version)
-program
-  .showSuggestionAfterError();
+  .version(process.env.npm_package_version);
+program.showSuggestionAfterError();
 
 program
   .command('dev')


### PR DESCRIPTION
Added a line to make sure I can run the index script. I have no clue what was causing this bug, but for some reason on my machine the `version` function wasn't returning `this`, even though the docs say it should. This change shouldn't change any functionality, only a small bug fix. Specifically, the error was saying: 
```
file:///<redacted>/fabric.js/scripts/index.mjs:490
  .showSuggestionAfterError();
  ^

TypeError: Cannot read properties of undefined (reading 'showSuggestionAfterError')
    at file:///<redacted>/fabric.js/scripts/index.mjs:490:3
    at ModuleJob.run (node:internal/modules/esm/module_job:185:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)
```