### PR TITLE
Avoid Group transform when calculating the initial objects bb

### DIFF
--- a/src/shapes/Group.spec.ts
+++ b/src/shapes/Group.spec.ts
@@ -12,4 +12,13 @@ describe('Group', () => {
     expect(objs).toHaveLength(2);
     expect(group._objects).toHaveLength(3);
   });
+
+  it('avoid Group transform for children bounding box during initialization', () => {
+    const child = new FabricObject({ width: 200, height: 200 });
+    const group = new Group([child], { width: 200, height: 200 });
+    const xy = child.getRelativeXY();
+
+    expect(xy.x).toBe(-100);
+    expect(xy.y).toBe(-100);
+  });
 });

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -826,7 +826,8 @@ export class Group extends createCollectionMixin(
       return;
     }
 
-    const bbox = this.getObjectsBoundingBox(objects) || ({} as LayoutResult);
+    const bbox =
+      this.getObjectsBoundingBox(objects, true) || ({} as LayoutResult);
     const { centerX = 0, centerY = 0, width: w = 0, height: h = 0 } = bbox;
     const width = hasWidth ? this.width : w,
       height = hasHeight ? this.height : h,
@@ -897,14 +898,14 @@ export class Group extends createCollectionMixin(
   }
 
   /**
-   * Calculate the bbox of objects relative to instance's containing plane
+   * Calculate the bbox of objects, by default relative to instance's containing plane
    * @public
    * @param {FabricObject[]} objects
    * @returns {LayoutResult | null} bounding box
    */
   getObjectsBoundingBox(
     objects: FabricObject[],
-    ignoreOffset?: boolean
+    ignoreContainingPlane?: boolean
   ): LayoutResult | null {
     if (objects.length === 0) {
       return null;
@@ -930,15 +931,13 @@ export class Group extends createCollectionMixin(
       makeBoundingBoxFromPoints(objectBounds);
 
     const size = new Point(width, height),
-      relativeCenter = (!ignoreOffset ? new Point(left, top) : new Point()).add(
-        size.scalarDivide(2)
-      ),
+      relativeCenter = new Point(left, top).add(size.scalarDivide(2)),
       //  we send `relativeCenter` up to group's containing plane
       center = relativeCenter.transform(this.calcOwnMatrix());
 
     return {
-      centerX: center.x,
-      centerY: center.y,
+      centerX: ignoreContainingPlane ? relativeCenter.x : center.x,
+      centerY: ignoreContainingPlane ? relativeCenter.y : center.y,
       width: size.x,
       height: size.y,
     };


### PR DESCRIPTION
Not 100% this is a bug, but it looks like it to me. If you create a Group and you specify the `width + height`, but not `top/left`, the Group will calculate the initial children bounding box. Hower the calculation is wrong IMO, because it sends the `relativeCenter` to the Group plane, which I'm pretty sure should not be done during initialization. The group is calculating its center by computing the children bb, which in turn uses the group center ??? 

In the test I added for instance:
- the `relativeCenter` is `x: 100, y: 100`
- it gets sent to the Group plane, whose centerPoint is also `x: 100, y: 100` because I've specified a width and height

The end result is that the child is at `x: -200, y: -200`, whereas it should be `x: -100, y: -100`.

![Screenshot 2023-08-30 at 13 25 05](https://github.com/fabricjs/fabric.js/assets/10067273/412e1e76-03b7-448f-a024-5c06fed0598f)