### PR TITLE
Added patternTransform to Pattern's toSVG method

### DIFF
--- a/src/Pattern/Pattern.ts
+++ b/src/Pattern/Pattern.ts
@@ -177,10 +177,13 @@ export class Pattern {
       patternHeight =
         repeat === 'repeat-x' || repeat === 'no-repeat'
           ? 1 + Math.abs(patternOffsetY || 0)
-          : ifNaN((patternSource.height as number) / height, 0);
+          : ifNaN((patternSource.height as number) / height, 0),
+      patternTransformMatrix = Array.isArray(this.patternTransform)
+          ? this.patternTransform.join(' ')
+          : '1 0 0 1 0 0';
 
     return [
-      `<pattern id="SVGID_${id}" x="${patternOffsetX}" y="${patternOffsetY}" width="${patternWidth}" height="${patternHeight}">`,
+      `<pattern id="SVGID_${id}" x="${patternOffsetX}" y="${patternOffsetY}" width="${patternWidth}" height="${patternHeight}" patternTransform="matrix(${patternTransformMatrix})">`,
       `<image x="0" y="0" width="${patternSource.width}" height="${
         patternSource.height
       }" xlink:href="${this.sourceToString()}"></image>`,


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

The `patternTransform` attribute is missing in Pattern SVG export, even though the Pattern fill has a `patternTransform`
If there's no `patternTransform` on the Pattern, it provides a default identity matrix.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/patternTransform

## Changes


## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
