### PR TITLE
chore(IText): cleanup `_renderCursor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(IText): cleanup `_renderCursor` [#9113](https://github.com/fabricjs/fabric.js/pull/9113)
 - fix(): #8344 stroke projection [#8374](https://github.com/fabricjs/fabric.js/pull/8374)
 - fix(Filters) Removing type from the options passed in the constructor [#9089](https://github.com/fabricjs/fabric.js/pull/9089)
 - feat(InteractiveObject): add `getActiveControl()` to expose `__corner` [#9102](https://github.com/fabricjs/fabric.js/pull/9102)

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -385,7 +385,7 @@ export class IText<
       return;
     }
     const boundaries = this._getCursorBoundaries();
-    if (this.selectionStart === this.selectionEnd || this.inCompositionMode) {
+    if (this.selectionStart === this.selectionEnd && !this.inCompositionMode) {
       this.renderCursor(ctx, boundaries);
     } else {
       this.renderSelection(ctx, boundaries);


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

Exposing the cursor measurements it crucial for devs
<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description
 - extracted the mesuring logic to `getCursorRenderData`
- moved the `inCompositionMode` logic to top level where it should be:
   - logically it seems fine since `renderCursor` is called for the same place and `renderCursorAt` is imperative
<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
