### PR TITLE
feat(): Missing features from fabric 5 and types exports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
               size: { fabric: { minified: fs.statSync('${{ env.minified }}').size, bundled: fs.statSync('${{ env.bundled }}').size } }
             });
       - name: checkout src files
-        run: git checkout origin/master -- src fabric.ts index.ts index.node.ts .browserslistrc
+        run: git checkout origin/master -- src fabric.ts index.ts index.node.ts .browserslistrc rollup.config.mjs
       - name: upstream build stats
         run: npm run build -- -s
       - name: persist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- feat(): Export setFilterBackend and port the texture filtering option from fabric 5 [#8954](https://github.com/fabricjs/fabric.js/pull/8954)
+- feat(): Export setFilterBackend and port the texture filtering option from fabric 5, exports some extra types [#8954](https://github.com/fabricjs/fabric.js/pull/8954)
 - chore(): swap commonly used string with constants [#8933](https://github.com/fabricjs/fabric.js/pull/8933)
 - chore(TS): Add more text types [#8941](https://github.com/fabricjs/fabric.js/pull/8941)
 - ci(): fix changelog action race condition [#8949](https://github.com/fabricjs/fabric.js/pull/8949)

--- a/fabric.ts
+++ b/fabric.ts
@@ -34,6 +34,7 @@ export { SprayBrush } from './src/brushes/SprayBrush';
 export { PatternBrush } from './src/brushes/PatternBrush';
 
 export { FabricObject as Object } from './src/shapes/Object/FabricObject';
+export type { TProps } from './src/shapes/Object/types';
 export { Line } from './src/shapes/Line';
 export { Circle } from './src/shapes/Circle';
 export { Triangle } from './src/shapes/Triangle';
@@ -48,6 +49,11 @@ export { Textbox } from './src/shapes/Textbox';
 export { Group } from './src/shapes/Group';
 export { ActiveSelection } from './src/shapes/ActiveSelection';
 export { Image } from './src/shapes/Image';
+export type {
+  ImageSource,
+  SerializedImageProps,
+  ImageProps,
+} from './src/shapes/Image';
 export { createCollectionMixin } from './src/Collection';
 
 export * as util from './src/util';

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -32,6 +32,15 @@ const plugins = [
  * @param {*} warn
  */
 function onwarn(warning, warn) {
+  // we error at any warning.
+  // we allow-list the errors we understand are not harmful
+  if (
+    warning.code === 'PLUGIN_WARNING' &&
+    !warning.message.includes('sourcemap')
+  ) {
+    console.error(chalk.redBright(warning.message));
+    throw Object.assign(new Error(), warning);
+  }
   if (warning.code === 'CIRCULAR_DEPENDENCY') {
     console.error(chalk.redBright(warning.message));
     throw Object.assign(new Error(), warning);

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -1319,17 +1319,16 @@ export class StaticCanvas<
       if (!isTextObject(obj)) {
         return;
       }
-      let fontFamily = obj.fontFamily;
+      const { styles, fontFamily } = obj;
       if (fontList[fontFamily] || !fontPaths[fontFamily]) {
         return;
       }
       fontList[fontFamily] = true;
-      if (!obj.styles) {
+      if (!styles) {
         return;
       }
-      Object.values(obj.styles).forEach((styleRow) => {
-        Object.values(styleRow).forEach((textCharStyle) => {
-          fontFamily = textCharStyle.fontFamily;
+      Object.values(styles).forEach((styleRow) => {
+        Object.values(styleRow).forEach(({ fontFamily = '' }) => {
           if (!fontList[fontFamily] && fontPaths[fontFamily]) {
             fontList[fontFamily] = true;
           }

--- a/src/filters/BlendImage.ts
+++ b/src/filters/BlendImage.ts
@@ -74,7 +74,7 @@ export class BlendImage extends BaseFilter {
   applyToWebGL(options: TWebGLPipelineState) {
     const gl = options.context,
       texture = this.createTexture(options.filterBackend, this.image);
-    this.bindAdditionalTexture(gl, texture, gl.TEXTURE1);
+    this.bindAdditionalTexture(gl, texture!, gl.TEXTURE1);
     super.applyToWebGL(options);
     this.unbindAdditionalTexture(gl, gl.TEXTURE1);
   }

--- a/src/filters/FilterBackend.ts
+++ b/src/filters/FilterBackend.ts
@@ -32,3 +32,7 @@ export function getFilterBackend(strict = true): FilterBackend {
   }
   return filterBackend;
 }
+
+export function setFilterBackend(backend: FilterBackend) {
+  filterBackend = backend;
+}

--- a/src/filters/WebGLFilterBackend.ts
+++ b/src/filters/WebGLFilterBackend.ts
@@ -246,7 +246,8 @@ export class WebGLFilterBackend {
    * @param {number} width The width to initialize the texture at.
    * @param {number} height The height to initialize the texture.
    * @param {TexImageSource} textureImageSource A source for the texture data.
-   * @param {number} filter gl.NEAREST default or gl.LINEAR A source for the texture data.
+   * @param {number} filter gl.NEAREST default or gl.LINEAR filters for the texture.
+   * This filter is very useful for LUTs filters. If you need interpolation use gl.LINEAR
    * @returns {WebGLTexture}
    */
   createTexture(

--- a/src/filters/WebGLFilterBackend.ts
+++ b/src/filters/WebGLFilterBackend.ts
@@ -257,31 +257,41 @@ export class WebGLFilterBackend {
     textureImageSource?: TexImageSource,
     filter = gl.NEAREST
   ) {
+    const {
+      TEXTURE_2D,
+      RGBA,
+      UNSIGNED_BYTE,
+      CLAMP_TO_EDGE,
+      TEXTURE_MAG_FILTER,
+      TEXTURE_MIN_FILTER,
+      TEXTURE_WRAP_S,
+      TEXTURE_WRAP_T,
+    } = gl;
     const texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.bindTexture(TEXTURE_2D, texture);
+    gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, filter);
+    gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, filter);
+    gl.texParameteri(TEXTURE_2D, TEXTURE_WRAP_S, CLAMP_TO_EDGE);
+    gl.texParameteri(TEXTURE_2D, TEXTURE_WRAP_T, CLAMP_TO_EDGE);
     if (textureImageSource) {
       gl.texImage2D(
-        gl.TEXTURE_2D,
+        TEXTURE_2D,
         0,
-        gl.RGBA,
-        gl.RGBA,
-        gl.UNSIGNED_BYTE,
+        RGBA,
+        RGBA,
+        UNSIGNED_BYTE,
         textureImageSource
       );
     } else {
       gl.texImage2D(
-        gl.TEXTURE_2D,
+        TEXTURE_2D,
         0,
-        gl.RGBA,
+        RGBA,
         width,
         height,
         0,
-        gl.RGBA,
-        gl.UNSIGNED_BYTE,
+        RGBA,
+        UNSIGNED_BYTE,
         null
       );
     }

--- a/src/filters/WebGLFilterBackend.ts
+++ b/src/filters/WebGLFilterBackend.ts
@@ -243,21 +243,23 @@ export class WebGLFilterBackend {
    * Accepts specific dimensions to initialize the texture to or a source image.
    *
    * @param {WebGLRenderingContext} gl The GL context to use for creating the texture.
-   * @param {Number} width The width to initialize the texture at.
-   * @param {Number} height The height to initialize the texture.
-   * @param {HTMLImageElement|HTMLCanvasElement} textureImageSource A source for the texture data.
+   * @param {number} width The width to initialize the texture at.
+   * @param {number} height The height to initialize the texture.
+   * @param {TexImageSource} textureImageSource A source for the texture data.
+   * @param {number} filter gl.NEAREST default or gl.LINEAR A source for the texture data.
    * @returns {WebGLTexture}
    */
   createTexture(
     gl: WebGLRenderingContext,
     width: number,
     height: number,
-    textureImageSource?: TexImageSource
+    textureImageSource?: TexImageSource,
+    filter = gl.NEAREST
   ) {
     const texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     if (textureImageSource) {
@@ -294,7 +296,10 @@ export class WebGLFilterBackend {
    * @param {HTMLImageElement|HTMLCanvasElement} textureImageSource A source to use to create the
    * texture cache entry if one does not already exist.
    */
-  getCachedTexture(uniqueId: string, textureImageSource: TexImageSource) {
+  getCachedTexture(
+    uniqueId: string,
+    textureImageSource: TexImageSource
+  ): WebGLTexture | null {
     if (this.textureCache[uniqueId]) {
       return this.textureCache[uniqueId];
     } else {
@@ -304,7 +309,9 @@ export class WebGLFilterBackend {
         textureImageSource.height,
         textureImageSource
       );
-      this.textureCache[uniqueId] = texture;
+      if (texture) {
+        this.textureCache[uniqueId] = texture;
+      }
       return texture;
     }
   }

--- a/src/filters/WebGLFilterBackend.ts
+++ b/src/filters/WebGLFilterBackend.ts
@@ -190,7 +190,7 @@ export class WebGLFilterBackend {
           width,
           height,
           !cachedTexture ? source : undefined
-        ),
+        )!,
       passes: filters.length,
       webgl: true,
       aPosition: this.aPosition,

--- a/src/filters/WebGLFilterBackend.ts
+++ b/src/filters/WebGLFilterBackend.ts
@@ -311,8 +311,9 @@ export class WebGLFilterBackend {
     uniqueId: string,
     textureImageSource: TexImageSource
   ): WebGLTexture | null {
-    if (this.textureCache[uniqueId]) {
-      return this.textureCache[uniqueId];
+    const { textureCache } = this;
+    if (textureCache[uniqueId]) {
+      return textureCache[uniqueId];
     } else {
       const texture = this.createTexture(
         this.gl,
@@ -321,7 +322,7 @@ export class WebGLFilterBackend {
         textureImageSource
       );
       if (texture) {
-        this.textureCache[uniqueId] = texture;
+        textureCache[uniqueId] = texture;
       }
       return texture;
     }

--- a/src/filters/WebGLFilterBackend.ts
+++ b/src/filters/WebGLFilterBackend.ts
@@ -255,9 +255,12 @@ export class WebGLFilterBackend {
     width: number,
     height: number,
     textureImageSource?: TexImageSource,
-    filter = gl.NEAREST
+    filter?:
+      | WebGLRenderingContextBase['NEAREST']
+      | WebGLRenderingContextBase['LINEAR']
   ) {
     const {
+      NEAREST,
       TEXTURE_2D,
       RGBA,
       UNSIGNED_BYTE,
@@ -269,8 +272,8 @@ export class WebGLFilterBackend {
     } = gl;
     const texture = gl.createTexture();
     gl.bindTexture(TEXTURE_2D, texture);
-    gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, filter);
-    gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, filter);
+    gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, filter || NEAREST);
+    gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, filter || NEAREST);
     gl.texParameteri(TEXTURE_2D, TEXTURE_WRAP_S, CLAMP_TO_EDGE);
     gl.texParameteri(TEXTURE_2D, TEXTURE_WRAP_T, CLAMP_TO_EDGE);
     if (textureImageSource) {
@@ -309,7 +312,10 @@ export class WebGLFilterBackend {
    */
   getCachedTexture(
     uniqueId: string,
-    textureImageSource: TexImageSource
+    textureImageSource: TexImageSource,
+    filter?:
+      | WebGLRenderingContextBase['NEAREST']
+      | WebGLRenderingContextBase['LINEAR']
   ): WebGLTexture | null {
     const { textureCache } = this;
     if (textureCache[uniqueId]) {
@@ -319,7 +325,8 @@ export class WebGLFilterBackend {
         this.gl,
         textureImageSource.width,
         textureImageSource.height,
-        textureImageSource
+        textureImageSource,
+        filter
       );
       if (texture) {
         textureCache[uniqueId] = texture;

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -1,6 +1,10 @@
 export * as filters from './filters';
 
-export { getFilterBackend, initFilterBackend } from './FilterBackend';
+export {
+  getFilterBackend,
+  initFilterBackend,
+  setFilterBackend,
+} from './FilterBackend';
 export { Canvas2dFilterBackend } from './Canvas2dFilterBackend';
 export { WebGLFilterBackend } from './WebGLFilterBackend';
 export { isWebGLPipelineState } from './utils';

--- a/src/filters/typedefs.ts
+++ b/src/filters/typedefs.ts
@@ -3,7 +3,7 @@ import type { Canvas2dFilterBackend } from './Canvas2dFilterBackend';
 
 export type TProgramCache = any;
 
-export type TTextureCache = any;
+export type TTextureCache = Record<string, WebGLTexture>;
 
 export type TPipelineResources = {
   blendImage?: HTMLCanvasElement;

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -189,8 +189,8 @@ export class Image<
    * @param {ImageSource | string} element Image element
    * @param {Object} [options] Options object
    */
-  constructor(elementId: string, options: Props);
-  constructor(element: ImageSource, options: Props);
+  constructor(elementId: string, options?: Props);
+  constructor(element: ImageSource, options?: Props);
   constructor(arg0: ImageSource | string, options: Props = {} as Props) {
     super({ filters: [], ...options });
     this.cacheKey = `texture${uid()}`;

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -1299,11 +1299,11 @@ export class FabricObject<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @returns {Promise<FabricObject>}
    */
-  clone(propertiesToInclude: string[]) {
+  clone(propertiesToInclude?: string[]): Promise<this> {
     const objectForm = this.toObject(propertiesToInclude);
     return (this.constructor as typeof FabricObject).fromObject(
       objectForm
-    ) as unknown as this;
+    ) as unknown as Promise<this>;
   }
 
   /**

--- a/src/shapes/Text/StyledText.ts
+++ b/src/shapes/Text/StyledText.ts
@@ -110,7 +110,6 @@ export abstract class StyledText<
       letterCount = 0;
       for (const p2 in obj[p1]) {
         const styleObject = obj[p1][p2] || {},
-          // TODO: this shouldn't be necessary anymore with modern browsers
           stylePropertyHasBeenSet = styleObject[property] !== undefined;
 
         stylesCount++;

--- a/src/shapes/Text/constants.ts
+++ b/src/shapes/Text/constants.ts
@@ -35,7 +35,21 @@ export const additionalProps = [
   'direction',
 ] as const;
 
-export const styleProperties = [
+export type StylePropertiesType =
+  | 'fill'
+  | 'stroke'
+  | 'strokeWidth'
+  | 'fontSize'
+  | 'fontFamily'
+  | 'fontWeight'
+  | 'fontStyle'
+  | 'textBackgroundColor'
+  | 'deltaY'
+  | 'overline'
+  | 'underline'
+  | 'linethrough';
+
+export const styleProperties: Readonly<StylePropertiesType[]> = [
   ...fontProperties,
   ...textDecorationProperties,
   'stroke',

--- a/src/util/misc/textStyles.ts
+++ b/src/util/misc/textStyles.ts
@@ -102,10 +102,7 @@ export const stylesFromArray = (
     return cloneDeep(styles);
   }
   const textLines = text.split('\n'),
-    stylesObject = {} as Record<
-      string | number,
-      Record<string | number, Record<string, string>>
-    >;
+    stylesObject: TextStyle = {};
   let charIndex = -1,
     styleIndex = 0;
   //loop through each textLine


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

Converting a small app from fabric 5 to 6 i noticed the following issues:
- can't set anymore my own filter backend
- can't set anymore the filter for texture for scalin

Also added some typings

