### PR TITLE
Add a way to start an animation at any arbitrary time

### DIFF
--- a/src/util/animation/AnimationBase.ts
+++ b/src/util/animation/AnimationBase.ts
@@ -18,6 +18,7 @@ export abstract class AnimationBase<
   declare readonly startValue: T;
   declare readonly endValue: T;
   declare readonly duration: number;
+  declare readonly startOffset: number;
   declare readonly delay: number;
 
   protected declare readonly byValue: T;
@@ -58,6 +59,7 @@ export abstract class AnimationBase<
     byValue,
     duration = 500,
     delay = 0,
+    startOffset = 0,
     easing = defaultEasing,
     onStart = noop,
     onChange = noop,
@@ -69,6 +71,7 @@ export abstract class AnimationBase<
 
     this.duration = duration;
     this.delay = delay;
+    this.startOffset = startOffset;
     this.easing = easing;
     this._onStart = onStart;
     this._onChange = onChange;
@@ -121,7 +124,7 @@ export abstract class AnimationBase<
   }
 
   private tick(t: number) {
-    const durationMs = (t || +new Date()) - this.startTime;
+    const durationMs = (t || +new Date()) - this.startTime + this.startOffset;
     const boundDurationMs = Math.min(durationMs, this.duration);
     this.durationProgress = boundDurationMs / this.duration;
     const { value, valueProgress } = this.calculate(boundDurationMs);


### PR DESCRIPTION
Adding an argument called startOffset so you can start an animation at any given percentage (so not always at the beguining), this way the users of this library can do stuff like kill an animation and later on re-create it where it left (and the easing function will continue right where it left, instead of wrongly assuming t=0)

<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
