### PR TITLE
fix(Object): dirty unflagging inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- fix(Object): dirty flagging cleanup inconsistency [#8910](https://github.com/fabricjs/fabric.js/pull/8910)
+- fix(Object): dirty unflagging inconsistency [#8910](https://github.com/fabricjs/fabric.js/pull/8910)
 - chore(TS): minor type/import fixes [#8904](https://github.com/fabricjs/fabric.js/pull/8904)
 - chore(): Matrix util cleanup [#8894](https://github.com/fabricjs/fabric.js/pull/8894)
 - chore(TS): pattern cleanup + export types [#8875](https://github.com/fabricjs/fabric.js/pull/8875)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Object): dirty flagging cleanup inconsistency [#8910](https://github.com/fabricjs/fabric.js/pull/8910)
 - chore(TS): minor type/import fixes [#8904](https://github.com/fabricjs/fabric.js/pull/8904)
 - chore(): Matrix util cleanup [#8894](https://github.com/fabricjs/fabric.js/pull/8894)
 - chore(TS): pattern cleanup + export types [#8875](https://github.com/fabricjs/fabric.js/pull/8875)

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -749,8 +749,8 @@ export class FabricObject<
       (this as TCachedFabricObject).drawCacheOnCanvas(ctx);
     } else {
       this._removeCacheCanvas();
-      this.dirty = false;
       this.drawObject(ctx);
+      this.dirty = false;
     }
     ctx.restore();
   }


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

Work issue

## Description

Object should unflag dirty after `drawObject`, see ref:
https://github.com/fabricjs/fabric.js/blob/d7bb027058fc0ce30dbc2b610336a7bcc4756e7a/src/shapes/Object/Object.ts#L768-L769

<!-- What you are proposing -->

## Changes

Consistently mark object as not dirty **after** calling `drawObject`

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
