### PR TITLE
chore(): Bump version to beta3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fabric",
   "description": "Object model for HTML5 canvas, and SVG-to-canvas parser. Backed by jsdom and node-canvas.",
   "homepage": "http://fabricjs.com/",
-  "version": "6.0.0-beta1",
+  "version": "6.0.0-beta3",
   "author": "Juriy Zaytsev <kangax@gmail.com>",
   "contributors": [
     {


### PR DESCRIPTION
I kind of missed bumping the version before tagging beta2.
So publishing failed.