### PR TITLE
fix(): `typeAssertions` not respecting subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): `typeAssertions` not respecting subclasses [#8931](https://github.com/fabricjs/fabric.js/pull/8931)
 - fix(TS): extending canvas and object event types (`type` => `interface`) [#8926](https://github.com/fabricjs/fabric.js/pull/8926)
 - chore(build) simple deps update [#8929](https://github.com/fabricjs/fabric.js/pull/8929)
 - fix(Canvas): sync cleanup of dom elements in dispose [#8903](https://github.com/fabricjs/fabric.js/pull/8903)

--- a/src/gradient/Gradient.ts
+++ b/src/gradient/Gradient.ts
@@ -203,7 +203,7 @@ export class Gradient<
     }
     if (
       object instanceof BaseFabricObject &&
-      object.isType('Path') &&
+      object.is('path') &&
       this.gradientUnits !== 'percentage'
     ) {
       offsetX -= object.pathOffset.x;

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -4,6 +4,10 @@ import { Group } from './Group';
 import type { FabricObject } from './Object/FabricObject';
 
 export class ActiveSelection extends Group {
+  static TAGS = {
+    selection: true,
+  };
+
   declare _objects: FabricObject[];
 
   /**

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -103,6 +103,11 @@ export class IText<
   extends ITextClickBehavior<Props, SProps, EventSpec>
   implements UniqueITextProps
 {
+  static TAGS = {
+    text: true,
+    interactive: true,
+  };
+
   /**
    * Index where text selection starts (or where cursor is when there is no selection)
    * @type Number

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -98,6 +98,18 @@ export class FabricObject<
   extends AnimatableObject<EventSpec>
   implements ObjectProps
 {
+  static TAGS: Record<string, boolean> = {};
+
+  /**
+   * A workaroud instead of using `type` that is deprecated or `instanceof` that cause import cycles
+   * @param tags
+   * @returns
+   */
+  is(...tags: string[]) {
+    const { TAGS } = this.constructor as typeof FabricObject;
+    return tags.every((tag) => TAGS[tag]);
+  }
+
   declare minScaleLimit: number;
 
   declare opacity: number;
@@ -1443,6 +1455,7 @@ export class FabricObject<
 
   /**
    * Returns true if any of the specified types is identical to the type of an instance
+   * @deprecated use `instanceof` or `is`
    * @param {String} type Type to check against
    * @return {Boolean}
    */

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -49,6 +49,10 @@ export class Path<
   SProps extends SerializedPathProps = SerializedPathProps,
   EventSpec extends ObjectEvents = ObjectEvents
 > extends FabricObject<Props, SProps, EventSpec> {
+  static TAGS = {
+    path: true,
+  };
+
   /**
    * Array of path points
    * @type Array

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -109,6 +109,10 @@ export class Text<
   extends StyledText<Props, SProps, EventSpec>
   implements UniqueTextProps
 {
+  static TAGS = {
+    text: true,
+  };
+
   /**
    * Properties that requires a text layout recalculation when changed
    * @type string[]

--- a/src/util/typeAssertions.ts
+++ b/src/util/typeAssertions.ts
@@ -40,7 +40,7 @@ export const isCollection = (
 export const isActiveSelection = (
   fabricObject?: FabricObject
 ): fabricObject is ActiveSelection => {
-  return !!fabricObject && fabricObject.isType('ActiveSelection');
+  return !!fabricObject && fabricObject.is('selection');
 };
 
 export const isTextObject = (
@@ -48,7 +48,7 @@ export const isTextObject = (
 ): fabricObject is Text => {
   // we could use instanceof but that would mean pulling in Text code for a simple check
   // @todo discuss what to do and how to do
-  return !!fabricObject && fabricObject.isType('Text', 'IText', 'Textbox');
+  return !!fabricObject && fabricObject.is('text');
 };
 
 export const isInteractiveTextObject = (
@@ -56,7 +56,7 @@ export const isInteractiveTextObject = (
 ): fabricObject is IText | Textbox => {
   // we could use instanceof but that would mean pulling in Text code for a simple check
   // @todo discuss what to do and how to do
-  return !!fabricObject && fabricObject.isType('IText', 'Textbox');
+  return !!fabricObject && fabricObject.is('text', 'interactive');
 };
 
 export const isFabricObjectCached = (

--- a/test/unit/activeselection.js
+++ b/test/unit/activeselection.js
@@ -38,6 +38,7 @@
 
     assert.ok(group);
     assert.ok(group instanceof fabric.ActiveSelection, 'should be instance of fabric.ActiveSelection');
+    assert.ok(group.is('selection'), 'TAG');
   });
 
   QUnit.test('toString', function(assert) {

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -66,6 +66,7 @@
 
       assert.ok(iText instanceof fabric.IText);
       assert.ok(iText instanceof fabric.Text);
+      assert.ok(iText.is('text', 'interactive'), 'TAG');
     });
 
     QUnit.test('initial properties', function(assert) {

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -79,7 +79,8 @@
     makePathObject(function(path) {
       assert.ok(path instanceof fabric.Path);
       assert.ok(path instanceof fabric.Object);
-
+      
+      assert.ok(path.is('path'), 'TAG');
       assert.equal(path.constructor.name, 'Path');
 
       var error;

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -75,6 +75,7 @@
     assert.ok(text instanceof fabric.Text);
     assert.ok(text instanceof fabric.Object);
 
+    assert.ok(text.is('text'), 'TAG');
     assert.equal(text.constructor.name, 'Text');
     assert.equal(text.get('text'), 'x');
   });

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -81,6 +81,7 @@
     assert.ok(textbox instanceof fabric.Textbox);
     assert.ok(textbox instanceof fabric.IText);
     assert.ok(textbox instanceof fabric.Text);
+    assert.ok(textbox.is('text', 'interactive'), 'TAG');
   });
 
   QUnit.test('constructor with width', function(assert) {


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

Was working on a subclass of IText when selection rendering started having bugs, being cleared because passing this condition (should pass ` isInteractiveTextObject` and `isEditing`):
https://github.com/fabricjs/fabric.js/blob/0f0ed963b959969e1968563b176e9e67a3d0feb5/src/canvas/Canvas.ts#L890-L896

https://github.com/fabricjs/fabric.js/blob/0f0ed963b959969e1968563b176e9e67a3d0feb5/src/util/typeAssertions.ts#L54-L60

Of course it will because types are deprecated and the name of the class doesn't match.

Indeed this line is more types than logic but the rest aren't

## Description

<!-- What you are proposing -->

Came up with a solution in the form of static TAGS and an `is` method that is extremely similar to `isType`

## Changes

<!-- before the fix vs. after -->

## Gist

There is no decent way for me to test this
<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
