### PR TITLE
fix(IText): cursor detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- fix(IText): cursor detection  [#8972](https://github.com/fabricjs/fabric.js/pull/8972)
+- fix(IText): cursor detection [#8972](https://github.com/fabricjs/fabric.js/pull/8972)
 - BREAKING: fabric.util.makeElementSelectable / fabric.util.makeElementUnselectable are removed [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 - refactor(): Canvas DOM delegation to utility class [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(IText): cursor detection  [#8972](https://github.com/fabricjs/fabric.js/pull/8972)
 - BREAKING: fabric.util.makeElementSelectable / fabric.util.makeElementUnselectable are removed [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 - refactor(): Canvas DOM delegation to utility class [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 

--- a/src/shapes/IText/ITextClickBehavior.ts
+++ b/src/shapes/IText/ITextClickBehavior.ts
@@ -3,7 +3,7 @@ import type { XY } from '../../Point';
 import { Point } from '../../Point';
 import type { DragMethods } from '../Object/InteractiveObject';
 import { stopEvent } from '../../util/dom_event';
-import { invertTransform, transformPoint } from '../../util/misc/matrix';
+import { invertTransform } from '../../util/misc/matrix';
 import { DraggableTextDelegate } from './DraggableTextDelegate';
 import type { ITextEvents } from './ITextBehavior';
 import { ITextKeyBehavior } from './ITextKeyBehavior';
@@ -231,24 +231,14 @@ export abstract class ITextClickBehavior<
   }
 
   /**
-   * Returns coordinates of a pointer relative to object's top left corner in object's plane
-   * @param {Point} [pointer] Pointer to operate upon
-   * @return {Point} Coordinates of a pointer (x, y)
-   */
-  getLocalPointer(pointer: Point): Point {
-    return transformPoint(
-      pointer,
-      invertTransform(this.calcTransformMatrix())
-    ).add(new Point(this.width / 2, this.height / 2));
-  }
-
-  /**
    * Returns index of a character corresponding to where an object was clicked
    * @param {TPointerEvent} e Event object
    * @return {Number} Index of a character
    */
   getSelectionStartFromPointer(e: TPointerEvent): number {
-    const mouseOffset = this.getLocalPointer(this.canvas!.getPointer(e));
+    const mouseOffset = this.canvas!.getPointer(e)
+      .transform(invertTransform(this.calcTransformMatrix()))
+      .add(new Point(-this._getLeftOffset(), -this._getTopOffset()));
     let height = 0,
       charIndex = 0,
       lineIndex = 0;
@@ -267,13 +257,6 @@ export abstract class ITextClickBehavior<
     const lineLeftOffset = Math.abs(this._getLineLeftOffset(lineIndex));
     let width = lineLeftOffset;
     const jlen = this._textLines[lineIndex].length;
-    // handling of RTL: in order to get things work correctly,
-    // we assume RTL writing is mirrored compared to LTR writing.
-    // so in position detection we mirror the X offset, and when is time
-    // of rendering it, we mirror it again.
-    if (this.direction === 'rtl') {
-      mouseOffset.x = this.width - mouseOffset.x;
-    }
     let prevWidth = 0;
     for (let j = 0; j < jlen; j++) {
       prevWidth = width;


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->


Working on a subclass that has vertical text alignment.
This class overrides `_getTopOffset` => rendering is perfect.
However, pointer detection is off.
Traced it back to this line.

## Description

The local pointer is relative to the left/top point of where the text begins.

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

I hate the naming of the methods in Text and subclasses.

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
