### PR TITLE
ci(): fix changelog action race condition

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -80,7 +80,6 @@ jobs:
       - name: Commit & Push
         if: fromJson(steps.update.outputs.result)
         run: |
-          rm .gitattributes
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
           git add ${{ env.file }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Commit & Push
         if: fromJson(steps.update.outputs.result)
         run: |
+          rm .gitattributes
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
           git add ${{ env.file }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,8 +3,13 @@ name: changelog
 on:
   workflow_call:
     inputs:
-      update:
+      create:
         description: Add a log to the changelog
+        type: boolean
+        required: false
+        default: false
+      update:
+        description: Update the existing changelog
         type: boolean
         required: false
         default: false
@@ -27,7 +32,8 @@ jobs:
   update:
     runs-on: ubuntu-latest
     needs: changelog
-    if: inputs.update && (failure() || success())
+    if: (inputs.create && failure()) || (inputs.update && success())
+    continue-on-error: true
     env:
       file: CHANGELOG.md
       next_version: next

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -10,4 +10,5 @@ jobs:
     if: github.event.action == 'opened' || github.event.changes.title.from != github.event.pull_request.title
     uses: ./.github/workflows/changelog.yml
     with:
-      update: true
+      create: ${{ github.event.action == 'opened' }}
+      update: ${{ github.event.changes.title.from != github.event.pull_request.title }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## [next]
 
-- ci(): fix changelog action race condition firing twice1 [#8948](https://github.com/fabricjs/fabric.js/pull/8948)
-- ci(): fix changelog action race condition firing twice [#8948](https://github.com/fabricjs/fabric.js/pull/8948)
 - ci(): automate PR changelog [#8938](https://github.com/fabricjs/fabric.js/pull/8938)
 - chore(): move canvas click handler to TextManager [#8939](https://github.com/fabricjs/fabric.js/pull/8939)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- ci() fix changelog action race condition [#8949](https://github.com/fabricjs/fabric.js/pull/8949)
+- ci(): fix changelog action race condition [#8949](https://github.com/fabricjs/fabric.js/pull/8949)
 - ci(): automate PR changelog [#8938](https://github.com/fabricjs/fabric.js/pull/8938)
 - chore(): move canvas click handler to TextManager [#8939](https://github.com/fabricjs/fabric.js/pull/8939)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci() fix changelog action race condition [#8949](https://github.com/fabricjs/fabric.js/pull/8949)
 - ci(): automate PR changelog [#8938](https://github.com/fabricjs/fabric.js/pull/8938)
 - chore(): move canvas click handler to TextManager [#8939](https://github.com/fabricjs/fabric.js/pull/8939)
 


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

I want to keep this action alive and not kill it yet
Last chance

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

The action would run twice on open (in case I edited the description/title before the opened event would finish)
Seems to because of an opened and an edited event being fired at the same time, strange that git allowed to commit on top of a changed origin w/o needing to fetch. 

Anyways it should be fixed now.
It also means the action is stricter
It will write a log on PR opened ONLY if there is none existing.
After that it will only **update** (and not try to create the log) in case it is identical to the PR title.



<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
