### PR TITLE
Fix toObject TS issues

### DIFF
--- a/fabric.ts
+++ b/fabric.ts
@@ -36,23 +36,33 @@ export { SprayBrush } from './src/brushes/SprayBrush';
 export { PatternBrush } from './src/brushes/PatternBrush';
 
 export { FabricObject as Object } from './src/shapes/Object/FabricObject';
-export type { TProps } from './src/shapes/Object/types';
+export type { TProps, SerializedObjectProps } from './src/shapes/Object/types';
 export { Line } from './src/shapes/Line';
+export type { SerializedLineProps } from './src/shapes/Line';
 export { Circle } from './src/shapes/Circle';
+export type { SerializedCircleProps } from './src/shapes/Circle';
 export { Triangle } from './src/shapes/Triangle';
 export { Ellipse } from './src/shapes/Ellipse';
+export type { SerializedEllipseProps } from './src/shapes/Ellipse';
 export { Rect } from './src/shapes/Rect';
+export type { SerializedRectProps } from './src/shapes/Rect';
 export { Path } from './src/shapes/Path';
+export type { SerializedPathProps } from './src/shapes/Path';
 export { Polyline } from './src/shapes/Polyline';
+export type { SerializedPolylineProps } from './src/shapes/Polyline';
 export { Polygon } from './src/shapes/Polygon';
 export { Text } from './src/shapes/Text/Text';
+export type { SerializedTextProps } from './src/shapes/Text/Text';
 export { IText } from './src/shapes/IText/IText';
+export type { SerializedITextProps } from './src/shapes/IText/IText';
 export { Textbox } from './src/shapes/Textbox';
+export type { SerializedTextboxProps } from './src/shapes/Textbox';
 export type {
   TextStyleDeclaration,
   TextStyle,
 } from './src/shapes/Text/StyledText';
 export { Group } from './src/shapes/Group';
+export type { SerializedGroupProps } from './src/shapes/Group';
 export { ActiveSelection } from './src/shapes/ActiveSelection';
 export { Image } from './src/shapes/Image';
 export type {

--- a/src/shapes/Circle.ts
+++ b/src/shapes/Circle.ts
@@ -6,7 +6,6 @@ import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { sin } from '../util/misc/sin';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
-import type { TClassProperties } from '../typedefs';
 import type {
   FabricObjectProps,
   SerializedObjectProps,
@@ -54,10 +53,9 @@ export const circleDefaultValues: UniqueCircleProps = {
 
 export class Circle<
     Props extends TProps<CircleProps> = Partial<CircleProps>,
-    SProps extends SerializedCircleProps = SerializedCircleProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends FabricObject<Props, SProps, EventSpec>
+  extends FabricObject<Props, EventSpec>
   implements UniqueCircleProps
 {
   declare radius: number;
@@ -136,10 +134,9 @@ export class Circle<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} object representation of an instance
    */
-  toObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedCircleProps> = []
+  ): SerializedCircleProps {
     return super.toObject([...CIRCLE_PROPS, ...propertiesToInclude]);
   }
 

--- a/src/shapes/Ellipse.ts
+++ b/src/shapes/Ellipse.ts
@@ -1,7 +1,6 @@
 import { twoMathPi } from '../constants';
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { TClassProperties } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
 import type {
@@ -31,10 +30,9 @@ const ELLIPSE_PROPS = ['rx', 'ry'] as const;
 
 export class Ellipse<
     Props extends TProps<EllipseProps> = Partial<EllipseProps>,
-    SProps extends SerializedEllipseProps = SerializedEllipseProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends FabricObject<Props, SProps, EventSpec>
+  extends FabricObject<Props, EventSpec>
   implements EllipseProps
 {
   /**
@@ -105,10 +103,9 @@ export class Ellipse<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} object representation of an instance
    */
-  toObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedEllipseProps> = []
+  ): SerializedEllipseProps {
     return super.toObject([...ELLIPSE_PROPS, ...propertiesToInclude]);
   }
 

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -4,7 +4,7 @@ import { createCollectionMixin } from '../Collection';
 import { resolveOrigin } from '../util/misc/resolveOrigin';
 import { Point } from '../Point';
 import { cos } from '../util/misc/cos';
-import type { TClassProperties, TSVGReviver } from '../typedefs';
+import type { TSVGReviver } from '../typedefs';
 import { makeBoundingBoxFromPoints } from '../util/misc/boundingBoxFromPoints';
 import {
   invertTransform,
@@ -111,7 +111,7 @@ export const groupDefaultValues = {
  * @fires layout once layout completes
  */
 export class Group extends createCollectionMixin(
-  FabricObject<GroupProps, SerializedGroupProps, GroupEvents>
+  FabricObject<GroupProps, GroupEvents>
 ) {
   /**
    * Specifies the **layout strategy** for instance
@@ -985,13 +985,9 @@ export class Group extends createCollectionMixin(
    * @param {string[]} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} object representation of an instance
    */
-  toObject<
-    T extends Omit<
-      GroupProps & TClassProperties<this>,
-      keyof SerializedGroupProps
-    >,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SerializedGroupProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedGroupProps> = []
+  ): SerializedGroupProps {
     return {
       ...super.toObject([
         'layout',

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -104,10 +104,9 @@ export interface ITextProps extends TextProps, UniqueITextProps {}
  */
 export class IText<
     Props extends ITextProps = ITextProps,
-    SProps extends SerializedITextProps = SerializedITextProps,
     EventSpec extends ITextEvents = ITextEvents
   >
-  extends ITextClickBehavior<Props, SProps, EventSpec>
+  extends ITextClickBehavior<Props, EventSpec>
   implements UniqueITextProps
 {
   /**

--- a/src/shapes/IText/ITextBehavior.ts
+++ b/src/shapes/IText/ITextBehavior.ts
@@ -10,7 +10,7 @@ import { animate } from '../../util/animation/animate';
 import type { TOnAnimationChangeCallback } from '../../util/animation/types';
 import type { ValueAnimation } from '../../util/animation/ValueAnimation';
 import type { TextStyleDeclaration } from '../Text/StyledText';
-import type { SerializedTextProps, TextProps } from '../Text/Text';
+import type { TextProps } from '../Text/Text';
 import type { TProps } from '../Object/types';
 import { getDocumentFromElement } from '../../util/dom_misc';
 import { LEFT, RIGHT } from '../../constants';
@@ -40,9 +40,8 @@ export type ITextEvents = ObjectEvents & {
 
 export abstract class ITextBehavior<
   Props extends TProps<TextProps> = Partial<TextProps>,
-  SProps extends SerializedTextProps = SerializedTextProps,
   EventSpec extends ITextEvents = ITextEvents
-> extends Text<Props, SProps, EventSpec> {
+> extends Text<Props, EventSpec> {
   declare abstract isEditing: boolean;
   declare abstract cursorDelay: number;
   declare abstract selectionStart: number;

--- a/src/shapes/IText/ITextClickBehavior.ts
+++ b/src/shapes/IText/ITextClickBehavior.ts
@@ -8,7 +8,7 @@ import { DraggableTextDelegate } from './DraggableTextDelegate';
 import type { ITextEvents } from './ITextBehavior';
 import { ITextKeyBehavior } from './ITextKeyBehavior';
 import type { TProps } from '../Object/types';
-import type { TextProps, SerializedTextProps } from '../Text/Text';
+import type { TextProps } from '../Text/Text';
 
 // TODO: this code seems wrong.
 // e.button for a left click is `0` and so different than `1` is more
@@ -19,10 +19,9 @@ function notALeftClick(e: MouseEvent) {
 
 export abstract class ITextClickBehavior<
     Props extends TProps<TextProps> = Partial<TextProps>,
-    SProps extends SerializedTextProps = SerializedTextProps,
     EventSpec extends ITextEvents = ITextEvents
   >
-  extends ITextKeyBehavior<Props, SProps, EventSpec>
+  extends ITextKeyBehavior<Props, EventSpec>
   implements DragMethods
 {
   private declare __lastSelected: boolean;

--- a/src/shapes/IText/ITextKeyBehavior.ts
+++ b/src/shapes/IText/ITextKeyBehavior.ts
@@ -7,15 +7,14 @@ import type { ITextEvents } from './ITextBehavior';
 import { ITextBehavior } from './ITextBehavior';
 import type { TKeyMapIText } from './constants';
 import type { TProps } from '../Object/types';
-import type { TextProps, SerializedTextProps } from '../Text/Text';
+import type { TextProps } from '../Text/Text';
 import { getDocumentFromElement } from '../../util/dom_misc';
 import { LEFT, RIGHT } from '../../constants';
 
 export abstract class ITextKeyBehavior<
   Props extends TProps<TextProps> = Partial<TextProps>,
-  SProps extends SerializedTextProps = SerializedTextProps,
   EventSpec extends ITextEvents = ITextEvents
-> extends ITextBehavior<Props, SProps, EventSpec> {
+> extends ITextBehavior<Props, EventSpec> {
   /**
    * For functionalities on keyDown
    * Map a special key to a function of the instance/prototype

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -4,7 +4,7 @@ import type { BaseFilter } from '../filters/BaseFilter';
 import { getFilterBackend } from '../filters/FilterBackend';
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { TClassProperties, TSize } from '../typedefs';
+import type { TSize } from '../typedefs';
 import type { Abortable } from '../typedefs';
 import { uid } from '../util/internals/uid';
 import { createCanvasElement } from '../util/misc/dom';
@@ -73,10 +73,9 @@ const IMAGE_PROPS = ['cropX', 'cropY'] as const;
  */
 export class Image<
     Props extends TProps<ImageProps> = Partial<ImageProps>,
-    SProps extends SerializedImageProps = SerializedImageProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends FabricObject<Props, SProps, EventSpec>
+  extends FabricObject<Props, EventSpec>
   implements ImageProps
 {
   /**
@@ -317,10 +316,9 @@ export class Image<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} Object representation of an instance
    */
-  toObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedImageProps> = []
+  ): SerializedImageProps {
     const filters: Record<string, any>[] = [];
     this.filters.forEach((filterObj) => {
       filterObj && filters.push(filterObj.toObject());

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -1,6 +1,5 @@
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { TClassProperties } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
 import { Point } from '../Point';
@@ -31,10 +30,9 @@ export interface SerializedLineProps
 
 export class Line<
     Props extends TProps<FabricObjectProps> = Partial<FabricObjectProps>,
-    SProps extends SerializedLineProps = SerializedLineProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends FabricObject<Props, SProps, EventSpec>
+  extends FabricObject<Props, EventSpec>
   implements UniqueLineProps
 {
   /**
@@ -157,10 +155,9 @@ export class Line<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} object representation of an instance
    */
-  toObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedLineProps> = []
+  ): SerializedLineProps {
     return {
       ...super.toObject(propertiesToInclude),
       ...this.calcLinePoints(),

--- a/src/shapes/Object/FabricObject.ts
+++ b/src/shapes/Object/FabricObject.ts
@@ -3,7 +3,7 @@ import { FabricObjectSVGExportMixin } from './FabricObjectSVGExportMixin';
 import { InteractiveFabricObject } from './InteractiveObject';
 import { applyMixins } from '../../util/applyMixins';
 import type { FabricObjectProps } from './types/FabricObjectProps';
-import type { TFabricObjectProps, SerializedObjectProps } from './types';
+import type { TFabricObjectProps } from './types';
 import { classRegistry } from '../../ClassRegistry';
 
 // TODO somehow we have to make a tree-shakeable import
@@ -11,15 +11,13 @@ import { classRegistry } from '../../ClassRegistry';
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unused-vars
 export interface FabricObject<
   Props extends TFabricObjectProps = Partial<FabricObjectProps>,
-  SProps extends SerializedObjectProps = SerializedObjectProps,
   EventSpec extends ObjectEvents = ObjectEvents
 > extends FabricObjectSVGExportMixin {}
 
 export class FabricObject<
   Props extends TFabricObjectProps = Partial<FabricObjectProps>,
-  SProps extends SerializedObjectProps = SerializedObjectProps,
   EventSpec extends ObjectEvents = ObjectEvents
-> extends InteractiveFabricObject<Props, SProps, EventSpec> {}
+> extends InteractiveFabricObject<Props, EventSpec> {}
 
 applyMixins(FabricObject, [FabricObjectSVGExportMixin]);
 

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -15,7 +15,7 @@ import type { ObjectEvents, TPointerEvent } from '../../EventTypeDefs';
 import type { Canvas } from '../../canvas/Canvas';
 import type { ControlRenderingStyleOverride } from '../../controls/controlRendering';
 import type { FabricObjectProps } from './types/FabricObjectProps';
-import type { TFabricObjectProps, SerializedObjectProps } from './types';
+import type { TFabricObjectProps } from './types';
 import { createObjectDefaultControls } from '../../controls/commonControls';
 
 type TOCoord = Point & {
@@ -48,10 +48,9 @@ const interactiveDefaults = {};
 
 export class InteractiveFabricObject<
     Props extends TFabricObjectProps = Partial<FabricObjectProps>,
-    SProps extends SerializedObjectProps = SerializedObjectProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends FabricObject<Props, SProps, EventSpec>
+  extends FabricObject<Props, EventSpec>
   implements FabricObjectProps
 {
   declare noScaleCache: boolean;

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -49,9 +49,8 @@ import {
 import type { Gradient } from '../../gradient/Gradient';
 import type { Pattern } from '../../Pattern';
 import type { Canvas } from '../../canvas/Canvas';
-import type { SerializedObjectProps } from './types/SerializedObjectProps';
 import type { ObjectProps } from './types/ObjectProps';
-import type { TProps } from './types';
+import type { SerializedObjectProps, TProps } from './types';
 import { getEnv } from '../../env';
 
 export type TCachedFabricObject = FabricObject &
@@ -99,7 +98,6 @@ export type TCachedFabricObject = FabricObject &
  */
 export class FabricObject<
     Props extends TProps<ObjectProps> = Partial<ObjectProps>,
-    SProps extends SerializedObjectProps = SerializedObjectProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
   extends AnimatableObject<EventSpec>

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -24,7 +24,7 @@ import type {
   TProps,
 } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
-import type { TBBox, TClassProperties, TSVGReviver } from '../typedefs';
+import type { TBBox, TSVGReviver } from '../typedefs';
 import { cloneDeep } from '../util/internals/cloneDeep';
 import { CENTER, LEFT, TOP } from '../constants';
 
@@ -47,9 +47,8 @@ export interface IPathBBox extends TBBox {
 
 export class Path<
   Props extends TProps<PathProps> = Partial<PathProps>,
-  SProps extends SerializedPathProps = SerializedPathProps,
   EventSpec extends ObjectEvents = ObjectEvents
-> extends FabricObject<Props, SProps, EventSpec> {
+> extends FabricObject<Props, EventSpec> {
   /**
    * Array of path points
    * @type Array
@@ -198,10 +197,9 @@ export class Path<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} object representation of an instance
    */
-  toObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedPathProps> = []
+  ): SerializedPathProps {
     return {
       ...super.toObject(propertiesToInclude),
       path: cloneDeep(this.path),
@@ -213,11 +211,10 @@ export class Path<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} object representation of an instance
    */
-  toDatalessObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
-    const o = this.toObject<T, K>(propertiesToInclude);
+  toDatalessObject(
+    propertiesToInclude: Array<keyof SerializedPathProps> = []
+  ): SerializedPathProps {
+    const o = this.toObject(propertiesToInclude);
     if (this.sourcePath) {
       delete o.path;
       o.sourcePath = this.sourcePath;

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -30,9 +30,8 @@ export interface SerializedPolylineProps extends SerializedObjectProps {
 
 export class Polyline<
   Props extends TProps<FabricObjectProps> = Partial<FabricObjectProps>,
-  SProps extends SerializedPolylineProps = SerializedPolylineProps,
   EventSpec extends ObjectEvents = ObjectEvents
-> extends FabricObject<Props, SProps, EventSpec> {
+> extends FabricObject<Props, EventSpec> {
   /**
    * Points array
    * @type Array
@@ -239,10 +238,9 @@ export class Polyline<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} Object representation of an instance
    */
-  toObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedPolylineProps> = []
+  ): SerializedPolylineProps {
     return {
       ...super.toObject(propertiesToInclude),
       points: cloneDeep(this.points),

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -31,10 +31,9 @@ const RECT_PROPS = ['rx', 'ry'] as const;
 
 export class Rect<
     Props extends TProps<RectProps> = Partial<RectProps>,
-    SProps extends SerializedRectProps = SerializedRectProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends FabricObject<Props, SProps, EventSpec>
+  extends FabricObject<Props, EventSpec>
   implements RectProps
 {
   /**
@@ -148,10 +147,9 @@ export class Rect<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} object representation of an instance
    */
-  toObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedRectProps> = []
+  ): SerializedRectProps {
     return super.toObject([...RECT_PROPS, ...propertiesToInclude]);
   }
 

--- a/src/shapes/Text/StyledText.ts
+++ b/src/shapes/Text/StyledText.ts
@@ -1,9 +1,5 @@
 import type { ObjectEvents } from '../../EventTypeDefs';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from '../Object/types';
+import type { FabricObjectProps, TProps } from '../Object/types';
 import { FabricObject } from '../Object/FabricObject';
 import { styleProperties } from './constants';
 import type { StylePropertiesType } from './constants';
@@ -18,9 +14,8 @@ export type TextStyle = {
 
 export abstract class StyledText<
   Props extends TProps<FabricObjectProps> = Partial<FabricObjectProps>,
-  SProps extends SerializedObjectProps = SerializedObjectProps,
   EventSpec extends ObjectEvents = ObjectEvents
-> extends FabricObject<Props, SProps, EventSpec> {
+> extends FabricObject<Props, EventSpec> {
   declare abstract styles: TextStyle;
   protected declare abstract _textLines: string[][];
   protected declare _forceClearCache: boolean;

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -7,11 +7,7 @@ import { StyledText } from './StyledText';
 import { SHARED_ATTRIBUTES } from '../../parser/attributes';
 import { parseAttributes } from '../../parser/parseAttributes';
 import type { Point } from '../../Point';
-import type {
-  TCacheCanvasDimensions,
-  TClassProperties,
-  TFiller,
-} from '../../typedefs';
+import type { TCacheCanvasDimensions, TFiller } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import { graphemeSplit } from '../../util/lang_string';
 import { createCanvasElement } from '../../util/misc/dom';
@@ -40,6 +36,7 @@ import {
   JUSTIFY_RIGHT,
 } from './constants';
 import { CENTER, LEFT, RIGHT, TOP, BOTTOM } from '../../constants';
+import { SerializedITextProps } from '../IText/IText';
 
 let measuringContext: CanvasRenderingContext2D | null;
 
@@ -108,10 +105,9 @@ export interface TextProps extends FabricObjectProps, UniqueTextProps {}
  */
 export class Text<
     Props extends TProps<TextProps> = Partial<TextProps>,
-    SProps extends SerializedTextProps = SerializedTextProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends StyledText<Props, SProps, EventSpec>
+  extends StyledText<Props, EventSpec>
   implements UniqueTextProps
 {
   /**
@@ -1691,10 +1687,9 @@ export class Text<
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} Object representation of an instance
    */
-  toObject<
-    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
-    K extends keyof T = never
-  >(propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedITextProps> = []
+  ): SerializedITextProps {
     return {
       ...super.toObject([...additionalProps, ...propertiesToInclude]),
       styles: stylesToArray(this.styles, this.text),

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -1,9 +1,11 @@
 // @ts-nocheck
 import type { TClassProperties } from '../typedefs';
-import { IText } from './IText/IText';
+import { IText, ITextProps, SerializedITextProps } from './IText/IText';
 import { classRegistry } from '../ClassRegistry';
 import { createTextboxDefaultControls } from '../controls/commonControls';
 import { JUSTIFY } from './Text/constants';
+import { TProps } from './Object/types';
+import { ITextEvents } from './IText/ITextBehavior';
 // @TODO: Many things here are configuration related and shouldn't be on the class nor prototype
 // regexes, list of properties that are not suppose to change by instances, magic consts.
 // this will be a separated effort
@@ -16,13 +18,27 @@ export const textboxDefaultValues: Partial<TClassProperties<Textbox>> = {
   splitByGrapheme: false,
 };
 
+export interface ITextboxProps extends ITextProps {}
+
+interface UniqueTextboxProps {
+  minWidth: number;
+  splitByGrapheme: boolean;
+}
+
+export interface SerializedTextboxProps
+  extends SerializedITextProps,
+    UniqueTextboxProps {}
+
 /**
  * Textbox class, based on IText, allows the user to resize the text rectangle
  * and wraps lines automatically. Textboxes have their Y scaling locked, the
  * user can only change width. Height is adjusted automatically based on the
  * wrapping of lines.
  */
-export class Textbox extends IText {
+export class Textbox<
+  Props extends TProps<ITextboxProps> = Partial<ITextboxProps>,
+  EventSpec extends ITextEvents = ITextEvents
+> extends IText<Props, EventSpec> {
   /**
    * Minimum width of textbox, in pixels.
    * @type Number
@@ -467,7 +483,9 @@ export class Textbox extends IText {
    * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
    * @return {Object} object representation of an instance
    */
-  toObject(propertiesToInclude: Array<any>): object {
+  toObject(
+    propertiesToInclude: Array<keyof SerializedTextboxProps> = []
+  ): SerializedTextboxProps {
     return super.toObject(
       ['minWidth', 'splitByGrapheme'].concat(propertiesToInclude)
     );

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -1,11 +1,12 @@
 // @ts-nocheck
 import type { TClassProperties } from '../typedefs';
-import { IText, ITextProps, SerializedITextProps } from './IText/IText';
+import { IText, ITextProps } from './IText/IText';
+import type { SerializedITextProps } from './IText/IText';
 import { classRegistry } from '../ClassRegistry';
 import { createTextboxDefaultControls } from '../controls/commonControls';
 import { JUSTIFY } from './Text/constants';
-import { TProps } from './Object/types';
-import { ITextEvents } from './IText/ITextBehavior';
+import type { TProps } from './Object/types';
+import type { ITextEvents } from './IText/ITextBehavior';
 // @TODO: Many things here are configuration related and shouldn't be on the class nor prototype
 // regexes, list of properties that are not suppose to change by instances, magic consts.
 // this will be a separated effort

--- a/src/shapes/Triangle.ts
+++ b/src/shapes/Triangle.ts
@@ -1,10 +1,6 @@
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject } from './Object/FabricObject';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, TProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
 
 export const triangleDefaultValues = {
@@ -14,10 +10,9 @@ export const triangleDefaultValues = {
 
 export class Triangle<
     Props extends TProps<FabricObjectProps> = Partial<FabricObjectProps>,
-    SProps extends SerializedObjectProps = SerializedObjectProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends FabricObject<Props, SProps, EventSpec>
+  extends FabricObject<Props, EventSpec>
   implements FabricObjectProps
 {
   static ownDefaults: Record<string, any> = triangleDefaultValues;


### PR DESCRIPTION
For some obscure reasons, the current complex TS types for `toObject` makes a perfectly fine instance of `Textbox` not assignable to `IText` because of incompatibility in `toObject`.

![Screenshot 2023-06-12 at 15 28 44](https://github.com/fabricjs/fabric.js/assets/10067273/11a634d2-e98d-41c0-a045-20ebca415574)

After simplifying the types like this, it was still not assignable but this type is easier to reason about.

<img width="1075" alt="Screenshot 2023-06-12 at 16 26 57" src="https://github.com/fabricjs/fabric.js/assets/10067273/fb4fc9c4-80ce-4e74-a60c-baf238dcd0ce">

- An object of type `Textbox` is assignable to a parameter of type `IText` if every property and method is assignable, i.e. every property and method of `Textbox` is subtype of `IText`
- `Textbox.prototype.toObject` is subtype of `IText.prototype.toObject` if:
   1. The parameter type `propertiesToInclude` from `IText` is assignable to the one from `Textbox`. Notice the change of direction, this is couter-intuitive. But indeed for `Textbox.prototype.toObject` to be used in place of `IText.prototype.toObject`, it means that it must be safely accept the parameters from `IText.prototype.toObject`
   2. The return type `SProps` from `Textbox` is assignable to the return type from `IText`. This is intuitive.

The issue with the above simplified type is that `SProps` from `Textbox` can be different from `SProps` from `IText`, even though apparently the one from Textbox seems to extend the one in IText in the default case. E.g.

```ts
interface SPropsTextbox extends SerializedTextProps { a: string }
interface SPropsIText extends SerializedTextProps { b: string }
```

The above two types are incompatible even though they seem both to extend from `SerializedTextProps`. And this issue applies both to the parameter type and the return type of `toObject`. I think this also explains why the current overcomplex type `T extends Omit<Props & TClassProperties<this>, keyof SProps>` just makes everything worse and for some reason TS seem even to just give up and say that `K extends keyof T` is just `string | number | symbol` for `propertiesToInclude` from `IText` (not shown in the above screenshot because it contained only the beginning of the huge TS error). `string | number | symbol` is the default type returned from `keyof T` when `type T = object`, so it's like as if TS just said that `T extends Omit<Props & TClassProperties<this>, keyof SProps>` for `IText` is just any generic object.

So my proposal is to simplify the types for `toObject`, which I don't expect to be that much called, except for serialization. So the current attempt to be overly-accurate in the TS is counter-effective. And if you want to customize the types, you can just do declaration merging, e.g. extend the interface of `SerializedTextProps` to add extra properties.

The advantage now is also that, because we're not doing `SProps extends SerializedTextProps`, it's not possible to have a `SProps` type from `Textbox` that is incompatible with the `SProps` from `IText`. The `toObject` method statically expects a `keyof SerializedTextboxProps`, which is guaranteed to extend from `SerializedTextProps` so TS can easily verify that `SerializedTextProps -> (assignable) SerializedTextboxProps` for the parameter type and `SerializedTextboxProps -> SerializedTextProps` for the return type, thus `Textbox.prototype.toObject -> IText.prototype.toObject`

I think this should significantly also improve type checking performance, since TS doesn't have to do all the `Omit<Props & TClassProperties<this>, keyof SProps>` computation and compare if one `SProps` is assignable to the other.