### PR TITLE
Force lose context of the WebGL context that is created within fabric…

### DIFF
--- a/dist/fabric.js
+++ b/dist/fabric.js
@@ -20908,6 +20908,7 @@ fabric.util.object.extend(fabric.StaticCanvas.prototype, /** @lends fabric.Stati
           break;
         };
       }
+      gl.getExtension("WEBGL_lose_context").loseContext();
     }
     this.isSupported = isSupported;
     return isSupported;


### PR DESCRIPTION
update fabric.isWebglSupported() to clear the webgl context that it creates so that it doesn't count toward the total number of webgl contexts in the browser.

## Motivation

Browsers can only have a limited number of webgl contexts, and the context that this helper function creates is not cleared or deleted, so it counts toward the total number of active webgl contexts.

## Description

Force the context that's created to lose context before returning whether or not webgl is enabled.

## Changes

https://github.com/fabricjs/fabric.js/commit/224299091520b131e1c63d633cf988cb699222db



