### PR TITLE
typo(): percision => precision

### DIFF
--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -580,7 +580,7 @@
    * @param {*} actual
    * @param {*} expected
    * @param {*} [message]
-   * @param {number} [error] floating point percision, defaults to 10
+   * @param {number} [error] floating point precision, defaults to 10
    */
   QUnit.assert.matrixIsEqualEnough = function (actual, expected, message, error) {
     var error = Math.pow(10, error ? -error : -10);


### PR DESCRIPTION
There is a small typo in test/unit/util.js.

Should read `precision` rather than `percision`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md