### PR TITLE
fix(): export `setEnv` for Jest interoperability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- bundle(): export `setEnv` [#8888](https://github.com/fabricjs/fabric.js/pull/8888)
+
 ## [6.0.0-beta4]
 
 - chore(): Code cleanup and reuse of code in svg-parsing code [#8881](https://github.com/fabricjs/fabric.js/pull/8881)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- bundle(): export `setEnv` [#8888](https://github.com/fabricjs/fabric.js/pull/8888)
+- bundle(): export `setEnv` for JEST interoperability [#8888](https://github.com/fabricjs/fabric.js/pull/8888)
 
 ## [6.0.0-beta4]
 

--- a/fabric.ts
+++ b/fabric.ts
@@ -1,4 +1,4 @@
-export { getEnv, getDocument, getWindow } from './src/env';
+export { getEnv, getDocument, getWindow, setEnv } from './src/env';
 export { cache } from './src/cache';
 export { VERSION as version, iMatrix } from './src/constants';
 export { config } from './src/config';

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -13,6 +13,19 @@ import type { DOMWindow } from 'jsdom';
 
 let env: TFabricEnv;
 
+/**
+ * Sets the environment variables used by fabric.\
+ * This is exposed for special cases, such as configuring a test environment, and should be used with care.
+ *
+ * **CAUTION**: Must be called before using the package.
+ *
+ * @example Testing with jest
+ * // jest is commonjs (https://jestjs.io/docs/ecmascript-modules), so by default it imports the node entry point.
+ * import { getEnv, setEnv } from 'fabric';
+ * // we want fabric to use the `window` and `document` objects exposed by jest.
+ * setEnv({ ...getEnv(), window, document });
+ * // done with setup, now run tests
+ */
 export const setEnv = (value: TFabricEnv) => {
   env = value;
 };


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation


Using jest testing with fabric v6 and getting error related to jsdom,
setting env fixes it

```bash
   TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'.
```

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

expose `setEnv` with a clear comment on usage.

@asturur I need this for work so please release a patch once it merges.

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
