### PR TITLE
chore() remove unnecessary typeof === 'undefined'

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -146,7 +146,7 @@ export class Observable<EventSpec> {
     }
 
     // remove all key/value pairs (event name -> event handler)
-    if (typeof arg0 === 'undefined') {
+    if (arg0 === undefined) {
       for (const eventName in this.__eventListeners) {
         this._removeEventListener(eventName);
       }

--- a/src/parser/parseAttributes.ts
+++ b/src/parser/parseAttributes.ts
@@ -30,7 +30,7 @@ export function parseAttributes(
     fontSize,
     parentFontSize;
 
-  if (typeof svgUid === 'undefined') {
+  if (svgUid === undefined) {
     svgUid = element.getAttribute('svgUid');
   }
   // if there's a parent container (`g` or `a` or `symbol` node), parse its attributes recursively upwards

--- a/src/parser/parseStyleObject.ts
+++ b/src/parser/parseStyleObject.ts
@@ -3,7 +3,7 @@
 export function parseStyleObject(style, oStyle) {
   let attr, value;
   for (const prop in style) {
-    if (typeof style[prop] === 'undefined') {
+    if (style[prop] === undefined) {
       continue;
     }
 

--- a/src/parser/setStrokeFillOpacity.ts
+++ b/src/parser/setStrokeFillOpacity.ts
@@ -12,13 +12,13 @@ import { FabricObject } from '../shapes/Object/FabricObject';
 export function setStrokeFillOpacity(attributes) {
   for (const attr in colorAttributes) {
     if (
-      typeof attributes[colorAttributes[attr]] === 'undefined' ||
+      attributes[colorAttributes[attr]] === undefined ||
       attributes[attr] === ''
     ) {
       continue;
     }
     const defaults = FabricObject.getDefaults();
-    if (typeof attributes[attr] === 'undefined') {
+    if (attributes[attr] === undefined) {
       if (!defaults[attr]) {
         continue;
       }

--- a/src/shapes/Text/StyledText.ts
+++ b/src/shapes/Text/StyledText.ts
@@ -41,9 +41,7 @@ export abstract class StyledText<
       return true;
     }
     const obj =
-      typeof lineIndex === 'undefined'
-        ? this.styles
-        : { line: this.styles[lineIndex] };
+      lineIndex === undefined ? this.styles : { line: this.styles[lineIndex] };
     for (const p1 in obj) {
       for (const p2 in obj[p1]) {
         // eslint-disable-next-line no-unused-vars
@@ -70,9 +68,7 @@ export abstract class StyledText<
       return false;
     }
     const obj =
-      typeof lineIndex === 'undefined'
-        ? this.styles
-        : { 0: this.styles[lineIndex] };
+      lineIndex === undefined ? this.styles : { 0: this.styles[lineIndex] };
     // eslint-disable-next-line
     for (const p1 in obj) {
       // eslint-disable-next-line
@@ -274,9 +270,7 @@ export abstract class StyledText<
     for (let i = 0; i < styleProps.length; i++) {
       const prop = styleProps[i];
       styleObject[prop] =
-        typeof style[prop] === 'undefined'
-          ? this[prop as keyof this]
-          : style[prop];
+        style[prop] === undefined ? this[prop as keyof this] : style[prop];
     }
     return styleObject;
   }

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -164,9 +164,7 @@ export class Textbox extends IText {
       nextOffset = mapNextLine.offset;
     }
     const obj =
-      typeof lineIndex === 'undefined'
-        ? this.styles
-        : { line: this.styles[lineIndex] };
+      lineIndex === undefined ? this.styles : { line: this.styles[lineIndex] };
     for (const p1 in obj) {
       for (const p2 in obj[p1]) {
         if (p2 >= offset && (!shouldLimit || p2 < nextOffset)) {

--- a/src/util/misc/dom.ts
+++ b/src/util/misc/dom.ts
@@ -6,7 +6,7 @@ import type { ImageFormat } from '../../typedefs';
  */
 export const createCanvasElement = (): HTMLCanvasElement => {
   const element = getFabricDocument().createElement('canvas');
-  if (!element || typeof element.getContext === 'undefined') {
+  if (!element || element.getContext === undefined) {
     throw new Error('Failed to create `canvas` element');
   }
   return element;


### PR DESCRIPTION


## Motivation

For variables that are declared, we don't need to check the typeof === 'undefined' to know if they are undefined. We can just check the strict equality with undefined.

`typeof variable === 'undefined'` is needed when you don't know if the variable is in scope at all

Please someone correct me if i m wrong