### PR TITLE
Fix main export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- chore(): fix main export [#9045](https://github.com/fabricjs/fabric.js/pull/9045)
+
 ## [6.0.0-beta10]
 
 - chore(TS): Remove @ts-nocheck from Text class. [#9018](https://github.com/fabricjs/fabric.js/pull/9018)

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "node": ">=14.0.0"
   },
   "module": "./dist/index.mjs",
-  "main": "./dist/index.node.cjs",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "typesVersions": {
     ">=4.2": {


### PR DESCRIPTION
According to the [Node.js documentation](https://nodejs.org/api/packages.html#package-entry-points), `main` is the legacy property supported by all Node.js whereas `exports` is supported only by 12.x

What I've noticed with Create-React-App v5.0.1 (latest CRA btw) is that it internally uses Jest v27. Unfortunately Jest added [full support for `exports` field only in Jest 28](https://jestjs.io/blog/2022/04/25/jest-28#packagejson-exports) and we cannot update CRA to use Jest 28 because it's an internal dependency. This means that Jest 27 and CRA is currently using the `main` field, which however is exporting the node version.

This results in fabric defining its own canvas mock using jsdom, overriding the one globally defined in the project. @ShaMan123 fixed this temporarily by writing `fabric.setEnv({ ...fabric.getEnv(), window, document })` so that it overrides again the fabric jsdom mock with the global one, but even he didn't fully understand the root cause 😄 So it could be extremely confusing for other people. I've instead tried that updating the `main` field indeed solves the issue.

I believe that the `main` field should export the browser version because it's the legacy property supported by any Node version and tooling in the community. So it's safer to keep it referencing the `dist/index.js` as previous versions of fabric did, then modern tools can read `exports` and pick the best export.