### PR TITLE
fix(ClassRegistry) add the extended names to the registry

### DIFF
--- a/.codesandbox/templates/vanilla/src/index.ts
+++ b/.codesandbox/templates/vanilla/src/index.ts
@@ -1,10 +1,8 @@
-import * as fabric from 'fabric/dist/index.min.js';
+import * as fabric from 'fabric';
 import './styles.css';
 
 const el = document.getElementById('canvas');
 const canvas = new fabric.Canvas(el);
-
-window.fabric = fabric;
 
 //  edit from here
 canvas.setDimensions({

--- a/.codesandbox/templates/vanilla/src/index.ts
+++ b/.codesandbox/templates/vanilla/src/index.ts
@@ -1,8 +1,10 @@
-import * as fabric from 'fabric';
+import * as fabric from 'fabric/dist/index.min.js';
 import './styles.css';
 
 const el = document.getElementById('canvas');
 const canvas = new fabric.Canvas(el);
+
+window.fabric = fabric;
 
 //  edit from here
 canvas.setDimensions({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(classRegistry): make the registry name mandatory [#9007](https://github.com/fabricjs/fabric.js/pull/9007)
 - fix(lib): fix aligning_guideline zoom [#8998](https://github.com/fabricjs/fabric.js/pull/8998)
 - fix(IText): support control interaction in text editing mode [#8995](https://github.com/fabricjs/fabric.js/pull/8995)
 - fix(Textbox): `splitByGrapheme` measurements infix length bug [#8990](https://github.com/fabricjs/fabric.js/pull/8990)

--- a/src/ClassRegistry.ts
+++ b/src/ClassRegistry.ts
@@ -30,26 +30,16 @@ export class ClassRegistry {
     return constructor;
   }
 
-  setClass(classConstructor: any, classType?: string) {
-    if (classType) {
-      this[JSON].set(classType, classConstructor);
-    } else {
-      this[JSON].set(classConstructor.name, classConstructor);
-      // legacy
-      // @TODO: needs to be removed in fabric 7 or 8
-      this[JSON].set(classConstructor.name.toLowerCase(), classConstructor);
-    }
+  setClass(classConstructor: any, classType: string) {
+    this[JSON].set(classType, classConstructor);
   }
 
   getSVGClass(SVGTagName: string): any {
     return this[SVG].get(SVGTagName);
   }
 
-  setSVGClass(classConstructor: any, SVGTagName?: string) {
-    this[SVG].set(
-      SVGTagName ?? classConstructor.name.toLowerCase(),
-      classConstructor
-    );
+  setSVGClass(classConstructor: any, SVGTagName: string) {
+    this[SVG].set(SVGTagName, classConstructor);
   }
 }
 

--- a/src/Pattern/Pattern.ts
+++ b/src/Pattern/Pattern.ts
@@ -200,6 +200,6 @@ export class Pattern {
   }
 }
 
-classRegistry.setClass(Pattern);
+classRegistry.setClass(Pattern, 'Pattern');
 // kept for compatibility reason
 classRegistry.setClass(Pattern, 'pattern');

--- a/src/filters/BlendColor.ts
+++ b/src/filters/BlendColor.ts
@@ -214,4 +214,4 @@ export class BlendColor extends BaseFilter {
   }
 }
 
-classRegistry.setClass(BlendColor);
+classRegistry.setClass(BlendColor, 'BlendColor');

--- a/src/filters/BlendImage.ts
+++ b/src/filters/BlendImage.ts
@@ -225,4 +225,4 @@ export class BlendImage extends BaseFilter {
   }
 }
 
-classRegistry.setClass(BlendImage);
+classRegistry.setClass(BlendImage, 'BlendImage');

--- a/src/filters/Blur.ts
+++ b/src/filters/Blur.ts
@@ -176,4 +176,4 @@ export class Blur extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Blur);
+classRegistry.setClass(Blur, 'Blur');

--- a/src/filters/Brightness.ts
+++ b/src/filters/Brightness.ts
@@ -80,4 +80,4 @@ export class Brightness extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Brightness);
+classRegistry.setClass(Brightness, 'Brightness');

--- a/src/filters/ColorMatrix.ts
+++ b/src/filters/ColorMatrix.ts
@@ -142,4 +142,4 @@ export class ColorMatrix extends BaseFilter {
   }
 }
 
-classRegistry.setClass(ColorMatrix);
+classRegistry.setClass(ColorMatrix, 'ColorMatrix');

--- a/src/filters/Composed.ts
+++ b/src/filters/Composed.ts
@@ -73,4 +73,4 @@ export class Composed extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Composed);
+classRegistry.setClass(Composed, 'Composed');

--- a/src/filters/Contrast.ts
+++ b/src/filters/Contrast.ts
@@ -79,4 +79,4 @@ export class Contrast extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Contrast);
+classRegistry.setClass(Contrast, 'Contrast');

--- a/src/filters/Convolute.ts
+++ b/src/filters/Convolute.ts
@@ -181,4 +181,4 @@ export class Convolute extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Convolute);
+classRegistry.setClass(Convolute, 'Convolute');

--- a/src/filters/Gamma.ts
+++ b/src/filters/Gamma.ts
@@ -107,4 +107,4 @@ export class Gamma extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Gamma);
+classRegistry.setClass(Gamma, 'Gamma');

--- a/src/filters/Grayscale.ts
+++ b/src/filters/Grayscale.ts
@@ -99,4 +99,4 @@ export class Grayscale extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Grayscale);
+classRegistry.setClass(Grayscale, 'Grayscale');

--- a/src/filters/HueRotation.ts
+++ b/src/filters/HueRotation.ts
@@ -59,4 +59,4 @@ export class HueRotation extends ColorMatrix {
   }
 }
 
-classRegistry.setClass(HueRotation);
+classRegistry.setClass(HueRotation, 'HueRotation');

--- a/src/filters/Invert.ts
+++ b/src/filters/Invert.ts
@@ -96,4 +96,4 @@ export class Invert extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Invert);
+classRegistry.setClass(Invert, 'Invert');

--- a/src/filters/Noise.ts
+++ b/src/filters/Noise.ts
@@ -91,4 +91,4 @@ export class Noise extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Noise);
+classRegistry.setClass(Noise, 'Noise');

--- a/src/filters/Pixelate.ts
+++ b/src/filters/Pixelate.ts
@@ -93,4 +93,4 @@ export class Pixelate extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Pixelate);
+classRegistry.setClass(Pixelate, 'Pixelate');

--- a/src/filters/RemoveColor.ts
+++ b/src/filters/RemoveColor.ts
@@ -132,4 +132,4 @@ export class RemoveColor extends BaseFilter {
   }
 }
 
-classRegistry.setClass(RemoveColor);
+classRegistry.setClass(RemoveColor, 'RemoveColor');

--- a/src/filters/Resize.ts
+++ b/src/filters/Resize.ts
@@ -535,4 +535,4 @@ export class Resize extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Resize);
+classRegistry.setClass(Resize, 'Resize');

--- a/src/filters/Saturation.ts
+++ b/src/filters/Saturation.ts
@@ -84,4 +84,4 @@ export class Saturation extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Saturation);
+classRegistry.setClass(Saturation, 'Saturation');

--- a/src/filters/Vibrance.ts
+++ b/src/filters/Vibrance.ts
@@ -85,4 +85,4 @@ export class Vibrance extends BaseFilter {
   }
 }
 
-classRegistry.setClass(Vibrance);
+classRegistry.setClass(Vibrance, 'Vibrance');

--- a/src/gradient/Gradient.ts
+++ b/src/gradient/Gradient.ts
@@ -405,3 +405,4 @@ export class Gradient<
 }
 
 classRegistry.setClass(Gradient, 'gradient');
+classRegistry.setClass(Gradient, 'Gradient');

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -185,5 +185,5 @@ export class ActiveSelection extends Group {
   }
 }
 
-classRegistry.setClass(ActiveSelection);
-classRegistry.setClass(ActiveSelection, 'activeSelection');
+classRegistry.setClass(ActiveSelection, 'ActiveSelection');
+classRegistry.setClass(ActiveSelection, 'activeSelection'); // fabric 5 JSON compatibility

--- a/src/shapes/Circle.ts
+++ b/src/shapes/Circle.ts
@@ -230,5 +230,6 @@ export class Circle<
   }
 }
 
-classRegistry.setClass(Circle);
-classRegistry.setSVGClass(Circle);
+classRegistry.setClass(Circle, 'Circle');
+classRegistry.setClass(Circle, 'circle'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Circle, 'circle');

--- a/src/shapes/Ellipse.ts
+++ b/src/shapes/Ellipse.ts
@@ -171,5 +171,6 @@ export class Ellipse<
   /* _FROM_SVG_END_ */
 }
 
-classRegistry.setClass(Ellipse);
-classRegistry.setSVGClass(Ellipse);
+classRegistry.setClass(Ellipse, 'Ellipse');
+classRegistry.setClass(Ellipse, 'ellipse'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Ellipse, 'ellipse');

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -1098,4 +1098,5 @@ export class Group extends createCollectionMixin(
   }
 }
 
-classRegistry.setClass(Group);
+classRegistry.setClass(Group, 'Group');
+classRegistry.setClass(Group, 'group'); // fabric 5 JSON compatibility

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -689,6 +689,5 @@ export class IText<
   }
 }
 
-classRegistry.setClass(IText);
-// legacy
-classRegistry.setClass(IText, 'i-text');
+classRegistry.setClass(IText, 'IText');
+classRegistry.setClass(IText, 'i-text'); // fabric 5 JSON compatibility

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -842,5 +842,6 @@ export class Image<
   }
 }
 
-classRegistry.setClass(Image);
-classRegistry.setSVGClass(Image);
+classRegistry.setClass(Image, 'Image');
+classRegistry.setClass(Image, 'image'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Image, 'image');

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -279,5 +279,6 @@ export class Line<
   }
 }
 
-classRegistry.setClass(Line);
-classRegistry.setSVGClass(Line);
+classRegistry.setClass(Line, 'Line');
+classRegistry.setClass(Line, 'line'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Line, 'line');

--- a/src/shapes/Object/FabricObject.ts
+++ b/src/shapes/Object/FabricObject.ts
@@ -23,7 +23,7 @@ export class FabricObject<
 
 applyMixins(FabricObject, [FabricObjectSVGExportMixin]);
 
-classRegistry.setClass(FabricObject);
-classRegistry.setClass(FabricObject, 'object');
+classRegistry.setClass(FabricObject, 'FabricObject');
+classRegistry.setClass(FabricObject, 'object'); // fabric 5 JSON compatibility
 
 export { cacheProperties } from './defaultValues';

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -1573,5 +1573,5 @@ export class FabricObject<
   }
 }
 
-classRegistry.setClass(FabricObject);
-classRegistry.setClass(FabricObject, 'object');
+classRegistry.setClass(FabricObject, 'FabricObject');
+classRegistry.setClass(FabricObject, 'object'); // fabric 5 JSON compatibility

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -426,7 +426,6 @@ export class Path<
   }
 }
 
-classRegistry.setClass(Path);
-classRegistry.setSVGClass(Path);
-
-/* _FROM_SVG_START_ */
+classRegistry.setClass(Path, 'Path');
+classRegistry.setClass(Path, 'path'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Path, 'path');

--- a/src/shapes/Polygon.ts
+++ b/src/shapes/Polygon.ts
@@ -16,5 +16,6 @@ export class Polygon extends Polyline {
   }
 }
 
-classRegistry.setClass(Polygon);
-classRegistry.setSVGClass(Polygon);
+classRegistry.setClass(Polygon, 'Polygon');
+classRegistry.setClass(Polygon, 'polygon'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Polygon, 'polygon');

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -354,5 +354,6 @@ export class Polyline<
   }
 }
 
-classRegistry.setClass(Polyline);
-classRegistry.setSVGClass(Polyline);
+classRegistry.setClass(Polyline, 'Polyline');
+classRegistry.setClass(Polyline, 'polyline'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Polyline, 'polyline');

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -224,5 +224,6 @@ export class Rect<
   /* _FROM_SVG_END_ */
 }
 
-classRegistry.setClass(Rect);
-classRegistry.setSVGClass(Rect);
+classRegistry.setClass(Rect, 'Rect');
+classRegistry.setClass(Rect, 'rect'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Rect, 'rect');

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -1872,5 +1872,6 @@ export class Text<
 }
 
 applyMixins(Text, [TextSVGExportMixin]);
-classRegistry.setClass(Text);
-classRegistry.setSVGClass(Text);
+classRegistry.setClass(Text, 'Text');
+classRegistry.setClass(Text, 'text'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Text, 'text');

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -474,4 +474,5 @@ export class Textbox extends IText {
   }
 }
 
-classRegistry.setClass(Textbox);
+classRegistry.setClass(Textbox, 'Textbox');
+classRegistry.setClass(Textbox, 'textbox'); // fabric 5 JSON compatibility

--- a/src/shapes/Triangle.ts
+++ b/src/shapes/Triangle.ts
@@ -56,5 +56,6 @@ export class Triangle<
   }
 }
 
-classRegistry.setClass(Triangle);
-classRegistry.setSVGClass(Triangle);
+classRegistry.setClass(Triangle, 'Triangle');
+classRegistry.setClass(Triangle, 'triangle'); // fabric 5 JSON compatibility
+classRegistry.setSVGClass(Triangle, 'triangle');

--- a/test/unit/class_registry.js
+++ b/test/unit/class_registry.js
@@ -5,14 +5,6 @@
     assert.ok(fabric.classRegistry, 'classRegistry is available');
     assert.throws(() => classRegistry.getClass('rect'), new Error(`No class registered for rect`), 'initially Rect is undefined');
   });
-  QUnit.test('getClass will return specific class matched by name', function (assert) {
-    class TestClass {
-
-    }
-    classRegistry.setClass(TestClass);
-    assert.equal(classRegistry.getClass('TestClass'), TestClass, 'resolves class correctly');
-    assert.equal(classRegistry.getClass('testclass'), TestClass, 'resolves class correctly to lower case');
-  });
   QUnit.test('getClass will return specific class from custom type', function (assert) {
     class TestClass2 {
 


### PR DESCRIPTION
## Motivation

This is a pain because it brings back the topic of uppercase vs not.
Now that the class.constructor.name is not usable, there are 2 big issues:

- type / a string in the class  is again needed
- the old values for type are good enough but we can still move to the version similar to the class name becuase of consistency with filters that were always in that way.

This fixes the class registry:
<img width="885" alt="image" src="https://github.com/fabricjs/fabric.js/assets/1194048/014cc576-05e5-4b75-8d64-0c2190908ad7">

closes #9006


