### PR TITLE
refactor(): cache state => rm `isTextObject`

### DIFF
--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -569,6 +569,27 @@ export class Text<
     return dims;
   }
 
+  getCacheState() {
+    const data = super.getCacheState();
+    // IMHO in these lines we are using zoomX and zoomY not the this version.
+    const additionalWidth =
+      data.additionalSize.width + this.getHeightOfLine(0) * this.zoomX!;
+    const additionalHeight =
+      data.additionalSize.height + this.getHeightOfLine(0) * this.zoomY!;
+    return {
+      ...data,
+      redraw: true,
+      additionalSize: {
+        width: additionalWidth,
+        height: additionalHeight,
+      },
+      resize: {
+        width: Math.ceil(width + additionalWidth),
+        height: Math.ceil(height + additionalHeight),
+      },
+    };
+  }
+
   /**
    * @private
    * @param {CanvasRenderingContext2D} ctx Context to render on

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -93,6 +93,7 @@ export type TCacheCanvasDimensions = {
   zoomY: number;
   x: number;
   y: number;
+  capped: boolean;
 };
 
 export type TRectBounds = [min: XY, max: XY];


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

#8931 

## Description

<!-- What you are proposing -->

The last part of type assertion to handle.
I had to refactor the messy logic of `_updateCacheCanvas` and extract from it a method that has no side effects `getCacheState` so Text can override it.

Apart from that is is only one more use of `isTextObject`
https://github.com/fabricjs/fabric.js/blob/a1f94b29dda272f3dff6b2eda92f29d6d2b8c3ad/src/canvas/StaticCanvas.ts#L1319-L1321 which I don't understand but I guess we can check for an existence of an svg method that text has and we are done

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
