### PR TITLE
Remove subtype in method parameters

### DIFF
--- a/src/shapes/IText/ITextBehavior.ts
+++ b/src/shapes/IText/ITextBehavior.ts
@@ -4,7 +4,7 @@ import type {
   TPointerEventInfo,
 } from '../../EventTypeDefs';
 import { Point } from '../../Point';
-import type { FabricObject } from '../Object/FabricObject';
+import type { FabricObject } from '../Object/Object';
 import { Text } from '../Text/Text';
 import { animate } from '../../util/animation/animate';
 import type { TOnAnimationChangeCallback } from '../../util/animation/types';

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -29,7 +29,6 @@ import { NONE } from '../constants';
 import { getDocumentFromElement } from '../util/dom_misc';
 import type { CSSRules } from '../parser/typedefs';
 import type { Resize } from '../filters/Resize';
-import type { TCachedFabricObject } from './Object/Object';
 
 // @todo Would be nice to have filtering code not imported directly.
 
@@ -597,10 +596,7 @@ export class Image<
    * it will set the imageSmoothing for the draw operation
    * @param {CanvasRenderingContext2D} ctx Context to render on
    */
-  drawCacheOnCanvas(
-    this: TCachedFabricObject<Image>,
-    ctx: CanvasRenderingContext2D
-  ) {
+  drawCacheOnCanvas(ctx: CanvasRenderingContext2D) {
     ctx.imageSmoothingEnabled = this.imageSmoothing;
     // @ts-expect-error TS doesn't respect this type casting
     super.drawCacheOnCanvas(ctx);

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -620,10 +620,7 @@ export class InteractiveFabricObject<
    * @param {FabricObject} [options.object] next object we are setting as active, and reason why
    * this is being deselected
    */
-  onDeselect(options?: {
-    e?: TPointerEvent;
-    object?: InteractiveFabricObject;
-  }): boolean {
+  onDeselect(options?: { e?: TPointerEvent; object?: FabricObject }): boolean {
     // implemented by sub-classes, as needed.
     return false;
   }


### PR DESCRIPTION
Remove type specialization in methods that made them non-assignable to the base class `FabricObject`. If you make `onDeselect` in InteractiveObject to require `InteractiveObject`, it makes the object not assignable to `FabricObject` anymore.

```ts
// Assuming for InteractiveObject
onDeselect(options?: {
    e?: TPointerEvent;
    object?: InteractiveFabricObject;
}

const callOnDeselect = (o: FabricObject) => o.onDeselect({ object: new FabricObject() })

// Unsafe, InteractiveObject technically expects InteractiveObject on onDeselect. 
// May use properties or methods not defined in FabricObject
callOnDeselect(new InteractiveObject())
```