### PR TITLE
chore(): move canvas click handler to TextManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [next]
+
+- chore(): move canvas click handler to TextManager [#8939](https://github.com/fabricjs/fabric.js/pull/8939)
+
 ## [6.0.0-beta6]
 
 - patch(): expose `Control#shouldActivate` [#8934](https://github.com/fabricjs/fabric.js/pull/8934)

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -116,7 +116,7 @@ export class Canvas extends SelectableCanvas {
 
   private _isClick: boolean;
 
-  textEditingManager = new TextEditingManager();
+  textEditingManager = new TextEditingManager(this);
 
   constructor(el: string | HTMLCanvasElement, options = {}) {
     super(el, options);

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -1593,7 +1593,7 @@ export class Canvas extends SelectableCanvas {
    * @override clear {@link textEditingManager}
    */
   clear() {
-    this.textEditingManager.dispose();
+    this.textEditingManager.clear();
     super.clear();
   }
 
@@ -1602,7 +1602,7 @@ export class Canvas extends SelectableCanvas {
    */
   destroy() {
     this.removeListeners();
-    super.destroy();
     this.textEditingManager.dispose();
+    super.destroy();
   }
 }

--- a/src/canvas/TextEditingManager.ts
+++ b/src/canvas/TextEditingManager.ts
@@ -50,9 +50,13 @@ export class TextEditingManager {
     this.target?.isEditing && this.target.updateSelectionOnMouseMove(e);
   }
 
-  dispose() {
+  clear() {
     this.targets = [];
     this.target = undefined;
+  }
+
+  dispose() {
+    this.clear();
     this.__disposer();
     // @ts-expect-error disposing
     delete this.__disposer;

--- a/src/canvas/TextEditingManager.ts
+++ b/src/canvas/TextEditingManager.ts
@@ -1,6 +1,7 @@
 import type { TPointerEvent } from '../EventTypeDefs';
 import type { ITextBehavior } from '../shapes/IText/ITextBehavior';
 import { removeFromArray } from '../util/internals';
+import type { Canvas } from './Canvas';
 
 /**
  * In charge of synchronizing all interactive text instances of a canvas
@@ -8,6 +9,14 @@ import { removeFromArray } from '../util/internals';
 export class TextEditingManager {
   private targets: ITextBehavior[] = [];
   private declare target?: ITextBehavior;
+  private __disposer: VoidFunction;
+
+  constructor(canvas: Canvas) {
+    const cb = () => this.target?.hiddenTextarea?.focus();
+    canvas.upperCanvasEl.addEventListener('click', cb);
+    this.__disposer = () =>
+      canvas.upperCanvasEl.removeEventListener('click', cb);
+  }
 
   exitTextEditing() {
     this.target = undefined;
@@ -44,5 +53,8 @@ export class TextEditingManager {
   dispose() {
     this.targets = [];
     this.target = undefined;
+    this.__disposer();
+    // @ts-expect-error disposing
+    delete this.__disposer;
   }
 }

--- a/src/canvas/TextEditingManager.ts
+++ b/src/canvas/TextEditingManager.ts
@@ -13,9 +13,9 @@ export class TextEditingManager {
 
   constructor(canvas: Canvas) {
     const cb = () => this.target?.hiddenTextarea?.focus();
-    canvas.upperCanvasEl.addEventListener('click', cb);
-    this.__disposer = () =>
-      canvas.upperCanvasEl.removeEventListener('click', cb);
+    const el = canvas.upperCanvasEl;
+    el.addEventListener('click', cb);
+    this.__disposer = () => el.removeEventListener('click', cb);
   }
 
   exitTextEditing() {

--- a/src/shapes/IText/ITextKeyBehavior.ts
+++ b/src/shapes/IText/ITextKeyBehavior.ts
@@ -101,18 +101,6 @@ export abstract class ITextKeyBehavior<
       'compositionend',
       this.onCompositionEnd.bind(this)
     );
-
-    if (!this._clickHandlerInitialized && this.canvas) {
-      this.canvas.upperCanvasEl.addEventListener(
-        'click',
-        this.onClick.bind(this)
-      );
-      this._clickHandlerInitialized = true;
-    }
-  }
-
-  onClick() {
-    this.hiddenTextarea && this.hiddenTextarea.focus();
   }
 
   /**

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -1182,7 +1182,7 @@
     assert.ok(manager.target === a, 'should register a');
     canvas.remove(a);
     assert.ok(!manager.target, 'should unregister a');
-    manager.dispose();
+    manager.clear();
     assert.ok(!manager.target, 'should have disposed ref');
     assert.deepEqual(manager.targets, [], 'should have disposed refs');
     const g = new fabric.Group([a]);


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

I missed the click handler that IText attaches to canvas when I wrote the TextEditingManager

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

Move this click handler to the manager, where it belongs

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
