### PR TITLE
ci(): Revert "invoke tests after changelog action (#8974)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: '🩺'
 on:
   pull_request:
     branches: [master]
+    paths-ignore: [CHANGELOG.md]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,10 @@ name: '🧪'
 on:
   push:
     branches: [master]
+    paths-ignore: [CHANGELOG.md]
   pull_request:
     branches: [master]
+    paths-ignore: [CHANGELOG.md]
 
 jobs:
   browser:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - ci(): warn build errors in dev mode [#8971](https://github.com/fabricjs/fabric.js/pull/8971)
 - ci(): invoke tests after changelog action [#8974](https://github.com/fabricjs/fabric.js/pull/8974)
 - chore(TS): Export more types [#8965](https://github.com/fabricjs/fabric.js/pull/8965)
+- chore(TS): Export more types  [#8965](https://github.com/fabricjs/fabric.js/pull/8965)
 - BREAKING: fabric.util.makeElementSelectable / fabric.util.makeElementUnselectable are removed [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 - refactor(): Canvas DOM delegation to utility class [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): Revert "invoke tests after changelog action (#8974)" [#9013](https://github.com/fabricjs/fabric.js/pull/9013)
 - fix(lib): fix aligning_guideline zoom [#8998](https://github.com/fabricjs/fabric.js/pull/8998)
 - fix(IText): support control interaction in text editing mode [#8995](https://github.com/fabricjs/fabric.js/pull/8995)
 - fix(Textbox): `splitByGrapheme` measurements infix length bug [#8990](https://github.com/fabricjs/fabric.js/pull/8990)
@@ -15,7 +16,6 @@
 - ci(): warn build errors in dev mode [#8971](https://github.com/fabricjs/fabric.js/pull/8971)
 - ci(): invoke tests after changelog action [#8974](https://github.com/fabricjs/fabric.js/pull/8974)
 - chore(TS): Export more types [#8965](https://github.com/fabricjs/fabric.js/pull/8965)
-- chore(TS): Export more types  [#8965](https://github.com/fabricjs/fabric.js/pull/8965)
 - BREAKING: fabric.util.makeElementSelectable / fabric.util.makeElementUnselectable are removed [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 - refactor(): Canvas DOM delegation to utility class [#8930](https://github.com/fabricjs/fabric.js/pull/8930)
 


### PR DESCRIPTION
This reverts commit d5a955325a5ad9a521cd2b5831a768776dbddbf2.

<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

It was supposed to make CI trigger after the changelog action but github is smarter than that, at least we can trust github (if not TS).
So I will close and reopen a PR to make the test UI visible

## Description

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
