### PR TITLE
fix: :bug: typescript compiler error

### DIFF
--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -114,7 +114,7 @@ export class Canvas extends SelectableCanvas {
 
   declare currentSubTargets?: FabricObject[];
 
-  private _isClick: boolean;
+  private _isClick?: boolean;
 
   textEditingManager = new TextEditingManager();
 

--- a/src/shapes/IText/ITextClickBehavior.ts
+++ b/src/shapes/IText/ITextClickBehavior.ts
@@ -30,7 +30,7 @@ export abstract class ITextClickBehavior<
   private declare __lastPointer: XY | Record<string, never>;
   private declare __newClickTime: number;
 
-  protected draggableTextDelegate: DraggableTextDelegate;
+  protected draggableTextDelegate!: DraggableTextDelegate;
 
   initBehavior() {
     // Initializes event handlers related to cursor or selection

--- a/src/shapes/Object/types/index.ts
+++ b/src/shapes/Object/types/index.ts
@@ -1,7 +1,7 @@
 import { FabricObjectProps } from './FabricObjectProps';
 
-export { SerializedObjectProps } from './SerializedObjectProps';
-export { FabricObjectProps };
+export { type SerializedObjectProps } from './SerializedObjectProps';
+export { type FabricObjectProps };
 
 export type TProps<T> = Partial<T> & Record<string, any>;
 


### PR DESCRIPTION
## Motivation

fix typescript compiler error

## Description

Fix typescript compiler error
- In the case of the '_isClick' property, an error occurred because it was declared in the class property but not initialized. To correct this, it was changed to optional. The reason is that the value is a boolean value, and even if it is not assigned, it is recognized as undefined, so it is recognized as a negative value.

- The 'draggableTextDelegate' property is the same as the above, but since it is an instance, I did not change it to optional and thought that the initBehavior method was called necessarily, so I modified it using a Non-null assertion operator.

- For the reason why 'SerializedObjectProps' and 'FabricObjectProps' types were added, please refer to the link below.
https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names

## Changes

- Modified the '_isClick' property to be optional.
- Modified the draggableTextDelegate' property to be Non-null assertion operator.
- Add type export to 'SerializedObjectProps', 'FabricObjectProps' 


## Gist

## In Action
