### PR TITLE
fix(IText): `exitEditing` should clear contextTop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
 
 - fix(IText): `exitEditing` should clear contextTop [#9020](https://github.com/fabricjs/fabric.js/pull/9020)
+
 ## [6.0.0-beta9]
 
 - fix(fabric): Fix the serialization and registry dependency from minification [#9009](https://github.com/fabricjs/fabric.js/pull/9009)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(IText): `exitEditing` should clear contextTop [#9020](https://github.com/fabricjs/fabric.js/pull/9020)
 ## [6.0.0-beta9]
 
 - fix(fabric): Fix the serialization and registry dependency from minification [#9009](https://github.com/fabricjs/fabric.js/pull/9009)

--- a/src/shapes/IText/ITextBehavior.ts
+++ b/src/shapes/IText/ITextBehavior.ts
@@ -668,6 +668,7 @@ export abstract class ITextBehavior<
     }
     this.hiddenTextarea = null;
     this.abortCursorAnimation();
+    this.selectionStart !== this.selectionEnd && this.clearContextTop();
   }
 
   /**
@@ -675,8 +676,8 @@ export abstract class ITextBehavior<
    */
   exitEditing() {
     const isTextChanged = this._textBeforeEdit !== this.text;
-    this.selectionEnd = this.selectionStart;
     this._exitEditing();
+    this.selectionEnd = this.selectionStart;
     this._restoreEditingProps();
     if (this._forceClearCache) {
       this.initDimensions();


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

Reproduce:
- select text
- deselect text by pressing the canvas

Expected selection to be cleared.
It doesn't
This is a regression caused IMO by making `abortCursorAnimation` effecient.
We need to think about this.
I am not sure if there are more cases we want to clear selection.
The only path that I am not sure about is this:

https://github.com/fabricjs/fabric.js/blob/00bbc7ce2081d37c273fcdf4804ea2459fc2736b/src/shapes/IText/ITextKeyBehavior.ts#L106-L108

The rest seem fine.
I am quite sure that draggable text needs blur NOT to clear selection, but that might be incorrect. Due to `_renderDragEffects` handling that.

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
