### PR TITLE
refactor(): create Filler base class for Pattern/Gradient

### DIFF
--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -3,11 +3,11 @@ name: 'Update 📋'
 on:
   pull_request:
     branches: [master]
-    types: [opened, edited]
+    types: [edited]
 
 jobs:
   changelog:
-    if: github.event.action == 'opened' || github.event.changes.title.from != github.event.pull_request.title
+    if: github.event.changes.title.from != github.event.pull_request.title
     uses: ./.github/workflows/changelog.yml
     with:
       update: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## [next]
 
-- refactor(): create Filler base class for Pattern/Gradient [#8945](https://github.com/fabricjs/fabric.js/pull/8945)
-- refactor(): create Filler base class for Pattern/Gradient [#8945](https://github.com/fabricjs/fabric.js/pull/8945)
 - ci(): automate PR changelog [#8938](https://github.com/fabricjs/fabric.js/pull/8938)
 - chore(): move canvas click handler to TextManager [#8939](https://github.com/fabricjs/fabric.js/pull/8939)
 

--- a/src/Pattern/Pattern.ts
+++ b/src/Pattern/Pattern.ts
@@ -3,7 +3,6 @@ import type { Abortable, TCrossOrigin, TMat2D, TSize } from '../typedefs';
 import { ifNaN } from '../util/internals';
 import { uid } from '../util/internals/uid';
 import { loadImage } from '../util/misc/objectEnlive';
-import { pick } from '../util/misc/pick';
 import { toFixed } from '../util/misc/toFixed';
 import { classRegistry } from '../ClassRegistry';
 import type {
@@ -11,12 +10,13 @@ import type {
   PatternOptions,
   SerializedPatternOptions,
 } from './types';
+import { Filler } from '../fillers/Filler';
 
 /**
  * @see {@link http://fabricjs.com/patterns demo}
  * @see {@link http://fabricjs.com/dynamic-patterns demo}
  */
-export class Pattern {
+export class Pattern extends Filler<CanvasPattern> {
   /**
    * Legacy identifier of the class. Prefer using this.constructor.name 'Pattern'
    * or utils like isPattern
@@ -38,20 +38,6 @@ export class Pattern {
    * @defaults
    */
   repeat: PatternRepeat = 'repeat';
-
-  /**
-   * Pattern horizontal offset from object's left/top corner
-   * @type Number
-   * @default
-   */
-  offsetX = 0;
-
-  /**
-   * Pattern vertical offset from object's left/top corner
-   * @type Number
-   * @default
-   */
-  offsetY = 0;
 
   /**
    * @type TCrossOrigin
@@ -144,10 +130,10 @@ export class Pattern {
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {object} Object representation of a pattern instance
    */
-  toObject(propertiesToInclude: string[] = []): Record<string, any> {
+  toObject<T extends keyof this>(propertiesToInclude?: T[]) {
     const { repeat, crossOrigin } = this;
     return {
-      ...pick(this, propertiesToInclude as (keyof this)[]),
+      ...super.toObject(propertiesToInclude),
       type: 'pattern',
       source: this.sourceToString(),
       repeat,

--- a/src/Pattern/Pattern.ts
+++ b/src/Pattern/Pattern.ts
@@ -18,8 +18,7 @@ import { Filler } from '../fillers/Filler';
  */
 export class Pattern extends Filler<CanvasPattern> {
   /**
-   * Legacy identifier of the class. Prefer using this.constructor.name 'Pattern'
-   * or utils like isPattern
+   * Legacy identifier of the class. Prefer using this.constructor.name or `instanceof`
    * Will be removed in fabric 7 or 8.
    * @TODO add sustainable warning message
    * @type string
@@ -76,6 +75,7 @@ export class Pattern extends Filler<CanvasPattern> {
    * @param {option.source} [source] the pattern source, eventually empty or a drawable
    */
   constructor(options: PatternOptions = {}) {
+    super();
     this.id = uid();
     Object.assign(this, options);
   }

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -15,13 +15,13 @@ import type {
   Constructor,
   TCornerPoint,
   TDataUrlOptions,
-  TFiller,
   TMat2D,
   TSize,
   TSVGReviver,
   TToCanvasElementOptions,
   TValidToObjectMethod,
 } from '../typedefs';
+import type { TFiller } from '../fillers/typedefs';
 import {
   cancelAnimFrame,
   requestAnimFrame,
@@ -38,7 +38,8 @@ import {
 import { pick } from '../util/misc/pick';
 import { matrixToSVG } from '../util/misc/svgParsing';
 import { toFixed } from '../util/misc/toFixed';
-import { isCollection, isFiller, isTextObject } from '../util/typeAssertions';
+import { isCollection, isTextObject } from '../util/typeAssertions';
+import { isFiller } from '../fillers/Filler';
 
 export type TCanvasSizeOptions = {
   backstoreOnly?: boolean;

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -5,7 +5,7 @@ import type { CanvasEvents, StaticCanvasEvents } from '../EventTypeDefs';
 import type { Gradient } from '../gradient/Gradient';
 import { createCollectionMixin } from '../Collection';
 import { CommonMethods } from '../CommonMethods';
-import type { Pattern } from '../Pattern';
+import { Pattern } from '../Pattern';
 import { Point } from '../Point';
 import type { BaseFabricObject as FabricObject } from '../EventTypeDefs';
 import type { TCachedFabricObject } from '../shapes/Object/Object';
@@ -38,12 +38,7 @@ import {
 import { pick } from '../util/misc/pick';
 import { matrixToSVG } from '../util/misc/svgParsing';
 import { toFixed } from '../util/misc/toFixed';
-import {
-  isCollection,
-  isFiller,
-  isPattern,
-  isTextObject,
-} from '../util/typeAssertions';
+import { isCollection, isFiller, isTextObject } from '../util/typeAssertions';
 
 export type TCanvasSizeOptions = {
   backstoreOnly?: boolean;
@@ -1405,20 +1400,27 @@ export class StaticCanvas<
         additionalTransform = shouldInvert
           ? matrixToSVG(invertTransform(this.viewportTransform))
           : '';
+      const { width = finalWidth, height = finalHeight } =
+        filler instanceof Pattern
+          ? {
+              width:
+                repeat === 'repeat-y' || repeat === 'no-repeat'
+                  ? filler.source.width
+                  : undefined,
+              height:
+                repeat === 'repeat-x' || repeat === 'no-repeat'
+                  ? filler.source.height
+                  : undefined,
+            }
+          : {};
       markup.push(
         `<rect transform="${additionalTransform} translate(${finalWidth / 2},${
           finalHeight / 2
         })" x="${filler.offsetX - finalWidth / 2}" y="${
           filler.offsetY - finalHeight / 2
-        }" width="${
-          (repeat === 'repeat-y' || repeat === 'no-repeat') && isPattern(filler)
-            ? filler.source.width
-            : finalWidth
-        }" height="${
-          (repeat === 'repeat-x' || repeat === 'no-repeat') && isPattern(filler)
-            ? filler.source.height
-            : finalHeight
-        }" fill="url(#SVGID_${filler.id})"></rect>\n`
+        }" width="${width}" height="${height}" fill="url(#SVGID_${
+          filler.id
+        })"></rect>\n`
       );
     } else {
       markup.push(

--- a/src/fillers/Filler.ts
+++ b/src/fillers/Filler.ts
@@ -1,6 +1,6 @@
 import { config } from '../config';
-import { Point } from '../Point';
-import type { TMat2D, TSize } from '../typedefs';
+import type { Point } from '../Point';
+import type { TSize } from '../typedefs';
 import { pick } from '../util/misc/pick';
 import { toFixed } from '../util/misc/toFixed';
 
@@ -13,21 +13,7 @@ export type TFillerRenderingOptions = {
   noTransform?: boolean;
 };
 
-export type TCanvasFiller = CanvasPattern | CanvasGradient;
-
-export type TFillerExportedKeys = 'offsetX' | 'offsetY';
-
-export type TFillerOptions = {
-  action: TFillerAction;
-  filler: Filler<TCanvasFiller> | string;
-  size: TSize;
-};
-
-export type TCanvasFillerOptions = Omit<TFillerOptions, 'action'> & {
-  preTransform?: TMat2D;
-};
-
-export abstract class Filler<T extends TCanvasFiller> {
+export abstract class Filler<T extends CanvasPattern | CanvasGradient> {
   /**
    * horizontal offset from object's left/top corner
    * @type Number
@@ -64,52 +50,5 @@ export abstract class Filler<T extends TCanvasFiller> {
 
   toJSON() {
     return this.toObject();
-  }
-
-  static buildPath(ctx: CanvasRenderingContext2D, { width, height }: TSize) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.moveTo(0, 0);
-    ctx.lineTo(width, 0);
-    ctx.lineTo(width, height);
-    ctx.lineTo(0, height);
-    ctx.closePath();
-  }
-
-  static prepare(
-    ctx: CanvasRenderingContext2D,
-    { action, filler, size }: TFillerOptions
-  ) {
-    if (filler instanceof Filler) {
-      return filler.prepare(ctx, {
-        action,
-        size,
-        offset: new Point(size.width, size.height)
-          .scalarDivide(-2)
-          .add(new Point(filler.offsetX, filler.offsetY)),
-      });
-    } else if (filler) {
-      // is a color
-      ctx[`${action}Style`] = filler;
-    }
-  }
-
-  static prepareCanvasFill(
-    ctx: CanvasRenderingContext2D,
-    { filler, size, preTransform }: TCanvasFillerOptions
-  ) {
-    // mark area for fill
-    Filler.buildPath(ctx, size);
-    if (filler instanceof Filler) {
-      preTransform && ctx.transform(...preTransform);
-      return filler.prepare(ctx, {
-        action: 'fill',
-        size,
-        offset: new Point(filler.offsetX, filler.offsetY),
-      });
-    } else if (filler) {
-      // is a color
-      ctx.fillStyle = filler;
-    }
   }
 }

--- a/src/fillers/Filler.ts
+++ b/src/fillers/Filler.ts
@@ -1,0 +1,115 @@
+import { config } from '../config';
+import { Point } from '../Point';
+import type { TMat2D, TSize } from '../typedefs';
+import { pick } from '../util/misc/pick';
+import { toFixed } from '../util/misc/toFixed';
+
+export type TFillerAction = 'stroke' | 'fill';
+
+export type TFillerRenderingOptions = {
+  action: TFillerAction;
+  size: TSize;
+  offset: Point;
+  noTransform?: boolean;
+};
+
+export type TCanvasFiller = CanvasPattern | CanvasGradient;
+
+export type TFillerExportedKeys = 'offsetX' | 'offsetY';
+
+export type TFillerOptions = {
+  action: TFillerAction;
+  filler: Filler<TCanvasFiller> | string;
+  size: TSize;
+};
+
+export type TCanvasFillerOptions = Omit<TFillerOptions, 'action'> & {
+  preTransform?: TMat2D;
+};
+
+export abstract class Filler<T extends TCanvasFiller> {
+  /**
+   * horizontal offset from object's left/top corner
+   * @type Number
+   * @default
+   */
+  offsetX = 0;
+
+  /**
+   * vertical offset from object's left/top corner
+   * @type Number
+   * @default
+   */
+  offsetY = 0;
+
+  protected abstract toLive(
+    ctx: CanvasRenderingContext2D,
+    options: TFillerRenderingOptions
+  ): T | null;
+
+  protected prepare(
+    ctx: CanvasRenderingContext2D,
+    options: TFillerRenderingOptions
+  ): Point | void {
+    ctx[`${options.action}Style`] = this.toLive(ctx, options) || '';
+  }
+
+  toObject<T extends keyof this>(propertiesToInclude?: T[]) {
+    return {
+      ...pick(this, propertiesToInclude),
+      offsetX: toFixed(this.offsetX, config.NUM_FRACTION_DIGITS),
+      offsetY: toFixed(this.offsetY, config.NUM_FRACTION_DIGITS),
+    };
+  }
+
+  toJSON() {
+    return this.toObject();
+  }
+
+  static buildPath(ctx: CanvasRenderingContext2D, { width, height }: TSize) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(width, 0);
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height);
+    ctx.closePath();
+  }
+
+  static prepare(
+    ctx: CanvasRenderingContext2D,
+    { action, filler, size }: TFillerOptions
+  ) {
+    if (filler instanceof Filler) {
+      return filler.prepare(ctx, {
+        action,
+        size,
+        offset: new Point(size.width, size.height)
+          .scalarDivide(-2)
+          .add(new Point(filler.offsetX, filler.offsetY)),
+      });
+    } else if (filler) {
+      // is a color
+      ctx[`${action}Style`] = filler;
+    }
+  }
+
+  static prepareCanvasFill(
+    ctx: CanvasRenderingContext2D,
+    { filler, size, preTransform }: TCanvasFillerOptions
+  ) {
+    // mark area for fill
+    Filler.buildPath(ctx, size);
+    if (filler instanceof Filler) {
+      preTransform && ctx.transform(...preTransform);
+      return filler.prepare(ctx, {
+        action: 'fill',
+        size,
+        offset: new Point(filler.offsetX, filler.offsetY),
+      });
+    } else if (filler) {
+      // is a color
+      ctx.fillStyle = filler;
+    }
+  }
+}

--- a/src/fillers/Filler.ts
+++ b/src/fillers/Filler.ts
@@ -1,6 +1,7 @@
 import { config } from '../config';
 import type { Point } from '../Point';
 import type { TSize } from '../typedefs';
+import type { TFiller } from './typedefs';
 import { pick } from '../util/misc/pick';
 import { toFixed } from '../util/misc/toFixed';
 
@@ -11,6 +12,12 @@ export type TFillerRenderingOptions = {
   size: TSize;
   offset: Point;
   noTransform?: boolean;
+};
+
+export const isFiller = (
+  filler: TFiller | string | null
+): filler is TFiller => {
+  return !!filler && filler instanceof Filler;
 };
 
 export abstract class Filler<T extends CanvasPattern | CanvasGradient> {

--- a/src/fillers/typedefs.ts
+++ b/src/fillers/typedefs.ts
@@ -1,0 +1,4 @@
+import type { Gradient } from '../gradient/Gradient';
+import type { Pattern } from '../Pattern';
+
+export type TFiller = Gradient<'linear'> | Gradient<'radial'> | Pattern;

--- a/src/gradient/Gradient.ts
+++ b/src/gradient/Gradient.ts
@@ -6,7 +6,6 @@ import type { FabricObject } from '../shapes/Object/FabricObject';
 import { FabricObject as BaseFabricObject } from '../shapes/Object/Object';
 import type { TMat2D } from '../typedefs';
 import { uid } from '../util/internals/uid';
-import { pick } from '../util/misc/pick';
 import { matrixToSVG } from '../util/misc/svgParsing';
 import { linearDefaultCoords, radialDefaultCoords } from './constants';
 import {
@@ -24,6 +23,7 @@ import type {
   SVGOptions,
 } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
+import { Filler } from '../fillers/Filler';
 
 /**
  * Gradient class
@@ -33,21 +33,7 @@ import { classRegistry } from '../ClassRegistry';
 export class Gradient<
   S,
   T extends GradientType = S extends GradientType ? S : 'linear'
-> {
-  /**
-   * Horizontal offset for aligning gradients coming from SVG when outside pathgroups
-   * @type Number
-   * @default 0
-   */
-  declare offsetX: number;
-
-  /**
-   * Vertical offset for aligning gradients coming from SVG when outside pathgroups
-   * @type Number
-   * @default 0
-   */
-  declare offsetY: number;
-
+> extends Filler<CanvasGradient> {
   /**
    * A transform matrix to apply to the gradient before painting.
    * Imported from svg gradients, is not applied with the current transform in the center.
@@ -111,6 +97,7 @@ export class Gradient<
     gradientTransform = null,
     id,
   }: GradientOptions<T>) {
+    super();
     this.id = id ? `${id}_${uid()}` : uid();
     this.type = type;
     this.gradientUnits = gradientUnits;
@@ -150,9 +137,9 @@ export class Gradient<
    * @param {string[]} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {object}
    */
-  toObject(propertiesToInclude?: (keyof this | string)[]) {
+  toObject<T extends keyof this>(propertiesToInclude?: T[]) {
     return {
-      ...pick(this, propertiesToInclude),
+      ...super.toObject(propertiesToInclude),
       type: this.type,
       coords: this.coords,
       colorStops: this.colorStops,

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -7,7 +7,8 @@ import {
   keysMap,
   keysMapRtl,
 } from './constants';
-import type { AssertKeys, TFiller } from '../../typedefs';
+import type { AssertKeys } from '../../typedefs';
+import type { TFiller } from '../../fillers/typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import type { SerializedTextProps, TextProps } from '../Text/Text';
 

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -4,7 +4,7 @@ import type { TClassProperties } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
 import { Point } from '../Point';
-import { isFiller } from '../util/typeAssertions';
+import { isFiller } from '../fillers/Filler';
 import type {
   FabricObjectProps,
   SerializedObjectProps,

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -28,11 +28,7 @@ import { pick, pickBy } from '../../util/misc/pick';
 import { toFixed } from '../../util/misc/toFixed';
 import type { Group } from '../Group';
 import { StaticCanvas } from '../../canvas/StaticCanvas';
-import {
-  isFiller,
-  isSerializableFiller,
-  isTextObject,
-} from '../../util/typeAssertions';
+import { isFiller, isTextObject } from '../../util/typeAssertions';
 import type { Image } from '../Image';
 import {
   cacheProperties,
@@ -516,12 +512,8 @@ export class FabricObject<
         top: toFixed(this.top, NUM_FRACTION_DIGITS),
         width: toFixed(this.width, NUM_FRACTION_DIGITS),
         height: toFixed(this.height, NUM_FRACTION_DIGITS),
-        fill: isSerializableFiller(this.fill)
-          ? this.fill.toObject()
-          : this.fill,
-        stroke: isSerializableFiller(this.stroke)
-          ? this.stroke.toObject()
-          : this.stroke,
+        fill: isFiller(this.fill) ? this.fill.toObject() : this.fill,
+        stroke: isFiller(this.stroke) ? this.stroke.toObject() : this.stroke,
         strokeWidth: toFixed(this.strokeWidth, NUM_FRACTION_DIGITS),
         strokeDashArray: this.strokeDashArray
           ? this.strokeDashArray.concat()

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -7,11 +7,11 @@ import { Point } from '../../Point';
 import { Shadow } from '../../Shadow';
 import type {
   TDegree,
-  TFiller,
   TSize,
   TCacheCanvasDimensions,
   Abortable,
 } from '../../typedefs';
+import type { TFiller } from '../../fillers/typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import { runningAnimations } from '../../util/animation/AnimationRegistry';
 import { cloneDeep } from '../../util/internals/cloneDeep';
@@ -28,7 +28,8 @@ import { pick, pickBy } from '../../util/misc/pick';
 import { toFixed } from '../../util/misc/toFixed';
 import type { Group } from '../Group';
 import { StaticCanvas } from '../../canvas/StaticCanvas';
-import { isFiller, isTextObject } from '../../util/typeAssertions';
+import { isTextObject } from '../../util/typeAssertions';
+import { isFiller } from '../../fillers/Filler';
 import type { Image } from '../Image';
 import {
   cacheProperties,

--- a/src/shapes/Object/types/FillStrokeProps.ts
+++ b/src/shapes/Object/types/FillStrokeProps.ts
@@ -1,4 +1,4 @@
-import type { TFiller } from '../../../typedefs';
+import type { TFiller } from '../../../fillers/typedefs';
 
 export interface FillStrokeProps {
   /**

--- a/src/shapes/Object/types/ObjectProps.ts
+++ b/src/shapes/Object/types/ObjectProps.ts
@@ -1,7 +1,7 @@
 import type { Shadow } from '../../../Shadow';
 import type { Canvas } from '../../../canvas/Canvas';
 import type { StaticCanvas } from '../../../canvas/StaticCanvas';
-import type { TFiller } from '../../../typedefs';
+import type { TFiller } from '../../../fillers/typedefs';
 import type { FabricObject } from '../Object';
 import type {
   ClipPathProps,

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -7,11 +7,8 @@ import { StyledText } from './StyledText';
 import { SHARED_ATTRIBUTES } from '../../parser/attributes';
 import { parseAttributes } from '../../parser/parseAttributes';
 import type { Point } from '../../Point';
-import type {
-  TCacheCanvasDimensions,
-  TClassProperties,
-  TFiller,
-} from '../../typedefs';
+import type { TCacheCanvasDimensions, TClassProperties } from '../../typedefs';
+import type { TFiller } from '../../fillers/typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import { graphemeSplit } from '../../util/lang_string';
 import { createCanvasElement } from '../../util/misc/dom';

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -1,7 +1,5 @@
 // https://www.typescriptlang.org/docs/handbook/utility-types.html
 import type { BaseFabricObject } from './EventTypeDefs';
-import type { Gradient } from './gradient/Gradient';
-import type { Pattern } from './Pattern';
 import type { XY, Point } from './Point';
 
 interface NominalTag<T> {
@@ -28,8 +26,6 @@ export type TRadian = Nominal<number, Radian>;
 export type TAxis = 'x' | 'y';
 
 export type TAxisKey<T extends string> = `${T}${Capitalize<TAxis>}`;
-
-export type TFiller = Gradient<'linear'> | Gradient<'radial'> | Pattern;
 
 export type TSize = {
   width: number;

--- a/src/util/misc/objectEnlive.ts
+++ b/src/util/misc/objectEnlive.ts
@@ -1,7 +1,8 @@
 import { noop } from '../../constants';
 import type { Pattern } from '../../Pattern';
 import type { FabricObject } from '../../shapes/Object/FabricObject';
-import type { Abortable, TCrossOrigin, TFiller } from '../../typedefs';
+import type { Abortable, TCrossOrigin } from '../../typedefs';
+import type { TFiller } from '../../fillers/typedefs';
 import { createImage } from './dom';
 import { classRegistry } from '../../ClassRegistry';
 

--- a/src/util/typeAssertions.ts
+++ b/src/util/typeAssertions.ts
@@ -5,17 +5,9 @@ import type {
   TCachedFabricObject,
 } from '../shapes/Object/Object';
 import type { FabricObjectWithDragSupport } from '../shapes/Object/InteractiveObject';
-import type { TFiller } from '../typedefs';
 import type { Text } from '../shapes/Text/Text';
 import type { IText } from '../shapes/IText/IText';
 import type { Textbox } from '../shapes/Textbox';
-import { Filler } from '../fillers/Filler';
-
-export const isFiller = (
-  filler: TFiller | string | null
-): filler is TFiller => {
-  return !!filler && filler instanceof Filler;
-};
 
 export const isCollection = (
   fabricObject?: FabricObject

--- a/src/util/typeAssertions.ts
+++ b/src/util/typeAssertions.ts
@@ -7,28 +7,14 @@ import type {
 import type { FabricObjectWithDragSupport } from '../shapes/Object/InteractiveObject';
 import type { TFiller } from '../typedefs';
 import type { Text } from '../shapes/Text/Text';
-import type { Pattern } from '../Pattern';
 import type { IText } from '../shapes/IText/IText';
 import type { Textbox } from '../shapes/Textbox';
+import { Filler } from '../fillers/Filler';
 
 export const isFiller = (
   filler: TFiller | string | null
 ): filler is TFiller => {
-  return !!filler && (filler as TFiller).toLive !== undefined;
-};
-
-export const isSerializableFiller = (
-  filler: TFiller | string | null
-): filler is TFiller => {
-  return !!filler && typeof (filler as TFiller).toObject === 'function';
-};
-
-export const isPattern = (filler: TFiller): filler is Pattern => {
-  return (
-    !!filler &&
-    (filler as Pattern).offsetX !== undefined &&
-    (filler as Pattern).source !== undefined
-  );
+  return !!filler && filler instanceof Filler;
 };
 
 export const isCollection = (


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

1. allow `instance of Filler` as part of #8931 
2. share some interface
3. port some of #8263 

## Description

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

- moved `isFiller`, `TFiller` under `filler` => caused a lot of import changes
- rm `isPattern` in favor of instance of used only by canvas. We can add a dummy super class if you prefer to do `instanceof` checks against it but importing Pattern is ok, not cycles.
- export Filler base class with min logic/interface

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
