### PR TITLE
chore(TS): mv + rename `TProps` => `TOptions`

### DIFF
--- a/fabric.ts
+++ b/fabric.ts
@@ -41,7 +41,6 @@ export { PatternBrush } from './src/brushes/PatternBrush';
 
 export { FabricObject as Object } from './src/shapes/Object/FabricObject';
 export type {
-  TProps,
   TFabricObjectProps,
   FabricObjectProps,
   SerializedObjectProps,

--- a/src/filters/BaseFilter.ts
+++ b/src/filters/BaseFilter.ts
@@ -6,6 +6,7 @@ import type {
   TWebGLPipelineState,
   TWebGLProgramCacheItem,
   TWebGLUniformLocationMap,
+  Abortable,
 } from './typedefs';
 import { isWebGLPipelineState } from './utils';
 import {
@@ -13,7 +14,6 @@ import {
   identityFragmentShader,
   vertexSource,
 } from './shaders/baseFilter';
-import type { Abortable } from '../typedefs';
 
 export class BaseFilter {
   /**

--- a/src/filters/BaseFilter.ts
+++ b/src/filters/BaseFilter.ts
@@ -6,7 +6,6 @@ import type {
   TWebGLPipelineState,
   TWebGLProgramCacheItem,
   TWebGLUniformLocationMap,
-  Abortable,
 } from './typedefs';
 import { isWebGLPipelineState } from './utils';
 import {
@@ -14,6 +13,7 @@ import {
   identityFragmentShader,
   vertexSource,
 } from './shaders/baseFilter';
+import type { Abortable } from '../typedefs';
 
 export class BaseFilter {
   /**

--- a/src/shapes/Circle.ts
+++ b/src/shapes/Circle.ts
@@ -6,7 +6,7 @@ import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { sin } from '../util/misc/sin';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
-import type { Abortable, TClassProperties, TProps } from '../typedefs';
+import type { Abortable, TClassProperties, TOptions } from '../typedefs';
 import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { CSSRules } from '../parser/typedefs';
 
@@ -50,7 +50,7 @@ export const circleDefaultValues: UniqueCircleProps = {
 };
 
 export class Circle<
-    Props extends TProps<CircleProps> = Partial<CircleProps>,
+    Props extends TOptions<CircleProps> = Partial<CircleProps>,
     SProps extends SerializedCircleProps = SerializedCircleProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
@@ -232,7 +232,7 @@ export class Circle<
   /**
    * @todo how do we declare this??
    */
-  static fromObject<T extends TProps<SerializedCircleProps>>(object: T) {
+  static fromObject<T extends TOptions<SerializedCircleProps>>(object: T) {
     return super._fromObject<Circle>(object);
   }
 }

--- a/src/shapes/Circle.ts
+++ b/src/shapes/Circle.ts
@@ -6,12 +6,8 @@ import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { sin } from '../util/misc/sin';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
-import type { Abortable, TClassProperties } from '../typedefs';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { Abortable, TClassProperties, TProps } from '../typedefs';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { CSSRules } from '../parser/typedefs';
 
 interface UniqueCircleProps {

--- a/src/shapes/Ellipse.ts
+++ b/src/shapes/Ellipse.ts
@@ -1,14 +1,10 @@
 import { twoMathPi } from '../constants';
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { Abortable, TClassProperties } from '../typedefs';
+import type { Abortable, TClassProperties, TProps } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
 import type { CSSRules } from '../parser/typedefs';
 

--- a/src/shapes/Ellipse.ts
+++ b/src/shapes/Ellipse.ts
@@ -1,7 +1,7 @@
 import { twoMathPi } from '../constants';
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { Abortable, TClassProperties, TProps } from '../typedefs';
+import type { Abortable, TClassProperties, TOptions } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
 import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
@@ -27,7 +27,7 @@ export interface EllipseProps extends FabricObjectProps, UniqueEllipseProps {}
 const ELLIPSE_PROPS = ['rx', 'ry'] as const;
 
 export class Ellipse<
-    Props extends TProps<EllipseProps> = Partial<EllipseProps>,
+    Props extends TOptions<EllipseProps> = Partial<EllipseProps>,
     SProps extends SerializedEllipseProps = SerializedEllipseProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -3,7 +3,7 @@ import { createCollectionMixin } from '../Collection';
 import { resolveOrigin } from '../util/misc/resolveOrigin';
 import { Point } from '../Point';
 import { cos } from '../util/misc/cos';
-import type { TClassProperties, TSVGReviver } from '../typedefs';
+import type { TClassProperties, TSVGReviver, TProps } from '../typedefs';
 import { makeBoundingBoxFromPoints } from '../util/misc/boundingBoxFromPoints';
 import {
   invertTransform,
@@ -20,11 +20,7 @@ import { sin } from '../util/misc/sin';
 import { FabricObject } from './Object/FabricObject';
 import { Rect } from './Rect';
 import { classRegistry } from '../ClassRegistry';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import { CENTER } from '../constants';
 
 export type LayoutContextType =

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -3,7 +3,7 @@ import { createCollectionMixin } from '../Collection';
 import { resolveOrigin } from '../util/misc/resolveOrigin';
 import { Point } from '../Point';
 import { cos } from '../util/misc/cos';
-import type { TClassProperties, TSVGReviver, TProps } from '../typedefs';
+import type { TClassProperties, TSVGReviver, TOptions } from '../typedefs';
 import { makeBoundingBoxFromPoints } from '../util/misc/boundingBoxFromPoints';
 import {
   invertTransform,
@@ -1088,7 +1088,7 @@ export class Group extends createCollectionMixin(
    * @param {Object} object Object to create a group from
    * @returns {Promise<Group>}
    */
-  static fromObject<T extends TProps<SerializedGroupProps>>({
+  static fromObject<T extends TOptions<SerializedGroupProps>>({
     objects = [],
     ...options
   }: T) {

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -7,7 +7,7 @@ import {
   keysMap,
   keysMapRtl,
 } from './constants';
-import type { TFiller } from '../../typedefs';
+import type { TFiller, TProps } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import type { SerializedTextProps, TextProps } from '../Text/Text';
 import {
@@ -17,7 +17,6 @@ import {
   JUSTIFY_RIGHT,
 } from '../Text/constants';
 import { CENTER, LEFT, RIGHT } from '../../constants';
-import type { TProps } from '../Object/types';
 
 type CursorBoundaries = {
   left: number;

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -7,7 +7,7 @@ import {
   keysMap,
   keysMapRtl,
 } from './constants';
-import type { TFiller, TProps } from '../../typedefs';
+import type { TFiller, TOptions } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import type { SerializedTextProps, TextProps } from '../Text/Text';
 import {
@@ -103,7 +103,7 @@ export interface ITextProps extends TextProps, UniqueITextProps {}
  * ```
  */
 export class IText<
-    Props extends TProps<ITextProps> = Partial<ITextProps>,
+    Props extends TOptions<ITextProps> = Partial<ITextProps>,
     SProps extends SerializedITextProps = SerializedITextProps,
     EventSpec extends ITextEvents = ITextEvents
   >

--- a/src/shapes/IText/ITextBehavior.ts
+++ b/src/shapes/IText/ITextBehavior.ts
@@ -11,7 +11,7 @@ import type { TOnAnimationChangeCallback } from '../../util/animation/types';
 import type { ValueAnimation } from '../../util/animation/ValueAnimation';
 import type { TextStyleDeclaration } from '../Text/StyledText';
 import type { SerializedTextProps, TextProps } from '../Text/Text';
-import type { TProps } from '../Object/types';
+import type { TProps } from '../../typedefs';
 import { getDocumentFromElement } from '../../util/dom_misc';
 import { LEFT, RIGHT, reNewline } from '../../constants';
 

--- a/src/shapes/IText/ITextBehavior.ts
+++ b/src/shapes/IText/ITextBehavior.ts
@@ -11,7 +11,7 @@ import type { TOnAnimationChangeCallback } from '../../util/animation/types';
 import type { ValueAnimation } from '../../util/animation/ValueAnimation';
 import type { TextStyleDeclaration } from '../Text/StyledText';
 import type { SerializedTextProps, TextProps } from '../Text/Text';
-import type { TProps } from '../../typedefs';
+import type { TOptions } from '../../typedefs';
 import { getDocumentFromElement } from '../../util/dom_misc';
 import { LEFT, RIGHT, reNewline } from '../../constants';
 
@@ -39,7 +39,7 @@ export type ITextEvents = ObjectEvents & {
 };
 
 export abstract class ITextBehavior<
-  Props extends TProps<TextProps> = Partial<TextProps>,
+  Props extends TOptions<TextProps> = Partial<TextProps>,
   SProps extends SerializedTextProps = SerializedTextProps,
   EventSpec extends ITextEvents = ITextEvents
 > extends Text<Props, SProps, EventSpec> {

--- a/src/shapes/IText/ITextClickBehavior.ts
+++ b/src/shapes/IText/ITextClickBehavior.ts
@@ -7,7 +7,7 @@ import { invertTransform } from '../../util/misc/matrix';
 import { DraggableTextDelegate } from './DraggableTextDelegate';
 import type { ITextEvents } from './ITextBehavior';
 import { ITextKeyBehavior } from './ITextKeyBehavior';
-import type { TProps } from '../Object/types';
+import type { TProps } from '../../typedefs';
 import type { TextProps, SerializedTextProps } from '../Text/Text';
 
 // TODO: this code seems wrong.

--- a/src/shapes/IText/ITextClickBehavior.ts
+++ b/src/shapes/IText/ITextClickBehavior.ts
@@ -7,7 +7,7 @@ import { invertTransform } from '../../util/misc/matrix';
 import { DraggableTextDelegate } from './DraggableTextDelegate';
 import type { ITextEvents } from './ITextBehavior';
 import { ITextKeyBehavior } from './ITextKeyBehavior';
-import type { TProps } from '../../typedefs';
+import type { TOptions } from '../../typedefs';
 import type { TextProps, SerializedTextProps } from '../Text/Text';
 
 // TODO: this code seems wrong.
@@ -18,7 +18,7 @@ function notALeftClick(e: MouseEvent) {
 }
 
 export abstract class ITextClickBehavior<
-    Props extends TProps<TextProps> = Partial<TextProps>,
+    Props extends TOptions<TextProps> = Partial<TextProps>,
     SProps extends SerializedTextProps = SerializedTextProps,
     EventSpec extends ITextEvents = ITextEvents
   >

--- a/src/shapes/IText/ITextKeyBehavior.ts
+++ b/src/shapes/IText/ITextKeyBehavior.ts
@@ -4,7 +4,7 @@ import { capValue } from '../../util/misc/capValue';
 import type { ITextEvents } from './ITextBehavior';
 import { ITextBehavior } from './ITextBehavior';
 import type { TKeyMapIText } from './constants';
-import type { TProps } from '../Object/types';
+import type { TProps } from '../../typedefs';
 import type { TextProps, SerializedTextProps } from '../Text/Text';
 import { getDocumentFromElement } from '../../util/dom_misc';
 import { LEFT, RIGHT } from '../../constants';

--- a/src/shapes/IText/ITextKeyBehavior.ts
+++ b/src/shapes/IText/ITextKeyBehavior.ts
@@ -4,7 +4,7 @@ import { capValue } from '../../util/misc/capValue';
 import type { ITextEvents } from './ITextBehavior';
 import { ITextBehavior } from './ITextBehavior';
 import type { TKeyMapIText } from './constants';
-import type { TProps } from '../../typedefs';
+import type { TOptions } from '../../typedefs';
 import type { TextProps, SerializedTextProps } from '../Text/Text';
 import { getDocumentFromElement } from '../../util/dom_misc';
 import { LEFT, RIGHT } from '../../constants';
@@ -12,7 +12,7 @@ import type { IText } from './IText';
 import type { TextStyleDeclaration } from '../Text/StyledText';
 
 export abstract class ITextKeyBehavior<
-  Props extends TProps<TextProps> = Partial<TextProps>,
+  Props extends TOptions<TextProps> = Partial<TextProps>,
   SProps extends SerializedTextProps = SerializedTextProps,
   EventSpec extends ITextEvents = ITextEvents
 > extends ITextBehavior<Props, SProps, EventSpec> {

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -8,7 +8,7 @@ import type {
   TCrossOrigin,
   TSize,
   Abortable,
-  TProps,
+  TOptions,
 } from '../typedefs';
 import { uid } from '../util/internals/uid';
 import { createCanvasElement } from '../util/misc/dom';
@@ -75,7 +75,7 @@ const IMAGE_PROPS = ['cropX', 'cropY'] as const;
  * @tutorial {@link http://fabricjs.com/fabric-intro-part-1#images}
  */
 export class Image<
-    Props extends TProps<ImageProps> = Partial<ImageProps>,
+    Props extends TOptions<ImageProps> = Partial<ImageProps>,
     SProps extends SerializedImageProps = SerializedImageProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
@@ -788,7 +788,7 @@ export class Image<
    * @param {AbortSignal} [options.signal] handle aborting, see https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal
    * @returns {Promise<Image>}
    */
-  static fromObject<T extends TProps<SerializedImageProps>>(
+  static fromObject<T extends TOptions<SerializedImageProps>>(
     { filters: f, resizeFilter: rf, src, crossOrigin, ...object }: T,
     options: Abortable = {}
   ) {
@@ -817,7 +817,7 @@ export class Image<
    * @param {LoadImageOptions} [options] Options object
    * @returns {Promise<Image>}
    */
-  static fromURL<T extends TProps<ImageProps>>(
+  static fromURL<T extends TOptions<ImageProps>>(
     url: string,
     { crossOrigin = null, signal }: LoadImageOptions = {},
     imageOptions: T

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -3,8 +3,13 @@ import type { BaseFilter } from '../filters/BaseFilter';
 import { getFilterBackend } from '../filters/FilterBackend';
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { TClassProperties, TCrossOrigin, TSize } from '../typedefs';
-import type { Abortable } from '../typedefs';
+import type {
+  TClassProperties,
+  TCrossOrigin,
+  TSize,
+  Abortable,
+  TProps,
+} from '../typedefs';
 import { uid } from '../util/internals/uid';
 import { createCanvasElement } from '../util/misc/dom';
 import { findScaleToCover, findScaleToFit } from '../util/misc/findScaleTo';
@@ -17,11 +22,7 @@ import {
 import { parsePreserveAspectRatioAttribute } from '../util/misc/svgParsing';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
 import { WebGLFilterBackend } from '../filters/WebGLFilterBackend';
 import { NONE } from '../constants';

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -1,6 +1,6 @@
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { Abortable, TClassProperties, TProps } from '../typedefs';
+import type { Abortable, TClassProperties, TOptions } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
 import { Point } from '../Point';
@@ -27,7 +27,7 @@ export interface SerializedLineProps
     UniqueLineProps {}
 
 export class Line<
-    Props extends TProps<FabricObjectProps> = Partial<FabricObjectProps>,
+    Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
     SProps extends SerializedLineProps = SerializedLineProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
@@ -263,7 +263,7 @@ export class Line<
    * @param {Object} object Object to create an instance from
    * @returns {Promise<Line>}
    */
-  static fromObject<T extends TProps<SerializedLineProps>>({
+  static fromObject<T extends TOptions<SerializedLineProps>>({
     x1,
     y1,
     x2,

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -1,15 +1,11 @@
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { Abortable, TClassProperties } from '../typedefs';
+import type { Abortable, TClassProperties, TProps } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
 import { Point } from '../Point';
 import { isFiller } from '../util/typeAssertions';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
 import { makeBoundingBoxFromPoints } from '../util';
 import { CENTER, LEFT, TOP } from '../constants';

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -18,6 +18,7 @@ import type {
   TSize,
   TCacheCanvasDimensions,
   Abortable,
+  TProps,
 } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import { runningAnimations } from '../../util/animation/AnimationRegistry';
@@ -51,7 +52,6 @@ import type { Pattern } from '../../Pattern';
 import type { Canvas } from '../../canvas/Canvas';
 import type { SerializedObjectProps } from './types/SerializedObjectProps';
 import type { ObjectProps } from './types/ObjectProps';
-import type { TProps } from './types';
 import { getEnv } from '../../env';
 
 export type TCachedFabricObject<T extends FabricObject = FabricObject> = T &

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -18,7 +18,7 @@ import type {
   TSize,
   TCacheCanvasDimensions,
   Abortable,
-  TProps,
+  TOptions,
 } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import { runningAnimations } from '../../util/animation/AnimationRegistry';
@@ -98,7 +98,7 @@ export type TCachedFabricObject<T extends FabricObject = FabricObject> = T &
  * @fires drop
  */
 export class FabricObject<
-    Props extends TProps<ObjectProps> = Partial<ObjectProps>,
+    Props extends TOptions<ObjectProps> = Partial<ObjectProps>,
     SProps extends SerializedObjectProps = SerializedObjectProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
@@ -1577,7 +1577,7 @@ export class FabricObject<
    * @param {AbortSignal} [options.signal] handle aborting, see https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal
    * @returns {Promise<FabricObject>}
    */
-  static fromObject<T extends TProps<SerializedObjectProps>>(
+  static fromObject<T extends TOptions<SerializedObjectProps>>(
     object: T,
     options?: Abortable
   ) {

--- a/src/shapes/Object/types/index.ts
+++ b/src/shapes/Object/types/index.ts
@@ -1,7 +1,7 @@
 import type { FabricObjectProps } from './FabricObjectProps';
-import { TProps } from '../../../typedefs';
+import { TOptions } from '../../../typedefs';
 
 export type { SerializedObjectProps } from './SerializedObjectProps';
 export type { FabricObjectProps };
 
-export type TFabricObjectProps = TProps<FabricObjectProps>;
+export type TFabricObjectProps = TOptions<FabricObjectProps>;

--- a/src/shapes/Object/types/index.ts
+++ b/src/shapes/Object/types/index.ts
@@ -1,8 +1,7 @@
 import type { FabricObjectProps } from './FabricObjectProps';
+import { TProps } from '../../../typedefs';
 
 export type { SerializedObjectProps } from './SerializedObjectProps';
 export type { FabricObjectProps };
-
-export type TProps<T> = Partial<T> & Record<string, any>;
 
 export type TFabricObjectProps = TProps<FabricObjectProps>;

--- a/src/shapes/Object/types/index.ts
+++ b/src/shapes/Object/types/index.ts
@@ -1,5 +1,5 @@
 import type { FabricObjectProps } from './FabricObjectProps';
-import { TOptions } from '../../../typedefs';
+import type { TOptions } from '../../../typedefs';
 
 export type { SerializedObjectProps } from './SerializedObjectProps';
 export type { FabricObjectProps };

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -20,7 +20,12 @@ import type {
 } from '../util/path/typedefs';
 import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
-import type { TBBox, TClassProperties, TSVGReviver, TProps } from '../typedefs';
+import type {
+  TBBox,
+  TClassProperties,
+  TSVGReviver,
+  TOptions,
+} from '../typedefs';
 import { cloneDeep } from '../util/internals/cloneDeep';
 import { CENTER, LEFT, TOP } from '../constants';
 import type { CSSRules } from '../parser/typedefs';
@@ -43,7 +48,7 @@ export interface IPathBBox extends TBBox {
 }
 
 export class Path<
-  Props extends TProps<PathProps> = Partial<PathProps>,
+  Props extends TOptions<PathProps> = Partial<PathProps>,
   SProps extends SerializedPathProps = SerializedPathProps,
   EventSpec extends ObjectEvents = ObjectEvents
 > extends FabricObject<Props, SProps, EventSpec> {
@@ -397,7 +402,7 @@ export class Path<
    * @param {Object} object
    * @returns {Promise<Path>}
    */
-  static fromObject<T extends TProps<SerializedPathProps>>(object: T) {
+  static fromObject<T extends TOptions<SerializedPathProps>>(object: T) {
     return this._fromObject<Path>(object, {
       extraParam: 'path',
     });

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -18,13 +18,9 @@ import type {
   TPathSegmentInfo,
   TSimplePathData,
 } from '../util/path/typedefs';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
-import type { TBBox, TClassProperties, TSVGReviver } from '../typedefs';
+import type { TBBox, TClassProperties, TSVGReviver, TProps } from '../typedefs';
 import { cloneDeep } from '../util/internals/cloneDeep';
 import { CENTER, LEFT, TOP } from '../constants';
 import type { CSSRules } from '../parser/typedefs';

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -4,7 +4,7 @@ import { parseAttributes } from '../parser/parseAttributes';
 import { parsePointsAttribute } from '../parser/parsePointsAttribute';
 import type { XY } from '../Point';
 import { Point } from '../Point';
-import type { Abortable, TClassProperties } from '../typedefs';
+import type { Abortable, TClassProperties, TProps } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { makeBoundingBoxFromPoints } from '../util/misc/boundingBoxFromPoints';
 import { calcDimensionsMatrix, transformPoint } from '../util/misc/matrix';
@@ -13,11 +13,7 @@ import type { TProjectStrokeOnPointsOptions } from '../util/misc/projectStroke/t
 import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import { toFixed } from '../util/misc/toFixed';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
 import { cloneDeep } from '../util/internals/cloneDeep';
 import { CENTER, LEFT, TOP } from '../constants';

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -4,7 +4,7 @@ import { parseAttributes } from '../parser/parseAttributes';
 import { parsePointsAttribute } from '../parser/parsePointsAttribute';
 import type { XY } from '../Point';
 import { Point } from '../Point';
-import type { Abortable, TClassProperties, TProps } from '../typedefs';
+import type { Abortable, TClassProperties, TOptions } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { makeBoundingBoxFromPoints } from '../util/misc/boundingBoxFromPoints';
 import { calcDimensionsMatrix, transformPoint } from '../util/misc/matrix';
@@ -28,7 +28,7 @@ export interface SerializedPolylineProps extends SerializedObjectProps {
 }
 
 export class Polyline<
-  Props extends TProps<FabricObjectProps> = Partial<FabricObjectProps>,
+  Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
   SProps extends SerializedPolylineProps = SerializedPolylineProps,
   EventSpec extends ObjectEvents = ObjectEvents
 > extends FabricObject<Props, SProps, EventSpec> {
@@ -400,7 +400,7 @@ export class Polyline<
    * @param {Object} object Object to create an instance from
    * @returns {Promise<Polyline>}
    */
-  static fromObject<T extends TProps<SerializedPolylineProps>>(object: T) {
+  static fromObject<T extends TOptions<SerializedPolylineProps>>(object: T) {
     return this._fromObject<Polyline>(object, {
       extraParam: 'points',
     });

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -1,7 +1,7 @@
 import { kRect } from '../constants';
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { Abortable, TClassProperties, TProps } from '../typedefs';
+import type { Abortable, TClassProperties, TOptions } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
 import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
@@ -27,7 +27,7 @@ export interface RectProps extends FabricObjectProps, UniqueRectProps {}
 const RECT_PROPS = ['rx', 'ry'] as const;
 
 export class Rect<
-    Props extends TProps<RectProps> = Partial<RectProps>,
+    Props extends TOptions<RectProps> = Partial<RectProps>,
     SProps extends SerializedRectProps = SerializedRectProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -1,14 +1,10 @@
 import { kRect } from '../constants';
 import { SHARED_ATTRIBUTES } from '../parser/attributes';
 import { parseAttributes } from '../parser/parseAttributes';
-import type { Abortable, TClassProperties } from '../typedefs';
+import type { Abortable, TClassProperties, TProps } from '../typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject, cacheProperties } from './Object/FabricObject';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
 import type { CSSRules } from '../parser/typedefs';
 

--- a/src/shapes/Text/StyledText.ts
+++ b/src/shapes/Text/StyledText.ts
@@ -1,6 +1,6 @@
 import type { ObjectEvents } from '../../EventTypeDefs';
 import type { FabricObjectProps, SerializedObjectProps } from '../Object/types';
-import type { TProps } from '../../typedefs';
+import type { TOptions } from '../../typedefs';
 import { FabricObject } from '../Object/FabricObject';
 import { styleProperties } from './constants';
 import type { StylePropertiesType } from './constants';
@@ -16,7 +16,7 @@ export type TextStyle = {
 };
 
 export abstract class StyledText<
-  Props extends TProps<FabricObjectProps> = Partial<FabricObjectProps>,
+  Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
   SProps extends SerializedObjectProps = SerializedObjectProps,
   EventSpec extends ObjectEvents = ObjectEvents
 > extends FabricObject<Props, SProps, EventSpec> {

--- a/src/shapes/Text/StyledText.ts
+++ b/src/shapes/Text/StyledText.ts
@@ -1,9 +1,6 @@
 import type { ObjectEvents } from '../../EventTypeDefs';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from '../Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from '../Object/types';
+import type { TProps } from '../../typedefs';
 import { FabricObject } from '../Object/FabricObject';
 import { styleProperties } from './constants';
 import type { StylePropertiesType } from './constants';

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -14,6 +14,7 @@ import type {
   TCacheCanvasDimensions,
   TClassProperties,
   TFiller,
+  TProps,
 } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import { graphemeSplit } from '../../util/lang_string';
@@ -29,11 +30,7 @@ import { cacheProperties } from '../Object/FabricObject';
 import type { Path } from '../Path';
 import { TextSVGExportMixin } from './TextSVGExportMixin';
 import { applyMixins } from '../../util/applyMixins';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from '../Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from '../Object/types';
 import type { StylePropertiesType } from './constants';
 import {
   additionalProps,

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -14,7 +14,7 @@ import type {
   TCacheCanvasDimensions,
   TClassProperties,
   TFiller,
-  TProps,
+  TOptions,
 } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import { graphemeSplit } from '../../util/lang_string';
@@ -120,7 +120,7 @@ export interface TextProps extends FabricObjectProps, UniqueTextProps {
  * @tutorial {@link http://fabricjs.com/fabric-intro-part-2#text}
  */
 export class Text<
-    Props extends TProps<TextProps> = Partial<TextProps>,
+    Props extends TOptions<TextProps> = Partial<TextProps>,
     SProps extends SerializedTextProps = SerializedTextProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
@@ -1895,7 +1895,7 @@ export class Text<
    * @param {Object} object plain js Object to create an instance from
    * @returns {Promise<Text>}
    */
-  static fromObject<T extends TProps<SerializedTextProps>, S extends Text>(
+  static fromObject<T extends TOptions<SerializedTextProps>, S extends Text>(
     object: T
   ) {
     return this._fromObject<S>(

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -1,4 +1,4 @@
-import type { TClassProperties, TProps } from '../typedefs';
+import type { TClassProperties, TOptions } from '../typedefs';
 import { IText } from './IText/IText';
 import { classRegistry } from '../ClassRegistry';
 import { createTextboxDefaultControls } from '../controls/commonControls';
@@ -51,7 +51,7 @@ export interface TextboxProps extends ITextProps, UniqueTextboxProps {}
  * wrapping of lines.
  */
 export class Textbox<
-    Props extends TProps<TextboxProps> = Partial<TextboxProps>,
+    Props extends TOptions<TextboxProps> = Partial<TextboxProps>,
     SProps extends SerializedTextboxProps = SerializedTextboxProps,
     EventSpec extends ITextEvents = ITextEvents
   >

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -1,10 +1,9 @@
-import type { TClassProperties } from '../typedefs';
+import type { TClassProperties, TProps } from '../typedefs';
 import { IText } from './IText/IText';
 import { classRegistry } from '../ClassRegistry';
 import { createTextboxDefaultControls } from '../controls/commonControls';
 import { JUSTIFY } from './Text/constants';
 import type { TextStyleDeclaration } from './Text/StyledText';
-import type { TProps } from './Object/types';
 import type { SerializedITextProps, ITextProps } from './IText/IText';
 import type { ITextEvents } from './IText/ITextBehavior';
 import type { TextLinesInfo } from './Text/Text';

--- a/src/shapes/Triangle.ts
+++ b/src/shapes/Triangle.ts
@@ -1,10 +1,7 @@
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject } from './Object/FabricObject';
-import type {
-  FabricObjectProps,
-  SerializedObjectProps,
-  TProps,
-} from './Object/types';
+import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
+import type { TProps } from '../typedefs';
 import type { ObjectEvents } from '../EventTypeDefs';
 
 export const triangleDefaultValues = {

--- a/src/shapes/Triangle.ts
+++ b/src/shapes/Triangle.ts
@@ -1,7 +1,7 @@
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject } from './Object/FabricObject';
 import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
-import type { TProps } from '../typedefs';
+import type { TOptions } from '../typedefs';
 import type { ObjectEvents } from '../EventTypeDefs';
 
 export const triangleDefaultValues = {
@@ -10,7 +10,7 @@ export const triangleDefaultValues = {
 };
 
 export class Triangle<
-    Props extends TProps<FabricObjectProps> = Partial<FabricObjectProps>,
+    Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
     SProps extends SerializedObjectProps = SerializedObjectProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -122,3 +122,5 @@ export type Abortable = {
    */
   signal?: AbortSignal;
 };
+
+export type TProps<T> = Partial<T> & Record<string, any>;

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -123,4 +123,4 @@ export type Abortable = {
   signal?: AbortSignal;
 };
 
-export type TProps<T> = Partial<T> & Record<string, any>;
+export type TOptions<T> = Partial<T> & Record<string, any>;


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

I am typing canvas options and need `TProps`.
It was under `Obejct` which doesn't make sense anymore if using in canvas files.
So I moved it to typedefs and renamed to TOptions to get started with renaming

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

A lot of ink but nothing happening here

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
