### PR TITLE
ci(): invoke tests after changelog action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: '🩺'
 on:
   pull_request:
     branches: [master]
-    paths-ignore: [CHANGELOG.md]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [master]
     paths-ignore: [CHANGELOG.md]
-  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [master]
     paths-ignore: [CHANGELOG.md]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -12,3 +12,12 @@ jobs:
     with:
       create: ${{ github.event.action == 'opened' }}
       update: ${{ github.event.changes.title.from != github.event.pull_request.title }}
+  # manually invoke workflows if the changelog has been updated beause they are skipped in this case
+  invoke-build:
+    needs: changelog
+    if: needs.changelog.result == 'success'
+    uses: ./.github/workflows/build.yml
+  invoke-tests:
+    needs: changelog
+    if: needs.changelog.result == 'success'
+    uses: ./.github/workflows/tests.yml

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -12,12 +12,3 @@ jobs:
     with:
       create: ${{ github.event.action == 'opened' }}
       update: ${{ github.event.changes.title.from != github.event.pull_request.title }}
-  # manually invoke workflows if the changelog has been updated beause they are skipped in this case
-  invoke-build:
-    needs: changelog
-    if: needs.changelog.result == 'success'
-    uses: ./.github/workflows/build.yml
-  invoke-tests:
-    needs: changelog
-    if: needs.changelog.result == 'success'
-    uses: ./.github/workflows/tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,8 @@ name: '🧪'
 on:
   push:
     branches: [master]
-    paths-ignore: [CHANGELOG.md]
   pull_request:
     branches: [master]
-    paths-ignore: [CHANGELOG.md]
 
 jobs:
   browser:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [master]
     paths-ignore: [CHANGELOG.md]
-  workflow_call:
 
 jobs:
   browser:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [master]
     paths-ignore: [CHANGELOG.md]
+  workflow_call:
 
 jobs:
   browser:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- BREAKING: fabric.util.makeElementSelectable / fabric.util.makeElementUnselectable are removed [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 - refactor(): Canvas DOM delegation to utility class [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 
 ## [6.0.0-beta7]


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

~~Since I have disabled tests when a change is made to the changelog they don't show up in the PR UI after the changelog finishes and it is vital they do.
It is used for one commit PRs because if you continue pushing then tests will start and everything is fine. There are other options I have been using (closing and re-opening a PR and I think I can invoke manually but it is annoying)
We could simply remove the `ignore-paths` directive instead of what I did in this PR.
Whatever you decide is good for me.~~

It didn't work so I removed `paths-ignore`

## Description

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
