### PR TITLE
fix(): regression to itext focusing from #8939

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): regression to itext focusing from #8939 [#8970](https://github.com/fabricjs/fabric.js/pull/8970)
 - BREAKING: fabric.util.makeElementSelectable / fabric.util.makeElementUnselectable are removed [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 - refactor(): Canvas DOM delegation to utility class [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 

--- a/src/canvas/TextEditingManager.ts
+++ b/src/canvas/TextEditingManager.ts
@@ -12,7 +12,9 @@ export class TextEditingManager {
   private __disposer: VoidFunction;
 
   constructor(canvas: Canvas) {
-    const cb = () => this.target?.hiddenTextarea?.focus();
+    const cb = () => {
+      (canvas.getActiveObject() as ITextBehavior)?.hiddenTextarea?.focus();
+    };
     const el = canvas.upperCanvasEl;
     el.addEventListener('click', cb);
     this.__disposer = () => el.removeEventListener('click', cb);


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

I made a mistake in #8939 and introduced a bug.
Editing text and then clicking with the mouse on the itext will not gain focus (because TextEditingManager loses `target` on mouse up).

## Changes

<!-- before the fix vs. after -->

Use the active object for focusing the hiddenTextarea

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
