### PR TITLE
chore(TS): fix submodule type import

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,19 +130,6 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.node.cjs",
   "types": "./dist/index.d.ts",
-  "typesVersions": {
-    ">=4.2": {
-      "*": [
-        "dist/index.d.ts"
-      ],
-      "node": [
-        "dist/index.node.d.ts"
-      ],
-      "src/*": [
-        "src/*"
-      ]
-    }
-  },
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
The following code that imports a type from a submodule doesn't work as consumer of fabric.

```ts
import { GraphemeBBox } from "fabric/dist/src/shapes/Text/Text";
import type { GraphemeData } from "fabric/dist/src/shapes/Textbox";
```

(This was written by you @ShaMan123 ). I believed initially this was caused by our module augmentation, because VSCode would always open the augmentation file (with `declare module "fabric"`) along with `fabric/dist/index.d.ts`. Indeed I said multiple times in other issues that submodule type imports don't work with module augmentation, but it seems I was wrong.

Today I found out that if I remove `typesVersions`, the above imports work. I think it's because the `typesVersions` is resolving any (i.e. `*`) import to `dist/index.d.ts`:
- `fabric` -> `dist/index.d.ts`
- `fabric/dist/src/shapes/Text/Text` -> `dist/index.d.ts`

It should probably be `*: [dist/*]` and `"types": "./index.d.ts"` as described in the [official doc](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions). For now, I've just removed the config since I'd like to understand the initial rational as well.

Ironically, I found out your comment @ShaMan123 in https://github.com/microsoft/TypeScript/issues/8305#issuecomment-1415874037 while I was investigating why the submodule type import did not work. I didn't understand however the rational for `typesVersions`. After I removed, I was still able to compile fabric fine with `build:fast`.