### PR TITLE
ci(): warn build errors in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- BREAKING: fabric.util.makeElementSelectable / fabric.util.makeElementUnselectable are removed [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 - refactor(): Canvas DOM delegation to utility class [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 
 ## [6.0.0-beta7]

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -35,15 +35,14 @@ function onwarn(warning, warn) {
   // we error at any warning.
   // we allow-list the errors we understand are not harmful
   if (
-    warning.code === 'PLUGIN_WARNING' &&
-    !warning.message.includes('sourcemap')
+    (warning.code === 'PLUGIN_WARNING' &&
+      !warning.message.includes('sourcemap')) ||
+    warning.code === 'CIRCULAR_DEPENDENCY'
   ) {
     console.error(chalk.redBright(warning.message));
-    throw Object.assign(new Error(), warning);
-  }
-  if (warning.code === 'CIRCULAR_DEPENDENCY') {
-    console.error(chalk.redBright(warning.message));
-    throw Object.assign(new Error(), warning);
+    if (process.env.CI) {
+      throw Object.assign(new Error(), warning);
+    }
   }
   warn(warning);
 }

--- a/src/canvas/TextEditingManager.ts
+++ b/src/canvas/TextEditingManager.ts
@@ -12,7 +12,7 @@ export class TextEditingManager {
   private __disposer: VoidFunction;
 
   constructor(canvas: Canvas) {
-    const cb = () => canvas.getActiveObject()?.hiddenTextarea?.focus();
+    const cb = () => this.target?.hiddenTextarea?.focus();
     const el = canvas.upperCanvasEl;
     el.addEventListener('click', cb);
     this.__disposer = () => el.removeEventListener('click', cb);

--- a/src/canvas/TextEditingManager.ts
+++ b/src/canvas/TextEditingManager.ts
@@ -12,7 +12,7 @@ export class TextEditingManager {
   private __disposer: VoidFunction;
 
   constructor(canvas: Canvas) {
-    const cb = () => this.target?.hiddenTextarea?.focus();
+    const cb = () => canvas.getActiveObject()?.hiddenTextarea?.focus();
     const el = canvas.upperCanvasEl;
     el.addEventListener('click', cb);
     this.__disposer = () => el.removeEventListener('click', cb);


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

Currently the process exits when there is a build error.
That should happen only in CI.
When we develop we want rollup to keep watching and building to fix the error (we don't want to restart the build each time)

## Description

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

https://github.com/fabricjs/fabric.js/actions/runs/5147975815/jobs/9269055157?pr=8971

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
