### PR TITLE
Bump version up to beta4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric",
-  "version": "6.0.0-beta3",
+  "version": "6.0.0-beta4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric",
-      "version": "6.0.0-beta3",
+      "version": "6.0.0-beta4",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.20.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fabric",
   "description": "Object model for HTML5 canvas, and SVG-to-canvas parser. Backed by jsdom and node-canvas.",
   "homepage": "http://fabricjs.com/",
-  "version": "6.0.0-beta3",
+  "version": "6.0.0-beta4",
   "author": "Juriy Zaytsev <kangax@gmail.com>",
   "contributors": [
     {


### PR DESCRIPTION
- chore(): Code cleanup and reuse of code in svg-parsing code [#8881](https://github.com/fabricjs/fabric.js/pull/8881)
- chore(TS): Parse transform attribute typing [#8878](https://github.com/fabricjs/fabric.js/pull/8878)
- chore(TS): Fix typing for DOMParser [#8871](https://github.com/fabricjs/fabric.js/pull/8871)
- fix(Path, polyline): fix for SVG import [#8879](https://github.com/fabricjs/fabric.js/pull/8879)
- chore(TS) add types for loadSVGFromURl, parseSVGDocument, loadSVGFromString [#8869](https://github.com/fabricjs/fabric.js/pull/8869)
- chore(TS): finalize Path migration [#8438](https://github.com/fabricjs/fabric.js/pull/8438)
- fix(Path, Obect) Fix path parsing edge case for zeroed arc command and for too small canvas patterns [#8853](https://github.com/fabricjs/fabric.js/pull/8853)