### PR TITLE
ci(): Install system deps only when necessary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ./.github/actions/cached-install
         with:
           node-version: 18.x
-          install-system-deps: true
+          install-system-deps: false
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
   node-coverage:
@@ -35,7 +35,7 @@ jobs:
       - uses: ./.github/actions/cached-install
         with:
           node-version: 18.x
-          install-system-deps: true
+          install-system-deps: false
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
       - name: Run ${{ matrix.suite }} tests with coverage
@@ -88,7 +88,7 @@ jobs:
       - uses: ./.github/actions/cached-install
         with:
           node-version: ${{ matrix.node-version }}
-          install-system-deps: true
+          install-system-deps: ${{ matrix.node-version }} == '20.x'
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
       - name: Run ${{ matrix.suite }} tests
@@ -101,7 +101,7 @@ jobs:
       - uses: ./.github/actions/cached-install
         with:
           node-version: 18.x
-          install-system-deps: true
+          install-system-deps: false
       - name: Run Jest unit test
         run: npm run test:jest:coverage
       - name: Upload test coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): Install system deps only when necessary [#9086](https://github.com/fabricjs/fabric.js/pull/9086)
 - fix(util, Path): path distance measurement fix for M cmd [#9076](https://github.com/fabricjs/fabric.js/pull/9076)
 - chore(TS): Image class type checks, BREAKING change to FromURL static method [#9036](https://github.com/fabricjs/fabric.js/pull/9036)
 - ci(): properly checkout head for stats [#9080](https://github.com/fabricjs/fabric.js/pull/9080)

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "canvas": "^2.8.0",
+        "canvas": "^2.11.2",
         "jsdom": "^20.0.1"
       }
     },
@@ -4186,9 +4186,10 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canvas": {
-      "version": "2.11.0",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -14760,7 +14761,9 @@
       "dev": true
     },
     "canvas": {
-      "version": "2.11.0",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
       "optional": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "babel-src": "babel --no-babelrc src --extensions '.ts' --ignore 'src/constants.ts' --out-dir dist/src --config-file ./.babelrcAlt"
   },
   "optionalDependencies": {
-    "canvas": "^2.8.0",
+    "canvas": "^2.11.2",
     "jsdom": "^20.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

Make the CI faster.
<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

Up to node 18.x installing system deps on linux amd64 is not required since binaries are prebuilt.
Ci will intall system deps only for node 20.x

