### PR TITLE
refactor() BREAKING: align line to other classes for positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [6.0.0-beta5]
 
+- refactor(fabric.Line): Line position is calculated from the center between the 2 points now [#8877](https://github.com/fabricjs/fabric.js/pull/8877)
 - bundle(): export `setEnv` for JEST interoperability [#8888](https://github.com/fabricjs/fabric.js/pull/8888)
 
 ## [6.0.0-beta4]

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -103,7 +103,7 @@ export class Line<
   _set(key: string, value: any) {
     super._set(key, value);
     if (coordProps.includes(key as keyof UniqueLineProps)) {
-      // this doesn't make sense anymore, since setting x1 when top or left
+      // this doesn't make sense very much, since setting x1 when top or left
       // are already set, is just going to show a strange result since the
       // line will move way more than the developer expect
       this._setWidthHeight();
@@ -185,20 +185,23 @@ export class Line<
    * @private
    */
   calcLinePoints(): UniqueLineProps {
-    const xMult = this.x1 <= this.x2 ? -1 : 1,
-      yMult = this.y1 <= this.y2 ? -1 : 1,
-      x1 = xMult * this.width * 0.5,
-      y1 = yMult * this.height * 0.5,
-      x2 = xMult * this.width * -0.5,
-      y2 = yMult * this.height * -0.5;
+    const { x1: _x1, x2: _x2, y1: _y1, y2: _y2, width, height } = this;
+    const xMult = _x1 <= _x2 ? -1 : 1,
+      yMult = _y1 <= _y2 ? -1 : 1,
+      x1 = (xMult * width) / 2,
+      y1 = (yMult * height) / 2,
+      x2 = (xMult * -width) / 2,
+      y2 = (yMult * -height) / 2;
 
     return {
-      x1: x1,
-      x2: x2,
-      y1: y1,
-      y2: y2,
+      x1,
+      x2,
+      y1,
+      y2,
     };
   }
+
+  /* _FROM_SVG_START_ */
 
   /**
    * Returns svg representation of an instance
@@ -206,23 +209,13 @@ export class Line<
    * of the instance
    */
   _toSVG() {
-    const p = this.calcLinePoints();
+    const { x1, x2, y1, y2 } = this.calcLinePoints();
     return [
       '<line ',
       'COMMON_PARTS',
-      'x1="',
-      p.x1,
-      '" y1="',
-      p.y1,
-      '" x2="',
-      p.x2,
-      '" y2="',
-      p.y2,
-      '" />\n',
+      `x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" />\n`,
     ];
   }
-
-  /* _FROM_SVG_START_ */
 
   /**
    * List of attribute names to account for when parsing SVG element (used by {@link Line.fromElement})
@@ -241,13 +234,14 @@ export class Line<
    * @param {Function} [callback] callback function invoked after parsing
    */
   static fromElement(element: SVGElement, callback: (line: Line) => any) {
-    const parsedAttributes = parseAttributes(element, this.ATTRIBUTE_NAMES),
-      points: [number, number, number, number] = [
-        parsedAttributes.x1 || 0,
-        parsedAttributes.y1 || 0,
-        parsedAttributes.x2 || 0,
-        parsedAttributes.y2 || 0,
-      ];
+    const {
+        x1 = 0,
+        y1 = 0,
+        x2 = 0,
+        y2 = 0,
+        ...parsedAttributes
+      } = parseAttributes(element, this.ATTRIBUTE_NAMES),
+      points: [number, number, number, number] = [x1, y1, x2, y2];
     callback(new this(points, parsedAttributes));
   }
 

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -105,7 +105,10 @@ export class Line<
     if (coordProps.includes(key as keyof UniqueLineProps)) {
       // this doesn't make sense very much, since setting x1 when top or left
       // are already set, is just going to show a strange result since the
-      // line will move way more than the developer expect
+      // line will move way more than the developer expect.
+      // in fabric5 it worked only when the line didn't have extra transformations,
+      // in fabric6 too. With extra transform they behave bad in different ways.
+      // This needs probably a good rework or a tutorial if you have to create a dynamic line
       this._setWidthHeight();
     }
     return this;
@@ -182,6 +185,9 @@ export class Line<
 
   /**
    * Recalculates line points given width and height
+   * Those points are simply placed around the center,
+   * This is not useful outside internal render functions and svg output
+   * Is not meant to be for the developer.
    * @private
    */
   calcLinePoints(): UniqueLineProps {

--- a/test/unit/line.js
+++ b/test/unit/line.js
@@ -5,8 +5,8 @@
     type:                     'Line',
     originX:                  'left',
     originY:                  'top',
-    left:                     11,
-    top:                      12,
+    left:                     10.5,
+    top:                      11.5,
     width:                    2,
     height:                   2,
     fill:                     'rgb(0,0,0)',
@@ -69,7 +69,7 @@
 
   QUnit.test('toSVG', function(assert) {
     var line = new fabric.Line([11, 12, 13, 14]);
-    var EXPECTED_SVG = '<g transform=\"matrix(1 0 0 1 12.5 13.5)\"  >\n<line style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x1=\"-1\" y1=\"-1\" x2=\"1\" y2=\"1\" />\n</g>\n';
+    var EXPECTED_SVG = '<g transform=\"matrix(1 0 0 1 12 13)\"  >\n<line style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"  x1=\"-1\" y1=\"-1\" x2=\"1\" y2=\"1\" />\n</g>\n';
     assert.equal(line.toSVG(), EXPECTED_SVG);
   });
 
@@ -169,304 +169,23 @@
     });
   });
 
-  // this isn't implemented yet, so disabling for now
-
-  // QUnit.test('x1,y1 less than x2,y2 should work', function(assert) {
-  //   var line = new fabric.Line([ 400, 200, 300, 400]);
-
-  //   assert.equal(100, line.width);
-  //   assert.equal(200, line.height);
-  // });
-
-  var lineCoordsCases = [
-    { description: 'default to 0 left and 0 top',
-      givenLineArgs: {
-        options: {
-          strokeWidth: 0,
-        }
-      },
-      expectedCoords: {
-        left: 0,
-        top: 0,
-      }
-    },
-    { description: 'default to 0 left and 0 top and default strokeWidth of 1',
-      givenLineArgs: {
-      },
-      expectedCoords: {
-        left: -0.5,
-        top: -0.5,
-      }
-    },
-    { description: 'origin defaults to left-top',
-      givenLineArgs: {
-        points: [0, 0, 11, 22],
-      },
-      expectedCoords: {
-        left: 0,
-        top: 0,
-      }
-    },
-    { description: 'equal smallest points when origin is left-top and line not offset',
-      givenLineArgs: {
-        points: [0, 0, 12.3, 34.5],
-        options: {
-          originX: 'left',
-          originY: 'top',
-        },
-      },
-      expectedCoords: {
-        left: 0,
-        top: 0,
-      }
-    },
-    { description: 'include offsets for left-top origin',
-      givenLineArgs: {
-        points: [33, 44, 44, 66],
-        options: {
-          originX: 'left',
-          originY: 'top',
-        },
-      },
-      expectedCoords: {
-        left: 33,
-        top: 44,
-      }
-    },
-    { description: 'equal half-dimensions when origin is center and line not offset',
-      givenLineArgs: {
-        points: [0, 0, 12.3, 34.5],
-        options: {
-          originX: 'center',
-          originY: 'center',
-        },
-      },
-      expectedCoords: {
-        left: 0.5 * 12.3,
-        top: 0.5 * 34.5,
-      }
-    },
-    { description: 'include offsets for center-center origin',
-      givenLineArgs: {
-        points: [0 + 9.87, 0 - 4.32, 12.3 + 9.87, 34.5 - 4.32],
-        options: {
-          originX: 'center',
-          originY: 'center',
-        },
-      },
-      expectedCoords: {
-        left: (0.5 * 12.3) + 9.87,
-        top: (0.5 * 34.5) - 4.32,
-      }
-    },
-    { description: 'equal full dimensions when origin is right-bottom and line not offset',
-      givenLineArgs: {
-        points: [0, 0, 55, 18],
-        options: {
-          originX: 'right',
-          originY: 'bottom',
-          strokeWidth: 0,
-        },
-      },
-      expectedCoords: {
-        left: 55,
-        top: 18,
-      }
-    },
-    { description: 'include offsets for right-bottom origin',
-      givenLineArgs: {
-        points: [0 - 3.14, 0 - 1.41, 55 - 3.14, 18 - 1.41],
-        options: {
-          strokeWidth: 0,
-          originX: 'right',
-          originY: 'bottom',
-        },
-      },
-      expectedCoords: {
-        left: 55 - 3.14,
-        top: 18 - 1.41,
-      }
-    },
-    { description: 'arent changed by rotation for left-top origin',
-      givenLineArgs: {
-        points: [1, 2, 30, 40],
-        options: {
-          originX: 'left',
-          originY: 'top',
-          angle: 67,
-        }
-      },
-      expectedCoords: {
-        left: 1,
-        top: 2,
-      }
-    },
-    { description: 'arent changed by rotation for right-bottom origin',
-      givenLineArgs: {
-        points: [1, 2, 30, 40],
-        options: {
-          originX: 'right',
-          originY: 'bottom',
-          angle: 67,
-        }
-      },
-      expectedCoords: {
-        left: 30,
-        top: 40,
-      }
-    },
-    { description: 'arent changed by scaling for left-top origin',
-      givenLineArgs: {
-        points: [1, 2, 30, 40],
-        options: {
-          originX: 'left',
-          originY: 'top',
-          scale: 2.1,
-        }
-      },
-      expectedCoords: {
-        left: 1,
-        top: 2,
-      }
-    },
-    { description: 'arent changed by scaling for right-bottom origin',
-      givenLineArgs: {
-        points: [1, 2, 30, 40],
-        options: {
-          originX: 'right',
-          originY: 'bottom',
-          scale: 1.2,
-        }
-      },
-      expectedCoords: {
-        left: 30,
-        top: 40,
-      }
-    },
-    { description: 'arent changed by strokeWidth for left-top origin',
-      givenLineArgs: {
-        points: [31, 41, 59, 26],
-        options: {
-          originX: 'left',
-          originY: 'top',
-          stroke: 'black',
-          strokeWidth: '53'
-        }
-      },
-      expectedCoords: {
-        left: 31,
-        top: 26,
-      }
-    },
-    { description: 'arent changed by strokeWidth for center-center origin',
-      givenLineArgs: {
-        points: [0 + 31, 15 + 26, 28 + 31, 0 + 26],
-        options: {
-          originX: 'center',
-          originY: 'center',
-          stroke: 'black',
-          strokeWidth: '53'
-        }
-      },
-      expectedCoords: {
-        left: (0.5 * 28) + 31,
-        top: (0.5 * 15) + 26,
-      }
-    },
-    { description: 'arent changed by strokeWidth for right-bottom origin',
-      givenLineArgs: {
-        points: [1, 2, 30, 40],
-        options: {
-          originX: 'right',
-          originY: 'bottom',
-          stroke: 'black',
-          strokeWidth: '53'
-        }
-      },
-      expectedCoords: {
-        left: 30,
-        top: 40,
-      }
-    },
-    { description: 'left and top options override points',
-      givenLineArgs: {
-        points: [12, 34, 56, 78],
-        options: {
-          left: 98,
-          top: 76,
-        }
-      },
-      expectedCoords: {
-        left: 98,
-        top: 76,
-      }
-    },
-    { description: '0 left and 0 top options override points',
-      givenLineArgs: {
-        points: [12, 34, 56, 78],
-        options: {
-          left: 0,
-          top: 0,
-        }
-      },
-      expectedCoords: {
-        left: 0,
-        top: 0,
-      }
-    },
-    { description: 'equal x2 and y2 for left-top origin when x1 and y1 are largest and line not offset',
-      givenLineArgs: {
-        points: [100, 200, 30, 40],
-        options: {
-          originX: 'left',
-          originY: 'top',
-        }
-      },
-      expectedCoords: {
-        left: 30,
-        top: 40,
-      }
-    },
-    { description: 'equal half-dimensions for center-center origin when x1 and y1 are largest and line not offset',
-      givenLineArgs: {
-        points: [100, 200, 0, 0],
-        options: {
-          originX: 'center',
-          originY: 'center',
-        }
-      },
-      expectedCoords: {
-        left: 0.5 * 100,
-        top: 0.5 * 200,
-      }
-    },
-    { description: 'equal x1 and y1 for right-bottom origin when x1 and y1 are largest and line not offset',
-      givenLineArgs: {
-        points: [100, 200, 0, 0],
-        options: {
-          originX: 'right',
-          originY: 'bottom',
-        }
-      },
-      expectedCoords: {
-        left: 100,
-        top: 200,
-      }
-    },
-  ];
-
-  lineCoordsCases.forEach(function (c_) {
-    QUnit.test('stroke-less line coords ' + c_.description, function(assert) {
-      var points = c_.givenLineArgs.points;
-      var options = c_.givenLineArgs.options;
-
-      var givenLine = new fabric.Line(
-        points,
-        options
-      );
-
-      assert.equal(givenLine.left, c_.expectedCoords.left);
-      assert.equal(givenLine.top, c_.expectedCoords.top);
+  ['left', 'center', 'right'].forEach((originX) => {
+    ['top', 'center', 'bottom'].forEach((originY) => {
+      [0, 7].forEach((strokeWidth) => {
+        [0, 33, 90].forEach((angle) => {
+          QUnit.test(`Regardless of strokeWidth or origin, a line is always positioned on its center when left/top are not specified (${originX}/${originY} stroke:${strokeWidth} angle:${angle})`, function(assert) {
+            const line = new fabric.Line([1, 1, 15, 7], {
+              strokeWidth,
+              originX,
+              originY,
+              angle,
+            });
+            const center = line.getCenterPoint();
+            assert.equal(Math.round(center.x), 8);
+            assert.equal(Math.round(center.y), 4);
+          });
+        });
+      });
     });
   });
 

--- a/test/unit/line.js
+++ b/test/unit/line.js
@@ -180,10 +180,22 @@
 
   var lineCoordsCases = [
     { description: 'default to 0 left and 0 top',
-      givenLineArgs: {},
+      givenLineArgs: {
+        options: {
+          strokeWidth: 0,
+        }
+      },
       expectedCoords: {
         left: 0,
         top: 0,
+      }
+    },
+    { description: 'default to 0 left and 0 top and default strokeWidth of 1',
+      givenLineArgs: {
+      },
+      expectedCoords: {
+        left: -0.5,
+        top: -0.5,
       }
     },
     { description: 'origin defaults to left-top',
@@ -210,7 +222,7 @@
     },
     { description: 'include offsets for left-top origin',
       givenLineArgs: {
-        points: [0 + 33, 0 + 44, 11 + 33, 22 + 44],
+        points: [33, 44, 44, 66],
         options: {
           originX: 'left',
           originY: 'top',
@@ -253,6 +265,7 @@
         options: {
           originX: 'right',
           originY: 'bottom',
+          strokeWidth: 0,
         },
       },
       expectedCoords: {
@@ -264,6 +277,7 @@
       givenLineArgs: {
         points: [0 - 3.14, 0 - 1.41, 55 - 3.14, 18 - 1.41],
         options: {
+          strokeWidth: 0,
           originX: 'right',
           originY: 'bottom',
         },
@@ -453,154 +467,6 @@
 
       assert.equal(givenLine.left, c_.expectedCoords.left);
       assert.equal(givenLine.top, c_.expectedCoords.top);
-    });
-  });
-
-  var getLeftToOriginXCases = [
-    { description: 'is x1 for left origin and x1 lesser than x2',
-      givenOrigin: 'left',
-      givenPoints: [0, 0, 1, 0],
-      expectedLeft: 0,
-    },
-    { description: 'is x2 for left origin and x1 greater than x2',
-      givenOrigin: 'left',
-      givenPoints: [1, 0, 0, 0],
-      expectedLeft: 0,
-    },
-    { description: 'includes positive offset for left origin',
-      givenOrigin: 'left',
-      givenPoints: [0 + 20, 0, 1 + 20, 0],
-      expectedLeft: 0 + 20,
-    },
-    { description: 'includes negative offset for left origin',
-      givenOrigin: 'left',
-      givenPoints: [0 - 11, 0, 1 - 11, 0],
-      expectedLeft: 0 - 11,
-    },
-    { description: 'is half of x1 for center origin and x1 > x2',
-      givenOrigin: 'center',
-      givenPoints: [4, 0, 0, 0],
-      expectedLeft: 0.5 * 4,
-    },
-    { description: 'is half of x2 for center origin and x1 < x2',
-      givenOrigin: 'center',
-      givenPoints: [0, 0, 7, 0],
-      expectedLeft: 0.5 * 7,
-    },
-    { description: 'includes positive offset for center origin',
-      givenOrigin: 'center',
-      givenPoints: [0 + 39, 0, 7 + 39, 0],
-      expectedLeft: (0.5 * 7) + 39,
-    },
-    { description: 'includes negative offset for center origin',
-      givenOrigin: 'center',
-      givenPoints: [4 - 13, 0, 0 - 13, 0],
-      expectedLeft: (0.5 * 4) - 13,
-    },
-    { description: 'is x1 for right origin and x1 > x2',
-      givenOrigin: 'right',
-      givenPoints: [9, 0, 0, 0],
-      expectedLeft: 9,
-    },
-    { description: 'is x2 for right origin and x1 < x2',
-      givenOrigin: 'right',
-      givenPoints: [0, 0, 6, 0],
-      expectedLeft: 6,
-    },
-    { description: 'includes positive offset for right origin',
-      givenOrigin: 'right',
-      givenPoints: [0 + 47, 0, 6 + 47, 0],
-      expectedLeft: 6 + 47,
-    },
-    { description: 'includes negative offset for right origin',
-      givenOrigin: 'right',
-      givenPoints: [9 - 17, 0, 0 - 17, 0],
-      expectedLeft: 9 - 17,
-    },
-  ];
-
-  getLeftToOriginXCases.forEach(function (c_) {
-    QUnit.test('Line.getLeftToOriginX() ' + c_.description, function (assert) {
-      var line = new fabric.Line(
-        c_.givenPoints,
-        { originX: c_.givenOrigin }
-      );
-
-      assert.equal(line._getLeftToOriginX(), c_.expectedLeft);
-    });
-  });
-
-  var getTopToOriginYCases = [
-    { description: 'is y1 for top origin and y1 lesser than y2',
-      givenOrigin: 'top',
-      givenPoints: [0, 0, 0, 1],
-      expectedTop: 0,
-    },
-    { description: 'is y2 for top origin and y1 greater than y2',
-      givenOrigin: 'top',
-      givenPoints: [0, 1, 0, 0],
-      expectedTop: 0,
-    },
-    { description: 'includes positive offset for top origin',
-      givenOrigin: 'top',
-      givenPoints: [0, 0 + 20, 0, 1 + 20],
-      expectedTop: 0 + 20,
-    },
-    { description: 'includes negative offset for top origin',
-      givenOrigin: 'top',
-      givenPoints: [0, 0 - 11, 0, 1 - 11],
-      expectedTop: 0 - 11,
-    },
-    { description: 'is half of y1 for center origin and y1 > y2',
-      givenOrigin: 'center',
-      givenPoints: [0, 4, 0, 0],
-      expectedTop: 0.5 * 4,
-    },
-    { description: 'is half of y2 for center origin and y1 < y2',
-      givenOrigin: 'center',
-      givenPoints: [0, 0, 0, 7],
-      expectedTop: 0.5 * 7,
-    },
-    { description: 'includes positive offset for center origin',
-      givenOrigin: 'center',
-      givenPoints: [0, 0 + 39, 0, 7 + 39],
-      expectedTop: (0.5 * 7) + 39,
-    },
-    { description: 'includes negative offset for center origin',
-      givenOrigin: 'center',
-      givenPoints: [0, 4 - 13, 0, 0 - 13],
-      expectedTop: (0.5 * 4) - 13,
-    },
-    { description: 'is y1 for bottom origin and y1 > y2',
-      givenOrigin: 'bottom',
-      givenPoints: [0, 9, 0, 0],
-      expectedTop: 9,
-    },
-    { description: 'is y2 for bottom origin and y1 < y2',
-      givenOrigin: 'bottom',
-      givenPoints: [0, 0, 0, 6],
-      expectedTop: 6,
-    },
-    { description: 'includes positive offset for bottom origin',
-      givenOrigin: 'bottom',
-      givenPoints: [0, 0 + 47, 0, 6 + 47],
-      expectedTop: 6 + 47,
-    },
-    { description: 'includes negative offset for bottom origin',
-      givenOrigin: 'bottom',
-      givenPoints: [0, 9 - 17, 0, 0 - 17],
-      expectedTop: 9 - 17,
-    },
-  ];
-
-  getTopToOriginYCases.forEach(function (c_) {
-    QUnit.test('Line._getTopToOriginY() ' + c_.description, function (assert) {
-      var line = new fabric.Line(
-        c_.givenPoints,
-        { originY: c_.givenOrigin }
-      );
-
-      assert.equal(line._getTopToOriginY(), c_.expectedTop);
     });
   });
 

--- a/test/unit/line.js
+++ b/test/unit/line.js
@@ -173,16 +173,19 @@
     ['top', 'center', 'bottom'].forEach((originY) => {
       [0, 7].forEach((strokeWidth) => {
         [0, 33, 90].forEach((angle) => {
-          QUnit.test(`Regardless of strokeWidth or origin, a line is always positioned on its center when left/top are not specified (${originX}/${originY} stroke:${strokeWidth} angle:${angle})`, function(assert) {
-            const line = new fabric.Line([1, 1, 15, 7], {
-              strokeWidth,
-              originX,
-              originY,
-              angle,
+          ['butt', 'round', 'square'].forEach((strokeLineCap) => {
+            QUnit.test(`Regardless of strokeWidth or origin, a line is always positioned on its center when left/top are not specified (${originX}/${originY} stroke:${strokeWidth} angle:${angle} cap:${strokeLineCap})`, function(assert) {
+              const line = new fabric.Line([1, 1, 15, 7], {
+                strokeWidth,
+                originX,
+                originY,
+                angle,
+                strokeLineCap,
+              });
+              const center = line.getCenterPoint();
+              assert.equal(Math.round(center.x), 8);
+              assert.equal(Math.round(center.y), 4);
             });
-            const center = line.getCenterPoint();
-            assert.equal(Math.round(center.x), 8);
-            assert.equal(Math.round(center.y), 4);
           });
         });
       });


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

Line has some peculiar code that could be removed in favor of standard methods we use everyewhere else.

## Description

Trying to remove the custom code for the standard setPostionByOrigin and makeBoundingBoxFromPoints, leaving open the issue with changes in positioning.

This won't affect old saved data but affect lines that are created without left,top and just points.
I would seem normal that if i have a line that extends from `5,15 to 15,5` it's center is in `10, 10` regardless of strokeWidth and that the left, top and originX or originY are assigned depending from the options or the defaults but not from the points themselves

Today you get different originX and originY depending on the order of your points, like if x1 or y1 are the origin, and unless you specified a different origin.

Make sense to remove those contraddictions but there are cases in which the lines aren't anymore in the previous places when initialized with the same points.

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
