### PR TITLE
chore(TS): remove troublesome `AssertKeys` TS construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(TS): rm troublesome `AssertKeys` [#9012](https://github.com/fabricjs/fabric.js/pull/9012)
 - fix(lib): fix aligning_guideline zoom [#8998](https://github.com/fabricjs/fabric.js/pull/8998)
 - fix(IText): support control interaction in text editing mode [#8995](https://github.com/fabricjs/fabric.js/pull/8995)
 - fix(Textbox): `splitByGrapheme` measurements infix length bug [#8990](https://github.com/fabricjs/fabric.js/pull/8990)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- chore(TS): rm troublesome `AssertKeys` [#9012](https://github.com/fabricjs/fabric.js/pull/9012)
+- chore(TS): remove troublesome `AssertKeys` TS construct [#9012](https://github.com/fabricjs/fabric.js/pull/9012)
 - fix(lib): fix aligning_guideline zoom [#8998](https://github.com/fabricjs/fabric.js/pull/8998)
 - fix(IText): support control interaction in text editing mode [#8995](https://github.com/fabricjs/fabric.js/pull/8995)
 - fix(Textbox): `splitByGrapheme` measurements infix length bug [#8990](https://github.com/fabricjs/fabric.js/pull/8990)

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -12,7 +12,6 @@ import { Point } from '../Point';
 import type { Group } from '../shapes/Group';
 import type { IText } from '../shapes/IText/IText';
 import type { FabricObject } from '../shapes/Object/FabricObject';
-import type { AssertKeys } from '../typedefs';
 import { isTouchEvent, stopEvent } from '../util/dom_event';
 import { getDocumentFromElement, getWindowFromElement } from '../util/dom_misc';
 import { sendPointToPlane } from '../util/misc/planeChange';
@@ -339,14 +338,14 @@ export class Canvas extends SelectableCanvas {
     if (source) {
       ctx.save();
       source.transform(ctx);
-      (source as AssertKeys<FabricObject, 'canvas'>).renderDragSourceEffect(e);
+      source.renderDragSourceEffect(e);
       ctx.restore();
       dirty = true;
     }
     if (target) {
       ctx.save();
       target.transform(ctx);
-      (target as AssertKeys<FabricObject, 'canvas'>).renderDropTargetEffect(e);
+      target.renderDropTargetEffect(e);
       ctx.restore();
       dirty = true;
     }
@@ -1457,10 +1456,7 @@ export class Canvas extends SelectableCanvas {
    * @param {FabricObject} target target of event to select/deselect
    * @returns true if grouping occurred
    */
-  protected handleMultiSelection(
-    e: TPointerEvent,
-    target?: FabricObject
-  ): this is AssertKeys<this, '_activeObject'> {
+  protected handleMultiSelection(e: TPointerEvent, target?: FabricObject) {
     const activeObject = this._activeObject;
     const activeSelection = this._activeSelection;
     const isAS = activeObject === activeSelection;
@@ -1538,9 +1534,7 @@ export class Canvas extends SelectableCanvas {
    * ---
    * runs on mouse up
    */
-  protected handleSelection(
-    e: TPointerEvent
-  ): this is AssertKeys<this, '_activeObject'> {
+  protected handleSelection(e: TPointerEvent) {
     if (!this.selection || !this._groupSelector) {
       return false;
     }

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -19,13 +19,7 @@ import { StaticCanvas } from './StaticCanvas';
 import { isCollection } from '../util/typeAssertions';
 import { invertTransform, transformPoint } from '../util/misc/matrix';
 import { isTransparent } from '../util/misc/isTransparent';
-import type {
-  AssertKeys,
-  TMat2D,
-  TOriginX,
-  TOriginY,
-  TSize,
-} from '../typedefs';
+import type { TMat2D, TOriginX, TOriginY, TSize } from '../typedefs';
 import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { getPointer, isTouchEvent } from '../util/dom_event';
 import type { IText } from '../shapes/IText/IText';
@@ -36,7 +30,7 @@ import { sendPointToPlane } from '../util/misc/planeChange';
 import { ActiveSelection } from '../shapes/ActiveSelection';
 import { createCanvasElement } from '../util';
 import { CanvasDOMManager } from './DOMManagers/CanvasDOMManager';
-import { BOTTOM, CENTER, LEFT, NONE, RIGHT, TOP } from '../constants';
+import { BOTTOM, CENTER, LEFT, RIGHT, TOP } from '../constants';
 
 export const DefaultCanvasProperties = {
   uniformScaling: true,
@@ -1298,10 +1292,7 @@ export class SelectableCanvas<
    * @param {TPointerEvent} [e] Event (passed along when firing "object:selected")
    * @return {Boolean} true if the object has been selected
    */
-  setActiveObject(
-    object: FabricObject,
-    e?: TPointerEvent
-  ): this is AssertKeys<this, '_activeObject'> {
+  setActiveObject(object: FabricObject, e?: TPointerEvent) {
     // we can't inline this, since _setActiveObject will change what getActiveObjects returns
     const currentActives = this.getActiveObjects();
     const selected = this._setActiveObject(object, e);
@@ -1317,10 +1308,7 @@ export class SelectableCanvas<
    * @param {Event} [e] Event (passed along when firing "object:selected")
    * @return {Boolean} true if the object has been selected
    */
-  _setActiveObject(
-    object: FabricObject,
-    e?: TPointerEvent
-  ): this is AssertKeys<this, '_activeObject'> {
+  _setActiveObject(object: FabricObject, e?: TPointerEvent) {
     if (this._activeObject === object) {
       return false;
     }

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -7,7 +7,7 @@ import {
   keysMap,
   keysMapRtl,
 } from './constants';
-import type { AssertKeys, TFiller } from '../../typedefs';
+import type { TFiller } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import type { SerializedTextProps, TextProps } from '../Text/Text';
 import {
@@ -542,11 +542,11 @@ export class IText<
   /**
    * Renders drag start text selection
    */
-  renderDragSourceEffect(this: AssertKeys<this, 'canvas'>) {
+  renderDragSourceEffect() {
     const dragStartSelection =
       this.draggableTextDelegate.getDragStartSelection()!;
     this._renderSelection(
-      this.canvas.contextTop,
+      this.canvas!.contextTop,
       dragStartSelection,
       this._getCursorBoundaries(dragStartSelection.selectionStart, true)
     );

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -1,5 +1,5 @@
 import { Point } from '../../Point';
-import type { AssertKeys, TCornerPoint, TDegree } from '../../typedefs';
+import type { TCornerPoint, TDegree } from '../../typedefs';
 import { FabricObject } from './Object';
 import { degreesToRadians } from '../../util/misc/radiansDegreesConversion';
 import type { TQrDecomposeOut } from '../../util/misc/matrix';
@@ -650,7 +650,7 @@ export class InteractiveFabricObject<
    * @param {DragEvent} e
    * @returns {boolean}
    */
-  renderDragSourceEffect(this: AssertKeys<this, 'canvas'>, e: DragEvent) {
+  renderDragSourceEffect(e: DragEvent) {
     // for subclasses
   }
 
@@ -663,7 +663,7 @@ export class InteractiveFabricObject<
    * @param {DragEvent} e
    * @returns {boolean}
    */
-  renderDropTargetEffect(this: AssertKeys<this, 'canvas'>, e: DragEvent) {
+  renderDropTargetEffect(e: DragEvent) {
     // for subclasses
   }
 }

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -112,8 +112,6 @@ export type TDataUrlOptions = TToCanvasElementOptions & {
   enableRetinaScaling?: boolean;
 };
 
-export type AssertKeys<T, K extends keyof T> = T & Record<K, NonNullable<T[K]>>;
-
 export type Abortable = {
   /**
    * handle aborting


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

Working on fabric, subclassing and experiencing annoying TS errors/warnings

## Description

TS is limited. I tried to hack it to provide a state/control flow to class methods but that can't be done.
So useless IMO.
But I was engaged in a conversation that tried to enlighten me.
@asturur now that there are devs that are much more TS fans than I.
Let me state plainly that v6 has made me appreciate the amount of trouble TS can cause.
Classes also.
JS/TS engineers please save the future of this language.

<!-- What you are proposing -->

## Changes

Remove `AssertKeys` and silence TS
<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
