### PR TITLE
patch(): `Control#shouldActivate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- patch(): expose `Control#shouldActivate` [#8934](https://github.com/fabricjs/fabric.js/pull/8934)
 - feat(Color) Improve regex for new standards, more documentation and code cleanup [#8916](https://github.com/fabricjs/fabric.js/pull/8916)
 - fix(TS): extending canvas and object event types (`type` => `interface`) [#8926](https://github.com/fabricjs/fabric.js/pull/8926)
 - chore(build) simple deps update [#8929](https://github.com/fabricjs/fabric.js/pull/8929)

--- a/src/controls/Control.ts
+++ b/src/controls/Control.ts
@@ -169,6 +169,14 @@ export class Control {
    */
   declare mouseUpHandler?: ControlActionHandler;
 
+  shouldActivate(controlKey: string, fabricObject: InteractiveFabricObject) {
+    // TODO: locking logic can be handled here instead of in the control handler logic
+    return (
+      fabricObject.canvas?.getActiveObject() === fabricObject &&
+      fabricObject.isControlVisible(controlKey)
+    );
+  }
+
   /**
    * Returns control actionHandler
    * @param {Event} eventData the native mouse event

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -184,31 +184,27 @@ export class InteractiveFabricObject<
    * @param {boolean} forTouch indicates if we are looking for interaction area with a touch action
    * @return {String|Boolean} corner code (tl, tr, bl, br, etc.), or 0 if nothing is found.
    */
-  _findTargetCorner(pointer: Point, forTouch = false): 0 | string {
-    if (
-      !this.hasControls ||
-      !this.canvas ||
-      (this.canvas._activeObject as unknown as this) !== this
-    ) {
-      return 0;
+  _findTargetCorner(pointer: Point, forTouch = false): string {
+    if (!this.hasControls || !this.canvas) {
+      return '';
     }
 
     this.__corner = undefined;
     // had to keep the reverse loop because was breaking tests
     const cornerEntries = Object.entries(this.oCoords);
     for (let i = cornerEntries.length - 1; i >= 0; i--) {
-      const [cornerKey, corner] = cornerEntries[i];
-      if (!this.isControlVisible(cornerKey)) {
-        continue;
+      const [key, corner] = cornerEntries[i];
+      if (this.controls[key].shouldActivate(key, this)) {
+        const lines = this._getImageLines(
+          forTouch ? corner.touchCorner : corner.corner
+        );
+        const xPoints = this._findCrossPoints(pointer, lines);
+        if (xPoints !== 0 && xPoints % 2 === 1) {
+          this.__corner = key;
+          return key;
+        }
       }
-      const lines = this._getImageLines(
-        forTouch ? corner.touchCorner : corner.corner
-      );
-      const xPoints = this._findCrossPoints(pointer, lines);
-      if (xPoints !== 0 && xPoints % 2 === 1) {
-        this.__corner = cornerKey;
-        return cornerKey;
-      }
+
       // // debugging
       //
       // this.canvas.contextTop.fillRect(lines.bottomline.d.x, lines.bottomline.d.y, 2, 2);
@@ -223,7 +219,7 @@ export class InteractiveFabricObject<
       // this.canvas.contextTop.fillRect(lines.rightline.d.x, lines.rightline.d.y, 2, 2);
       // this.canvas.contextTop.fillRect(lines.rightline.o.x, lines.rightline.o.y, 2, 2);
     }
-    return 0;
+    return '';
   }
 
   /**

--- a/test/unit/object_interactivity.js
+++ b/test/unit/object_interactivity.js
@@ -205,7 +205,7 @@
     assert.ok(typeof cObj._findTargetCorner === 'function', '_findTargetCorner should exist');
     cObj.setCoords();
     cObj.canvas = {
-      _activeObject: cObj
+      getActiveObject() { return cObj }
     };
     assert.equal(cObj._findTargetCorner(cObj.oCoords.br), 'br');
     assert.equal(cObj._findTargetCorner(cObj.oCoords.tl), 'tl');
@@ -223,7 +223,7 @@
     var cObj = new fabric.Object({ top: 10, left: 10, width: 30, height: 30, strokeWidth: 0 });
     cObj.setCoords();
     cObj.canvas = {
-      _activeObject: cObj
+      getActiveObject() { return cObj }
     };
     var pointNearBr = {
       x: cObj.oCoords.br.x + cObj.cornerSize / 3,
@@ -237,6 +237,28 @@
     };
     assert.equal(cObj._findTargetCorner(pointNearBr, true), 'br', 'touch event touchCornerSize/3 near br returns br');
     assert.equal(cObj._findTargetCorner(pointNearBr, false), false, 'not touch event touchCornerSize/3 near br returns false');
+  });
+
+
+  QUnit.test('_findTargetCorner for non active object', function (assert) {
+    var cObj = new fabric.Object({ top: 10, left: 10, width: 30, height: 30, strokeWidth: 0 });
+    assert.ok(typeof cObj._findTargetCorner === 'function', '_findTargetCorner should exist');
+    cObj.setCoords();
+    cObj.canvas = {
+      getActiveObject() { return }
+    };
+    assert.equal(cObj._findTargetCorner(cObj.oCoords.mtr), '', 'object is not active');
+  });
+
+  QUnit.test('_findTargetCorner for non visible control', function (assert) {
+    var cObj = new fabric.Object({ top: 10, left: 10, width: 30, height: 30, strokeWidth: 0 });
+    assert.ok(typeof cObj._findTargetCorner === 'function', '_findTargetCorner should exist');
+    cObj.setCoords();
+    cObj.canvas = {
+      getActiveObject() { return cObj }
+    };
+    cObj.isControlVisible = () => false;
+    assert.equal(cObj._findTargetCorner(cObj.oCoords.mtr), '', 'object is not active');
   });
 
   QUnit.test('_calculateCurrentDimensions', function(assert) {


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

I need the control api to be more flexible

## Description

Introduce the ability for a control to decide if it should be activated or not.
Before this was handled by the canvas in an hardcoded way with:

```js
      !this.hasControls ||
      !this.canvas ||
      (this.canvas._activeObject as unknown as this) !== this
```

as an early return and later on on the control check if the control is visible.


Now the first early return doesn't take care of the object being selected, but the control later has a new method `shouldActivate` that by default return true only if the object is the active one and if the control is visible.

The developer can override this in a custom control and apply the logic that prefers.

## Changes

- `Control#shouldActivate` - for overriding
- now the control loop and the visibility check run regardless if the object is active or not.

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
