### PR TITLE
Avoid unwanted mutation in Group

### DIFF
--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -173,7 +173,7 @@ export class Group extends createCollectionMixin(
     objectsRelativeToGroup?: boolean
   ) {
     super();
-    this._objects = objects;
+    this._objects = objects.slice(); // Avoid unwanted mutations of Collection to affect the caller
     this.__objectMonitor = this.__objectMonitor.bind(this);
     this.__objectSelectionTracker = this.__objectSelectionMonitor.bind(
       this,


### PR DESCRIPTION
Minor fix: since `Collection` mutates the `_objects` array, this can cause really hard-to-debug bugs if the passed array of objects is used for other purposes as well by the application. To avoid any complication for the unaware developer, a copy should be made.