### PR TITLE
fix(serialization): restore explict class type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(fabric): Fix the serialization and registry dependency from minification [#9009](https://github.com/fabricjs/fabric.js/pull/9009)
 - fix(lib): fix aligning_guideline zoom [#8998](https://github.com/fabricjs/fabric.js/pull/8998)
 - fix(IText): support control interaction in text editing mode [#8995](https://github.com/fabricjs/fabric.js/pull/8995)
 - fix(Textbox): `splitByGrapheme` measurements infix length bug [#8990](https://github.com/fabricjs/fabric.js/pull/8990)

--- a/src/ClassRegistry.ts
+++ b/src/ClassRegistry.ts
@@ -34,10 +34,10 @@ export class ClassRegistry {
     if (classType) {
       this[JSON].set(classType, classConstructor);
     } else {
-      this[JSON].set(classConstructor.name, classConstructor);
+      this[JSON].set(classConstructor.type, classConstructor);
       // legacy
       // @TODO: needs to be removed in fabric 7 or 8
-      this[JSON].set(classConstructor.name.toLowerCase(), classConstructor);
+      this[JSON].set(classConstructor.type.toLowerCase(), classConstructor);
     }
   }
 
@@ -47,7 +47,7 @@ export class ClassRegistry {
 
   setSVGClass(classConstructor: any, SVGTagName?: string) {
     this[SVG].set(
-      SVGTagName ?? classConstructor.name.toLowerCase(),
+      SVGTagName ?? classConstructor.type.toLowerCase(),
       classConstructor
     );
   }

--- a/src/Pattern/Pattern.ts
+++ b/src/Pattern/Pattern.ts
@@ -17,10 +17,12 @@ import type {
  * @see {@link http://fabricjs.com/dynamic-patterns demo}
  */
 export class Pattern {
+  static type = 'Pattern';
+
   /**
-   * Legacy identifier of the class. Prefer using this.constructor.name 'Pattern'
-   * or utils like isPattern
-   * Will be removed in fabric 7 or 8.
+   * Legacy identifier of the class. Prefer using this.constructor.type 'Pattern'
+   * or utils like isPattern, or instance of to indentify a pattern in your code.
+   * Will be removed in future versiones
    * @TODO add sustainable warning message
    * @type string
    * @deprecated

--- a/src/filters/BaseFilter.ts
+++ b/src/filters/BaseFilter.ts
@@ -22,8 +22,17 @@ export class BaseFilter {
    * @default
    */
   get type(): string {
-    return this.constructor.name;
+    return (this.constructor as typeof BaseFilter).type;
   }
+
+  /**
+   * The class type. Used to identify which class this is.
+   * This is used for serialization purposes and internally it can be used
+   * to identify classes. As a developer you could use `instance of Class`
+   * but to avoid importing all the code and blocking tree shaking we try
+   * to avoid doing that.
+   */
+  static type = 'BaseFilter';
 
   declare static defaults: Record<string, any>;
 

--- a/src/filters/BlendColor.ts
+++ b/src/filters/BlendColor.ts
@@ -66,6 +66,8 @@ export class BlendColor extends BaseFilter {
 
   static defaults = blendColorDefaultValues;
 
+  static type = 'BlendColor';
+
   getCacheKey() {
     return `${this.type}_${this.mode}`;
   }

--- a/src/filters/BlendImage.ts
+++ b/src/filters/BlendImage.ts
@@ -61,6 +61,8 @@ export class BlendImage extends BaseFilter {
    **/
   declare alpha: number;
 
+  static type = 'BlendImage';
+
   static defaults = blendImageDefaultValues;
 
   getCacheKey() {

--- a/src/filters/Blur.ts
+++ b/src/filters/Blur.ts
@@ -38,6 +38,8 @@ export class Blur extends BaseFilter {
   declare horizontal: boolean;
   declare aspectRatio: number;
 
+  static type = 'Blur';
+
   static defaults = blurDefaultValues;
 
   getFragmentSource(): string {

--- a/src/filters/Brightness.ts
+++ b/src/filters/Brightness.ts
@@ -27,6 +27,8 @@ export class Brightness extends BaseFilter {
    */
   declare brightness: number;
 
+  static type = 'Brightness';
+
   static defaults = brightnessDefaultValues;
 
   getFragmentSource() {

--- a/src/filters/ColorMatrix.ts
+++ b/src/filters/ColorMatrix.ts
@@ -45,6 +45,8 @@ export class ColorMatrix extends BaseFilter {
    */
   declare colorsOnly: boolean;
 
+  static type = 'ColorMatrix';
+
   static defaults = colorMatrixDefaultValues;
 
   setOptions({ matrix, ...options }: Record<string, any>) {

--- a/src/filters/ColorMatrixFilters.ts
+++ b/src/filters/ColorMatrixFilters.ts
@@ -7,6 +7,8 @@ export function createColorMatrixFilter(key: string, matrix: number[]) {
       return key;
     }
 
+    static type = key;
+
     static defaults = {
       ...colorMatrixDefaultValues,
       /**

--- a/src/filters/Composed.ts
+++ b/src/filters/Composed.ts
@@ -12,6 +12,8 @@ export class Composed extends BaseFilter {
    */
   declare subFilters: BaseFilter[];
 
+  static type = 'Composed';
+
   constructor({
     subFilters = [],
     ...options

--- a/src/filters/Contrast.ts
+++ b/src/filters/Contrast.ts
@@ -25,6 +25,8 @@ export class Contrast extends BaseFilter {
    */
   declare contrast: number;
 
+  static type = 'Contrast';
+
   static defaults = contrastDefaultValues;
 
   getFragmentSource() {

--- a/src/filters/Convolute.ts
+++ b/src/filters/Convolute.ts
@@ -60,6 +60,8 @@ export class Convolute extends BaseFilter {
    */
   declare matrix: number[];
 
+  static type = 'Convolute';
+
   static defaults = convoluteDefaultValues;
 
   getCacheKey() {

--- a/src/filters/Gamma.ts
+++ b/src/filters/Gamma.ts
@@ -32,6 +32,8 @@ export class Gamma extends BaseFilter {
     b: Uint8Array;
   };
 
+  static type = 'Gamma';
+
   static defaults = gammaDefaultValues;
 
   getFragmentSource() {

--- a/src/filters/Grayscale.ts
+++ b/src/filters/Grayscale.ts
@@ -21,6 +21,8 @@ export const grayscaleDefaultValues: Partial<TClassProperties<Grayscale>> = {
 export class Grayscale extends BaseFilter {
   declare mode: TGrayscaleMode;
 
+  static type = 'Grayscale';
+
   static defaults = grayscaleDefaultValues;
 
   /**

--- a/src/filters/HueRotation.ts
+++ b/src/filters/HueRotation.ts
@@ -27,6 +27,8 @@ export class HueRotation extends ColorMatrix {
    */
   declare rotation: number;
 
+  static type = 'HueRotation';
+
   static defaults = hueRotationDefaultValues;
 
   calculateMatrix() {

--- a/src/filters/Invert.ts
+++ b/src/filters/Invert.ts
@@ -31,6 +31,8 @@ export class Invert extends BaseFilter {
    */
   declare invert: boolean;
 
+  static type = 'Invert';
+
   static defaults = invertDefaultValues;
 
   /**

--- a/src/filters/Noise.ts
+++ b/src/filters/Noise.ts
@@ -27,6 +27,8 @@ export class Noise extends BaseFilter {
    */
   declare noise: number;
 
+  static type = 'Noise';
+
   static defaults = noiseDefaultValues;
 
   getFragmentSource() {

--- a/src/filters/Pixelate.ts
+++ b/src/filters/Pixelate.ts
@@ -21,6 +21,8 @@ export const pixelateDefaultValues: Partial<TClassProperties<Pixelate>> = {
 export class Pixelate extends BaseFilter {
   declare blocksize: number;
 
+  static type = 'Pixelate';
+
   static defaults = pixelateDefaultValues;
 
   /**

--- a/src/filters/RemoveColor.ts
+++ b/src/filters/RemoveColor.ts
@@ -41,6 +41,8 @@ export class RemoveColor extends BaseFilter {
    **/
   declare useAlpha: boolean;
 
+  static type = 'RemoveColor';
+
   static defaults = removeColorDefaultValues;
 
   getFragmentShader() {

--- a/src/filters/Resize.ts
+++ b/src/filters/Resize.ts
@@ -60,6 +60,8 @@ export class Resize extends BaseFilter {
 
   declare fragmentSourceTOP: string;
 
+  static type = 'Resize';
+
   static defaults = resizeDefaultValues;
 
   /**

--- a/src/filters/Saturation.ts
+++ b/src/filters/Saturation.ts
@@ -30,6 +30,8 @@ export class Saturation extends BaseFilter {
    */
   declare saturation: number;
 
+  static type = 'Saturation';
+
   static defaults = saturationDefaultValues;
 
   getFragmentSource() {

--- a/src/filters/Vibrance.ts
+++ b/src/filters/Vibrance.ts
@@ -29,6 +29,8 @@ export class Vibrance extends BaseFilter {
    */
   declare vibrance: number;
 
+  static type = 'Vibrance';
+
   static defaults = vibranceDefaultValues;
 
   getFragmentSource() {

--- a/src/gradient/Gradient.ts
+++ b/src/gradient/Gradient.ts
@@ -101,6 +101,8 @@ export class Gradient<
    */
   declare readonly id: string | number;
 
+  static type = 'Gradient';
+
   constructor({
     type = 'linear' as T,
     gradientUnits = 'pixels',

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -13,8 +13,11 @@ export class ActiveSelection extends Group {
    * meaning that the stack is ordered by the order in which objects were selected
    * @default `canvas-stacking`
    */
+  // TODO FIX THIS WITH THE DEFAULTS LOGIC
   multiSelectionStacking: 'canvas-stacking' | 'selection-order' =
     'canvas-stacking';
+
+  static type = 'ActiveSelection';
 
   constructor(
     objects?: FabricObject[],

--- a/src/shapes/Circle.ts
+++ b/src/shapes/Circle.ts
@@ -64,6 +64,8 @@ export class Circle<
   declare startAngle: number;
   declare endAngle: number;
 
+  static type = 'Circle';
+
   static cacheProperties = [...cacheProperties, ...CIRCLE_PROPS];
 
   static ownDefaults: Record<string, any> = circleDefaultValues;

--- a/src/shapes/Ellipse.ts
+++ b/src/shapes/Ellipse.ts
@@ -51,6 +51,8 @@ export class Ellipse<
    */
   declare ry: number;
 
+  static type = 'Ellipse';
+
   static cacheProperties = [...cacheProperties, ...ELLIPSE_PROPS];
 
   static ownDefaults: Record<string, any> = ellipseDefaultValues;

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -151,6 +151,8 @@ export class Group extends createCollectionMixin(
     'layout',
   ];
 
+  static type = 'Group';
+
   static ownDefaults: Record<string, any> = groupDefaultValues;
   private __objectSelectionTracker: (ev: ObjectEvents['selected']) => void;
   private __objectSelectionDisposer: (ev: ObjectEvents['deselected']) => void;

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -202,6 +202,8 @@ export class IText<
     return { ...super.getDefaults(), ...IText.ownDefaults };
   }
 
+  static type = 'IText';
+
   get type() {
     return 'i-text';
   }

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -170,6 +170,8 @@ export class Image<
   protected declare _originalElement: ImageSource;
   protected declare _filteredEl: ImageSource;
 
+  static type = 'Image';
+
   static cacheProperties = [...cacheProperties, ...IMAGE_PROPS];
 
   static ownDefaults: Record<string, any> = imageDefaultValues;

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -65,6 +65,8 @@ export class Line<
    */
   declare y2: number;
 
+  static type = 'Line';
+
   static cacheProperties = [...cacheProperties, ...coordProps];
   /**
    * Constructor

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -269,6 +269,15 @@ export class FabricObject<
   }
 
   /**
+   * The class type. Used to identify which class this is.
+   * This is used for serialization purposes and internally it can be used
+   * to identify classes. As a developer you could use `instance of Class`
+   * but to avoid importing all the code and blocking tree shaking we try
+   * to avoid doing that.
+   */
+  static type = 'FabricObject';
+
+  /**
    * Legacy identifier of the class. Prefer using utils like isType or instanceOf
    * Will be removed in fabric 7 or 8.
    * The setter exists because is very hard to catch all the ways in which a type value
@@ -278,7 +287,7 @@ export class FabricObject<
    * @deprecated
    */
   get type() {
-    const name = this.constructor.name;
+    const name = this.constructor.type;
     if (name === 'FabricObject') {
       return 'object';
     }
@@ -515,7 +524,7 @@ export class FabricObject<
           : null,
       object = {
         ...pick(this, propertiesToInclude as (keyof this)[]),
-        type: this.constructor.name,
+        type: this.constructor.type,
         version: VERSION,
         originX: this.originX,
         originY: this.originY,
@@ -609,7 +618,7 @@ export class FabricObject<
    * @return {String}
    */
   toString() {
-    return `#<${this.constructor.name}>`;
+    return `#<${this.constructor.type}>`;
   }
 
   /**
@@ -1454,7 +1463,7 @@ export class FabricObject<
    * @return {Boolean}
    */
   isType(...types: string[]) {
-    return types.includes(this.constructor.name) || types.includes(this.type);
+    return types.includes(this.constructor.type) || types.includes(this.type);
   }
 
   /**

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -287,7 +287,7 @@ export class FabricObject<
    * @deprecated
    */
   get type() {
-    const name = this.constructor.type;
+    const name = (this.constructor as typeof FabricObject).type;
     if (name === 'FabricObject') {
       return 'object';
     }
@@ -524,7 +524,7 @@ export class FabricObject<
           : null,
       object = {
         ...pick(this, propertiesToInclude as (keyof this)[]),
-        type: this.constructor.type,
+        type: (this.constructor as typeof FabricObject).type,
         version: VERSION,
         originX: this.originX,
         originY: this.originY,
@@ -618,7 +618,7 @@ export class FabricObject<
    * @return {String}
    */
   toString() {
-    return `#<${this.constructor.type}>`;
+    return `#<${(this.constructor as typeof FabricObject).type}>`;
   }
 
   /**
@@ -1463,7 +1463,10 @@ export class FabricObject<
    * @return {Boolean}
    */
   isType(...types: string[]) {
-    return types.includes(this.constructor.type) || types.includes(this.type);
+    return (
+      types.includes((this.constructor as typeof FabricObject).type) ||
+      types.includes(this.type)
+    );
   }
 
   /**

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -63,6 +63,8 @@ export class Path<
 
   declare segmentsInfo?: TPathSegmentInfo[];
 
+  static type = 'Path';
+
   static cacheProperties = [...cacheProperties, 'path', 'fillRule'];
 
   /**

--- a/src/shapes/Polygon.ts
+++ b/src/shapes/Polygon.ts
@@ -4,6 +4,8 @@ import { Polyline, polylineDefaultValues } from './Polyline';
 export class Polygon extends Polyline {
   static ownDefaults: Record<string, any> = polylineDefaultValues;
 
+  static type = 'Polygon';
+
   static getDefaults() {
     return {
       ...super.getDefaults(),

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -271,7 +271,11 @@ export class Polyline<
       );
     }
     return [
-      `<${this.constructor.type.toLowerCase() as 'polyline' | 'polygon'} `,
+      `<${
+        (this.constructor as typeof Polyline).type.toLowerCase() as
+          | 'polyline'
+          | 'polygon'
+      } `,
       'COMMON_PARTS',
       `points="${points.join('')}" />\n`,
     ];

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -55,6 +55,8 @@ export class Polyline<
 
   static ownDefaults: Record<string, any> = polylineDefaultValues;
 
+  static type = 'Polyline';
+
   static getDefaults() {
     return {
       ...super.getDefaults(),
@@ -269,7 +271,7 @@ export class Polyline<
       );
     }
     return [
-      `<${this.constructor.name.toLowerCase() as 'polyline' | 'polygon'} `,
+      `<${this.constructor.type.toLowerCase() as 'polyline' | 'polygon'} `,
       'COMMON_PARTS',
       `points="${points.join('')}" />\n`,
     ];

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -51,6 +51,8 @@ export class Rect<
    */
   declare ry: number;
 
+  static type = 'Rect';
+
   static cacheProperties = [...cacheProperties, ...RECT_PROPS];
 
   static ownDefaults: Record<string, any> = rectDefaultValues;

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -396,6 +396,8 @@ export class Text<
 
   static ownDefaults: Record<string, any> = textDefaultValues;
 
+  static type = 'Text';
+
   static getDefaults() {
     return { ...super.getDefaults(), ...Text.ownDefaults };
   }

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -47,6 +47,8 @@ export class Textbox extends IText {
    */
   declare splitByGrapheme: boolean;
 
+  static type = 'Textbox';
+
   static textLayoutProperties = [...IText.textLayoutProperties, 'width'];
 
   static ownDefaults: Record<string, any> = textboxDefaultValues;

--- a/src/shapes/Triangle.ts
+++ b/src/shapes/Triangle.ts
@@ -20,6 +20,8 @@ export class Triangle<
   extends FabricObject<Props, SProps, EventSpec>
   implements FabricObjectProps
 {
+  static type = 'Triangle';
+
   static ownDefaults: Record<string, any> = triangleDefaultValues;
 
   static getDefaults() {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -576,7 +576,7 @@
     });
     canvas.__onMouseUp({ target: canvas.upperCanvasEl });
     assert.equal(isFired, true, 'selection created fired');
-    assert.equal(canvas.getActiveObject().constructor.name, 'ActiveSelection', 'an active selection is created');
+    assert.equal(canvas.getActiveObject().constructor.type, 'ActiveSelection', 'an active selection is created');
     assert.equal(canvas.getActiveObjects()[0], rect1, 'rect1 is first object');
     assert.equal(canvas.getActiveObjects()[1], rect2, 'rect2 is second object');
     assert.equal(canvas.getActiveObjects()[2], rect3, 'rect3 is third object');
@@ -1258,7 +1258,7 @@
     var rect = makeRect();
     canvas.add(rect);
 
-    assert.equal(canvas.toObject().objects[0].type, rect.constructor.name);
+    assert.equal(canvas.toObject().objects[0].type, rect.constructor.type);
   });
 
 
@@ -1311,7 +1311,7 @@
     var rect = makeRect();
     canvasWithClipPath.add(rect);
 
-    assert.equal(canvasWithClipPath.toObject().objects[0].type, rect.constructor.name);
+    assert.equal(canvasWithClipPath.toObject().objects[0].type, rect.constructor.type);
   });
 
   QUnit.test('toDatalessObject', function(assert) {
@@ -1326,7 +1326,7 @@
     var rect = makeRect();
     canvas.add(rect);
 
-    assert.equal(canvas.toObject().objects[0].type, rect.constructor.name);
+    assert.equal(canvas.toObject().objects[0].type, rect.constructor.type);
     // TODO (kangax): need to test this method with fabric.Path to ensure that path is not populated
   });
 
@@ -1344,7 +1344,7 @@
       var obj = canvas.item(0);
 
       assert.ok(!canvas.isEmpty(), 'canvas is not empty');
-      assert.equal(obj.constructor.name, 'Path', 'first object is a path object');
+      assert.equal(obj.constructor.type, 'Path', 'first object is a path object');
       assert.equal(canvas.backgroundColor, '#ff5555', 'backgroundColor is populated properly');
       assert.equal(canvas.overlayColor, 'rgba(0,0,0,0.2)', 'overlayColor is populated properly');
 
@@ -1372,7 +1372,7 @@
       var obj = canvas.item(0);
 
       assert.ok(!canvas.isEmpty(), 'canvas is not empty');
-      assert.equal(obj.constructor.name, 'Path', 'first object is a path object');
+      assert.equal(obj.constructor.type, 'Path', 'first object is a path object');
       assert.equal(canvas.backgroundColor, '#ff5555', 'backgroundColor is populated properly');
       assert.equal(canvas.overlayColor, 'rgba(0,0,0,0.2)', 'overlayColor is populated properly');
 
@@ -1400,7 +1400,7 @@
       var obj = canvas.item(0);
 
       assert.ok(!canvas.isEmpty(), 'canvas is not empty');
-      assert.equal(obj.constructor.name, 'Path', 'first object is a path object');
+      assert.equal(obj.constructor.type, 'Path', 'first object is a path object');
       assert.equal(canvas.backgroundColor, '#ff5555', 'backgroundColor is populated properly');
       assert.equal(canvas.overlayColor, 'rgba(0,0,0,0.2)', 'overlayColor is populated properly');
 
@@ -1428,7 +1428,7 @@
     function reviver(obj, instance) {
       assert.deepEqual(obj, JSON.parse(PATH_OBJ_JSON));
 
-      if (instance.constructor.name === 'Path') {
+      if (instance.constructor.type === 'Path') {
         instance.customID = 'fabric_1';
       }
     }
@@ -1437,7 +1437,7 @@
       var obj = canvas.item(0);
 
       assert.ok(!canvas.isEmpty(), 'canvas is not empty');
-      assert.equal(obj.constructor.name, 'Path', 'first object is a path object');
+      assert.equal(obj.constructor.type, 'Path', 'first object is a path object');
       assert.equal(canvas.backgroundColor, '#ff5555', 'backgroundColor is populated properly');
       assert.equal(canvas.overlayColor, 'rgba(0,0,0,0.2)', 'overlayColor is populated properly');
 

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1055,7 +1055,7 @@
     var rect = makeRect();
     canvas.add(rect);
 
-    assert.equal(canvas.toObject().objects[0].type, rect.constructor.name);
+    assert.equal(canvas.toObject().objects[0].type, rect.constructor.type);
   });
 
   QUnit.test('toObject non includeDefaultValues', function(assert) {
@@ -1134,7 +1134,7 @@
     var rect = makeRect();
     canvas.add(rect);
 
-    assert.equal(canvas.toObject().objects[0].type, rect.constructor.name);
+    assert.equal(canvas.toObject().objects[0].type, rect.constructor.type);
     // TODO (kangax): need to test this method with fabric.Path to ensure that path is not populated
   });
 
@@ -1173,7 +1173,7 @@
       var obj = canvas.item(0);
 
       assert.ok(!canvas.isEmpty(), 'canvas is not empty');
-      assert.equal(obj.constructor.name, 'Path', 'first object is a path object');
+      assert.equal(obj.constructor.type, 'Path', 'first object is a path object');
       assert.equal(canvas.backgroundColor, '#ff5555', 'backgroundColor is populated properly');
 
       assert.equal(obj.get('left'), 268);
@@ -1202,7 +1202,7 @@
       var obj = canvas.item(0);
 
       assert.ok(!canvas.isEmpty(), 'canvas is not empty');
-      assert.equal(obj.constructor.name, 'Path', 'first object is a path object');
+      assert.equal(obj.constructor.type, 'Path', 'first object is a path object');
       assert.equal(canvas.backgroundColor, '#ff5555', 'backgroundColor is populated properly');
       assert.equal(canvas.overlayColor, 'rgba(0,0,0,0.2)', 'overlayColor is populated properly');
 
@@ -1233,7 +1233,7 @@
       var obj = canvas.item(0);
 
       assert.ok(!canvas.isEmpty(), 'canvas is not empty');
-      assert.equal(obj.constructor.name, 'Path', 'first object is a path object');
+      assert.equal(obj.constructor.type, 'Path', 'first object is a path object');
       assert.equal(canvas.backgroundColor, '#ff5555', 'backgroundColor is populated properly');
       assert.equal(canvas.overlayColor, 'rgba(0,0,0,0.2)', 'overlayColor is populated properly');
 
@@ -1315,7 +1315,7 @@
 
       canvas.renderAll();
 
-      assert.equal(canvas.item(0).constructor.name, 'Text');
+      assert.equal(canvas.item(0).constructor.type, 'Text');
       assert.equal(150, canvas.item(0).left);
       assert.equal(200, canvas.item(0).top);
       assert.equal('NAME HERE', canvas.item(0).text);
@@ -1330,7 +1330,7 @@
     var json = '{"clipPath": {"type":"Text","left":150,"top":200,"width":128,"height":64.32,"fill":"#000000","stroke":"","strokeWidth":"","scaleX":0.8,"scaleY":0.8,"angle":0,"flipX":false,"flipY":false,"opacity":1,"text":"NAME HERE","fontSize":24,"fontWeight":"","fontFamily":"Delicious_500","fontStyle":"","lineHeight":"","textDecoration":"","textAlign":"center","path":"","strokeStyle":"","backgroundColor":""}}';
     canvas3.loadFromJSON(json).then(function() {
       assert.ok(canvas3.clipPath instanceof fabric.Text);
-      assert.equal(canvas3.clipPath.constructor.name, 'Text');
+      assert.equal(canvas3.clipPath.constructor.type, 'Text');
       done();
     });
   });
@@ -1598,7 +1598,7 @@
       assert.notOk(cloned instanceof fabric.Canvas, 'is not cloned in a Canvas');
 
       var clonedRect = cloned.getObjects()[0];
-      assert.equal(clonedRect.constructor.name, 'Rect', 'the rect has been cloned too');
+      assert.equal(clonedRect.constructor.type, 'Rect', 'the rect has been cloned too');
       assert.equal(clonedRect.width, rect.width, 'the rect has been cloned too with properties');
       assert.equal(cloned.width, canvas2.width, 'the canvas has been cloned with properties');
       done();

--- a/test/unit/circle.js
+++ b/test/unit/circle.js
@@ -10,7 +10,7 @@
     assert.ok(circle instanceof fabric.Circle, 'should inherit from fabric.Circle');
     assert.ok(circle instanceof fabric.Object, 'should inherit from fabric.Object');
 
-    assert.deepEqual(circle.constructor.name, 'Circle');
+    assert.deepEqual(circle.constructor.type, 'Circle');
   });
 
   QUnit.test('constructor with radius', function(assert) {

--- a/test/unit/class_registry.js
+++ b/test/unit/class_registry.js
@@ -7,11 +7,12 @@
   });
   QUnit.test('getClass will return specific class matched by name', function (assert) {
     class TestClass {
-
+      static type = 'NonTestClass';
     }
     classRegistry.setClass(TestClass);
-    assert.equal(classRegistry.getClass('TestClass'), TestClass, 'resolves class correctly');
-    assert.equal(classRegistry.getClass('testclass'), TestClass, 'resolves class correctly to lower case');
+    assert.equal(classRegistry.getClass('NonTestClass'), TestClass, 'resolves class correctly');
+    assert.equal(classRegistry.getClass('nontestclass'), TestClass, 'resolves class correctly to lower case');
+    assert.throws(() => classRegistry.getClass('TestClass'), new Error(`No class registered for TestClass`), 'Does not resolve by class constructor name');
   });
   QUnit.test('getClass will return specific class from custom type', function (assert) {
     class TestClass2 {

--- a/test/unit/ellipse.js
+++ b/test/unit/ellipse.js
@@ -12,7 +12,7 @@
     assert.ok(ellipse instanceof fabric.Ellipse, 'should inherit from fabric.Ellipse');
     assert.ok(ellipse instanceof fabric.Object, 'should inherit from fabric.Object');
 
-    assert.equal(ellipse.constructor.name, 'Ellipse');
+    assert.equal(ellipse.constructor.type, 'Ellipse');
   });
 
   QUnit.test('complexity', function(assert) {

--- a/test/unit/image.js
+++ b/test/unit/image.js
@@ -118,7 +118,7 @@
       assert.ok(image instanceof fabric.Image);
       assert.ok(image instanceof fabric.Object);
 
-      assert.equal(image.constructor.name, 'Image');
+      assert.equal(image.constructor.type, 'Image');
 
       done();
     });

--- a/test/unit/itext.js
+++ b/test/unit/itext.js
@@ -73,7 +73,7 @@
       assert.ok(iText instanceof fabric.IText);
 
       assert.equal(iText.text, 'test');
-      assert.equal(iText.constructor.name, 'IText');
+      assert.equal(iText.constructor.type, 'IText');
       assert.deepEqual(iText.styles, { });
     });
 

--- a/test/unit/line.js
+++ b/test/unit/line.js
@@ -47,7 +47,7 @@
     assert.ok(line instanceof fabric.Line);
     assert.ok(line instanceof fabric.Object);
 
-    assert.equal(line.constructor.name, 'Line');
+    assert.equal(line.constructor.type, 'Line');
 
     assert.equal(line.get('x1'), 10);
     assert.equal(line.get('y1'), 11);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -293,7 +293,7 @@
 
   QUnit.test('toString', function (assert) {
     class Moo extends fabric.Object {
-      static type = 'moo'
+      static type = 'Moo'
     }
     var cObj = new fabric.Object();
     assert.equal(cObj.toString(), '#<FabricObject>');

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -27,7 +27,7 @@
     assert.ok(cObj instanceof fabric.Object);
     assert.ok(cObj.constructor === fabric.Object);
 
-    assert.equal(cObj.constructor.name, 'FabricObject');
+    assert.equal(cObj.constructor.type, 'FabricObject');
     assert.equal(cObj.includeDefaultValues, true);
     assert.equal(cObj.selectable, true);
 

--- a/test/unit/parser.js
+++ b/test/unit/parser.js
@@ -757,8 +757,8 @@
                   '</svg>';
 
     fabric.loadSVGFromString(string).then(({ objects }) => {
-      assert.equal(objects[0].clipPath.constructor.name, 'Polygon');
-      assert.equal(objects[0].clipPath.clipPath.constructor.name, 'Rect');
+      assert.equal(objects[0].clipPath.constructor.type, 'Polygon');
+      assert.equal(objects[0].clipPath.clipPath.constructor.type, 'Rect');
       done();
     });
   });
@@ -785,7 +785,7 @@
                  '</svg>';
 
     fabric.loadSVGFromString(string).then(({ objects }) => {
-      assert.equal(objects[0].constructor.name, 'Rect');
+      assert.equal(objects[0].constructor.type, 'Rect');
       done();
     });
   });
@@ -799,7 +799,7 @@
       '</svg>';
 
     fabric.loadSVGFromString(string).then(({ objects }) => {
-      assert.equal(objects[0].constructor.name, 'Rect');
+      assert.equal(objects[0].constructor.type, 'Rect');
       done();
     });
   });
@@ -816,7 +816,7 @@
       '</svg>';
 
     fabric.loadSVGFromString(string).then(({ objects }) => {
-      assert.equal(objects[0].constructor.name, 'Image');
+      assert.equal(objects[0].constructor.type, 'Image');
       done();
     });
   });

--- a/test/unit/path.js
+++ b/test/unit/path.js
@@ -80,7 +80,7 @@
       assert.ok(path instanceof fabric.Path);
       assert.ok(path instanceof fabric.Object);
 
-      assert.equal(path.constructor.name, 'Path');
+      assert.equal(path.constructor.type, 'Path');
 
       var error;
       try {

--- a/test/unit/polygon.js
+++ b/test/unit/polygon.js
@@ -61,7 +61,7 @@
     assert.ok(polygon instanceof fabric.Polyline);
     assert.ok(polygon instanceof fabric.Object);
 
-    assert.equal(polygon.constructor.name, 'Polygon');
+    assert.equal(polygon.constructor.type, 'Polygon');
     assert.deepEqual(polygon.get('points'), [{ x: 10, y: 12 }, { x: 20, y: 22 }]);
   });
 

--- a/test/unit/polyline.js
+++ b/test/unit/polyline.js
@@ -60,7 +60,7 @@
     assert.ok(polyline instanceof fabric.Polyline);
     assert.ok(polyline instanceof fabric.Object);
 
-    assert.equal(polyline.constructor.name, 'Polyline');
+    assert.equal(polyline.constructor.type, 'Polyline');
     assert.deepEqual(polyline.get('points'), [{ x: 10, y: 12 }, { x: 20, y: 22 }]);
   });
 

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -46,7 +46,7 @@
     assert.ok(rect instanceof fabric.Rect);
     assert.ok(rect instanceof fabric.Object);
 
-    assert.deepEqual(rect.constructor.name, 'Rect');
+    assert.deepEqual(rect.constructor.type, 'Rect');
   });
 
   QUnit.test('complexity', function(assert) {

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -75,7 +75,7 @@
     assert.ok(text instanceof fabric.Text);
     assert.ok(text instanceof fabric.Object);
 
-    assert.equal(text.constructor.name, 'Text');
+    assert.equal(text.constructor.type, 'Text');
     assert.equal(text.get('text'), 'x');
   });
 
@@ -885,7 +885,7 @@
     });
     var toObject = text.toObject();
     fabric.Text.fromObject(toObject).then(function(text) {
-      assert.equal(text.path.constructor.name, 'Path', 'the path is restored');
+      assert.equal(text.path.constructor.type, 'Path', 'the path is restored');
       assert.ok(text.path instanceof fabric.Path, 'the path is a path');
       assert.ok(toObject.path, 'the input has still a path property');
       done();

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -96,7 +96,7 @@
   QUnit.test('initial properties', function(assert) {
     var textbox = new fabric.Textbox('test');
     assert.equal(textbox.text, 'test');
-    assert.equal(textbox.constructor.name, 'Textbox');
+    assert.equal(textbox.constructor.type, 'Textbox');
     assert.deepEqual(textbox.styles, { });
     assert.ok(fabric.Textbox.cacheProperties.indexOf('width') > -1, 'width is in cacheProperties');
   });


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

During the migration to "modern js" we thought that having a `type` property on an instance was kind of a duplicate because classes have costructor.name that is basically what type was.

Dumbly enough we didn't think that minification would have changed variable names and so constructor.name.
This wasn't caught by tests since tests run on the non minified version of the code.

This PR aims at fixing:
#9006 and #9008 making #9007 obsolete.

It restores class type, as a static property that will take the place o constructor.name ( constructor.type ).
The compatibility getter for type on the instances is still there and will return the static type.

closes #9006 
closes #9008

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
