### PR TITLE
Fix event types and .once this binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- chore(TS): Fix event types [#9119](https://github.com/fabricjs/fabric.js/pull/9130)
+- chore(TS): Fix event types and .once this binding [#9119](https://github.com/fabricjs/fabric.js/pull/9130)
 - ci(e2e): support relative imports [#9108](https://github.com/fabricjs/fabric.js/pull/9108)
 - chore(TS): complete type check [#9119](https://github.com/fabricjs/fabric.js/pull/9119)
 - chore(TS): Add type-checking to files excluded with ts-nocheck [#9097](https://github.com/fabricjs/fabric.js/pull/9097)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(TS): Fix event types [#9119](https://github.com/fabricjs/fabric.js/pull/9130)
 - ci(e2e): support relative imports [#9108](https://github.com/fabricjs/fabric.js/pull/9108)
 - chore(TS): complete type check [#9119](https://github.com/fabricjs/fabric.js/pull/9119)
 - chore(TS): Add type-checking to files excluded with ts-nocheck [#9097](https://github.com/fabricjs/fabric.js/pull/9097)

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -80,18 +80,19 @@ export type Transform = {
   actionPerformed: boolean;
 };
 
-export type TEvent<E extends Event = TPointerEvent> = {
+export interface TEvent<E extends Event = TPointerEvent> {
   e: E;
-};
+}
 
-type TEventWithTarget<E extends Event = TPointerEvent> = TEvent<E> & {
+interface TEventWithTarget<E extends Event = TPointerEvent> extends TEvent<E> {
   target: FabricObject;
-};
+}
 
-export type BasicTransformEvent<E extends Event = TPointerEvent> = TEvent<E> & {
+export interface BasicTransformEvent<E extends Event = TPointerEvent>
+  extends TEvent<E> {
   transform: Transform;
   pointer: Point;
-};
+}
 
 export type TModificationEvents =
   | 'moving'
@@ -100,11 +101,12 @@ export type TModificationEvents =
   | 'skewing'
   | 'resizing';
 
-export type ModifiedEvent<E extends Event = TPointerEvent> = TEvent<E> & {
+export interface ModifiedEvent<E extends Event = TPointerEvent>
+  extends TEvent<E> {
   transform: Transform;
   target: FabricObject;
   action: string;
-};
+}
 
 type ModificationEventsSpec<
   Prefix extends string = '',
@@ -123,42 +125,45 @@ type CanvasModificationEvents = ModificationEventsSpec<
   'before:transform': TEvent & { transform: Transform };
 };
 
-export type TPointerEventInfo<E extends TPointerEvent = TPointerEvent> =
-  TEvent<E> & {
-    target?: FabricObject;
-    subTargets?: FabricObject[];
-    button?: number;
-    isClick: boolean;
-    pointer: Point;
-    transform?: Transform | null;
-    absolutePointer: Point;
-    currentSubTargets?: FabricObject[];
-    currentTarget?: FabricObject | null;
-  };
+export interface TPointerEventInfo<E extends TPointerEvent = TPointerEvent>
+  extends TEvent<E> {
+  target?: FabricObject;
+  subTargets?: FabricObject[];
+  button?: number;
+  isClick: boolean;
+  pointer: Point;
+  transform?: Transform | null;
+  absolutePointer: Point;
+  currentSubTargets?: FabricObject[];
+  currentTarget?: FabricObject | null;
+}
 
-type SimpleEventHandler<T extends Event = TPointerEvent> = TEvent<T> & {
+interface SimpleEventHandler<T extends Event = TPointerEvent>
+  extends TEvent<T> {
   target?: FabricObject;
   subTargets: FabricObject[];
-};
+}
 
-type InEvent = {
+interface InEvent {
   previousTarget?: FabricObject;
-};
+}
 
-type OutEvent = {
+interface OutEvent {
   nextTarget?: FabricObject;
-};
+}
 
-export type DragEventData = TEvent<DragEvent> & {
+export interface DragEventData extends TEvent<DragEvent> {
   target?: FabricObject;
   subTargets?: FabricObject[];
   dragSource?: FabricObject;
   canDrop?: boolean;
   didDrop?: boolean;
   dropTarget?: FabricObject;
-};
+}
 
-export type DropEventData = DragEventData & { pointer: Point };
+export interface DropEventData extends DragEventData {
+  pointer: Point;
+}
 
 interface DnDEvents {
   dragstart: TEventWithTarget<DragEvent>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -24,10 +24,6 @@ export class Observable<EventSpec> {
     eventName: K,
     handler: TEventCallback<E>
   ): VoidFunction;
-  on<K extends string, E>(
-    eventName: K,
-    handler: TEventCallback<E>
-  ): VoidFunction;
   on(handlers: EventRegistryObject<EventSpec>): VoidFunction;
   on<K extends keyof EventSpec, E extends EventSpec[K]>(
     arg0: K | EventRegistryObject<EventSpec>,
@@ -39,7 +35,7 @@ export class Observable<EventSpec> {
     if (typeof arg0 === 'object') {
       // one object with key/value pairs was passed
       Object.entries(arg0).forEach(([eventName, handler]) => {
-        this.on(eventName, handler as TEventCallback);
+        this.on(eventName as K, handler as TEventCallback);
       });
       return () => this.off(arg0);
     } else if (handler) {
@@ -67,10 +63,6 @@ export class Observable<EventSpec> {
     eventName: K,
     handler: TEventCallback<E>
   ): VoidFunction;
-  once<K extends string, E>(
-    eventName: K,
-    handler: TEventCallback<E>
-  ): VoidFunction;
   once(handlers: EventRegistryObject<EventSpec>): VoidFunction;
   once<K extends keyof EventSpec, E extends EventSpec[K]>(
     arg0: K | EventRegistryObject<EventSpec>,
@@ -80,7 +72,7 @@ export class Observable<EventSpec> {
       // one object with key/value pairs was passed
       const disposers: VoidFunction[] = [];
       Object.entries(arg0).forEach(([eventName, handler]) => {
-        disposers.push(this.once(eventName, handler as TEventCallback));
+        disposers.push(this.once(eventName as K, handler as TEventCallback));
       });
       return () => disposers.forEach((d) => d());
     } else if (handler) {

--- a/test/unit/observable.js
+++ b/test/unit/observable.js
@@ -35,6 +35,21 @@ QUnit.test('fire once', function (assert) {
   assert.equal(eventFired, 1);
 });
 
+QUnit.test('fire once context', function (assert) {
+  var foo = new fabric.Observable();
+
+  var eventFired = false;
+  var context;
+  foo.once('bar:baz', function() {
+    context = this;
+    eventFired = true;
+  });
+
+  foo.fire('bar:baz');
+  assert.equal(eventFired, true);
+  assert.equal(context, foo);
+});
+
 QUnit.test('fire once multiple handlers', function (assert) {
   var foo = new fabric.Observable();
   var eventFired = 0;


### PR DESCRIPTION
- Made event type definitions interfaces to allow again declaration merging
- Fixed the types for the `on, once, off` event registering. It was particularly not working for registering with an object of event handlers, since the type of `EventRegistryObject` was `Record<K, TEventCallback<E>>`, meaning that **every** event has the same callback type, whereas each event has its own.
- Fixed a bug with `obj.once("event", function() { console.log(this) })` where `this === undefined`, whereas `obj.on("event", function() { console.log(this) })` would correctly have `this === object`