### PR TITLE
chore(TS) remove enums for string unions when enum is not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(TS): change enums with types [#8918](https://github.com/fabricjs/fabric.js/pull/8918)
 - chore(TS): export gradient types
 - chore(lint) export filter colors and brushes types [#8913](https://github.com/fabricjs/fabric.js/pull/8913)
 - chore(lint) Add a rule for import type [#8907](https://github.com/fabricjs/fabric.js/pull/8907)

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -22,7 +22,6 @@ import type {
   TToCanvasElementOptions,
   TValidToObjectMethod,
 } from '../typedefs';
-import { ImageFormat } from '../typedefs';
 import {
   cancelAnimFrame,
   requestAnimFrame,
@@ -1577,7 +1576,7 @@ export class StaticCanvas<
    */
   toDataURL(options = {} as TDataUrlOptions): string {
     const {
-      format = ImageFormat.png,
+      format = 'png',
       quality = 1,
       multiplier = 1,
       enableRetinaScaling = false,

--- a/src/filters/BaseFilter.ts
+++ b/src/filters/BaseFilter.ts
@@ -8,7 +8,6 @@ import type {
   TWebGLUniformLocationMap,
 } from './typedefs';
 import { isWebGLPipelineState } from './utils';
-import { GLPrecision } from './GLProbes/GLProbe';
 import {
   highPsourceCode,
   identityFragmentShader,
@@ -71,10 +70,10 @@ export class BaseFilter {
     vertexSource: string = this.vertexSource
   ) {
     const { WebGLProbe } = getEnv();
-    if (WebGLProbe.GLPrecision && WebGLProbe.GLPrecision !== GLPrecision.high) {
+    if (WebGLProbe.GLPrecision && WebGLProbe.GLPrecision !== 'highp') {
       fragmentSource = fragmentSource.replace(
         new RegExp(highPsourceCode, 'g'),
-        highPsourceCode.replace(GLPrecision.high, WebGLProbe.GLPrecision)
+        highPsourceCode.replace('highp', WebGLProbe.GLPrecision)
       );
     }
     const vertexShader = gl.createShader(gl.VERTEX_SHADER);

--- a/src/filters/BaseFilter.ts
+++ b/src/filters/BaseFilter.ts
@@ -69,11 +69,13 @@ export class BaseFilter {
     fragmentSource: string = this.getFragmentSource(),
     vertexSource: string = this.vertexSource
   ) {
-    const { WebGLProbe } = getEnv();
-    if (WebGLProbe.GLPrecision && WebGLProbe.GLPrecision !== 'highp') {
+    const {
+      WebGLProbe: { GLPrecision = 'highp' },
+    } = getEnv();
+    if (GLPrecision !== 'highp') {
       fragmentSource = fragmentSource.replace(
         new RegExp(highPsourceCode, 'g'),
-        highPsourceCode.replace('highp', WebGLProbe.GLPrecision)
+        highPsourceCode.replace('highp', GLPrecision)
       );
     }
     const vertexShader = gl.createShader(gl.VERTEX_SHADER);

--- a/src/filters/GLProbes/GLProbe.ts
+++ b/src/filters/GLProbes/GLProbe.ts
@@ -1,8 +1,4 @@
-export enum GLPrecision {
-  low = 'lowp',
-  medium = 'mediump',
-  high = 'highp',
-}
+export type GLPrecision = 'lowp' | 'mediump' | 'highp';
 
 export abstract class GLProbe {
   declare GLPrecision: GLPrecision | undefined;

--- a/src/filters/GLProbes/WebGLProbe.ts
+++ b/src/filters/GLProbes/WebGLProbe.ts
@@ -1,4 +1,5 @@
-import { GLPrecision, GLProbe } from './GLProbe';
+import { GLProbe } from './GLProbe';
+import type { GLPrecision } from './GLProbe';
 
 /**
  * Lazy initialize WebGL constants
@@ -33,8 +34,8 @@ export class WebGLProbe extends GLProbe {
     const gl = canvas.getContext('webgl');
     if (gl) {
       this.maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-      this.GLPrecision = Object.values(GLPrecision).find((precision) =>
-        this.testPrecision(gl, precision)
+      this.GLPrecision = (['highp', 'mediump', 'lowp'] as const).find(
+        (precision) => this.testPrecision(gl, precision)
       );
       console.log(`fabric: max texture size ${this.maxTextureSize}`);
     }

--- a/src/filters/shaders/baseFilter.ts
+++ b/src/filters/shaders/baseFilter.ts
@@ -1,6 +1,4 @@
-import { GLPrecision } from '../GLProbes/GLProbe';
-
-export const highPsourceCode = `precision ${GLPrecision.high} float`;
+export const highPsourceCode = `precision highp float`;
 
 export const identityFragmentShader = `
     ${highPsourceCode};

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -43,26 +43,11 @@ export type TBBox = {
 
 export type Percent = `${number}%`;
 
-export const enum ImageFormat {
-  jpeg = 'jpeg',
-  jpg = 'jpeg',
-  png = 'png',
-}
+export type ImageFormat = 'jpeg' | 'png';
 
-export const enum SVGElementName {
-  linearGradient = 'linearGradient',
-  radialGradient = 'radialGradient',
-  stop = 'stop',
-}
+export type SVGElementName = 'linearGradient' | 'radialGradient' | 'stop';
 
-export const enum SupportedSVGUnit {
-  mm = 'mm',
-  cm = 'cm',
-  in = 'in',
-  pt = 'pt',
-  pc = 'pc',
-  em = 'em',
-}
+export type SupportedSVGUnit = 'mm' | 'cm' | 'in' | 'pt' | 'pc' | 'em';
 
 /**
  * A transform matrix.

--- a/src/util/misc/planeChange.ts
+++ b/src/util/misc/planeChange.ts
@@ -6,10 +6,7 @@ import type { StaticCanvas } from '../../canvas/StaticCanvas';
 import { invertTransform, multiplyTransformMatrices } from './matrix';
 import { applyTransformToObject } from './objectTransforms';
 
-export const enum ObjectRelation {
-  sibling = 'sibling',
-  child = 'child',
-}
+export type ObjectRelation = 'sibling' | 'child';
 
 /**
  * We are actually looking for the transformation from the destination plane to the source plane (change of basis matrix)\
@@ -73,16 +70,10 @@ export const transformPointRelativeToCanvas = (
   relationAfter: ObjectRelation
 ): Point => {
   // is this still needed with TS?
-  if (
-    relationBefore !== ObjectRelation.child &&
-    relationBefore !== ObjectRelation.sibling
-  ) {
+  if (relationBefore !== 'child' && relationBefore !== 'sibling') {
     throw new Error(`fabric.js: received bad argument ${relationBefore}`);
   }
-  if (
-    relationAfter !== ObjectRelation.child &&
-    relationAfter !== ObjectRelation.sibling
-  ) {
+  if (relationAfter !== 'child' && relationAfter !== 'sibling') {
     throw new Error(`fabric.js: received bad argument ${relationAfter}`);
   }
   if (relationBefore === relationAfter) {

--- a/src/util/misc/svgParsing.ts
+++ b/src/util/misc/svgParsing.ts
@@ -1,9 +1,14 @@
 import { Color } from '../../color/Color';
 import { config } from '../../config';
 import { DEFAULT_SVG_FONT_SIZE } from '../../constants';
-import type { TBBox, TMat2D } from '../../typedefs';
-import { SupportedSVGUnit, SVGElementName } from '../../typedefs';
+import type {
+  TBBox,
+  TMat2D,
+  SVGElementName,
+  SupportedSVGUnit,
+} from '../../typedefs';
 import { toFixed } from './toFixed';
+
 /**
  * Returns array of attributes for given svg that fabric parses
  * @param {SVGElementName} type Type of svg element (eg. 'circle')
@@ -12,7 +17,7 @@ import { toFixed } from './toFixed';
 export const getSvgAttributes = (type: SVGElementName) => {
   const commonAttributes = ['instantiated_by_use', 'style', 'id', 'class'];
   switch (type) {
-    case SVGElementName.linearGradient:
+    case 'linearGradient':
       return commonAttributes.concat([
         'x1',
         'y1',
@@ -52,23 +57,23 @@ export const parseUnit = (value: string, fontSize: number) => {
     fontSize = DEFAULT_SVG_FONT_SIZE;
   }
   const dpi = config.DPI;
-  switch (unit?.[0]) {
-    case SupportedSVGUnit.mm:
+  switch (unit?.[0] as SupportedSVGUnit) {
+    case 'mm':
       return (number * dpi) / 25.4;
 
-    case SupportedSVGUnit.cm:
+    case 'cm':
       return (number * dpi) / 2.54;
 
-    case SupportedSVGUnit.in:
+    case 'in':
       return number * dpi;
 
-    case SupportedSVGUnit.pt:
+    case 'pt':
       return (number * dpi) / 72; // or * 4 / 3
 
-    case SupportedSVGUnit.pc:
+    case 'pc':
       return ((number * dpi) / 72) * 12; // or * 16
 
-    case SupportedSVGUnit.em:
+    case 'em':
       return number * fontSize;
 
     default:
@@ -76,17 +81,9 @@ export const parseUnit = (value: string, fontSize: number) => {
   }
 };
 
-export const enum MeetOrSlice {
-  meet = 'meet',
-  slice = 'slice',
-}
+export type MeetOrSlice = 'meet' | 'slice';
 
-export const enum MinMidMax {
-  min = 'Min',
-  mid = 'Mid',
-  max = 'Max',
-  none = 'none',
-}
+export type MinMidMax = 'Min' | 'Mid' | 'Max' | 'none';
 
 export type TPreserveArParsed = {
   meetOrSlice: MeetOrSlice;
@@ -97,12 +94,12 @@ export type TPreserveArParsed = {
 // align can be either none or undefined or a combination of mid/max
 const parseAlign = (align: string): MinMidMax[] => {
   //divide align in alignX and alignY
-  if (align && align !== MinMidMax.none) {
+  if (align && align !== 'none') {
     return [align.slice(1, 4) as MinMidMax, align.slice(5, 8) as MinMidMax];
-  } else if (align === MinMidMax.none) {
+  } else if (align === 'none') {
     return [align, align];
   }
-  return [MinMidMax.mid, MinMidMax.mid];
+  return ['Mid', 'Mid'];
 };
 
 /**
@@ -120,7 +117,7 @@ export const parsePreserveAspectRatioAttribute = (
   ];
   const [alignX, alignY] = parseAlign(firstPart);
   return {
-    meetOrSlice: secondPart || MeetOrSlice.meet,
+    meetOrSlice: secondPart || 'meet',
     alignX,
     alignY,
   };


### PR DESCRIPTION
## Motivation

As per discussion, our use of enums isn't justified.
https://github.com/fabricjs/fabric.js/pull/8915#issuecomment-1546829630

Enums aren't supposed to be named dictionary of strings, we have union types for that.

There was also a possible bug in the glPrecision code in which we were transforming an object into an array, without knowing in which order we were loopin through precisions test

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->
