### PR TITLE
Fix a regression in `wrap with fixed anchor`

### DIFF
--- a/.codesandbox/templates/vanilla/src/index.ts
+++ b/.codesandbox/templates/vanilla/src/index.ts
@@ -44,4 +44,17 @@ function animate(toState) {
     }
   );
 }
+
+canvas.add(
+  new fabric.Line([30, 30, 30, 150], { strokeWidth: 2, stroke: 'red' })
+);
+canvas.add(
+  new fabric.Rect({
+    strokeWidth: 2,
+    stroke: 'green',
+    width: 400,
+    height: 100,
+    fill: 'blue',
+  })
+);
 // animate(1);

--- a/.codesandbox/templates/vanilla/src/index.ts
+++ b/.codesandbox/templates/vanilla/src/index.ts
@@ -44,17 +44,4 @@ function animate(toState) {
     }
   );
 }
-
-canvas.add(
-  new fabric.Line([30, 30, 30, 150], { strokeWidth: 2, stroke: 'red' })
-);
-canvas.add(
-  new fabric.Rect({
-    strokeWidth: 2,
-    stroke: 'green',
-    width: 400,
-    height: 100,
-    fill: 'blue',
-  })
-);
 // animate(1);

--- a/src/controls/scale.ts
+++ b/src/controls/scale.ts
@@ -193,7 +193,7 @@ function scaleObject(
       transform.signY = signY;
     }
   }
-  // minScale is taken are in the setter.
+  // minScale is taken care of in the setter.
   const oldScaleX = target.scaleX,
     oldScaleY = target.scaleY;
   if (!by) {

--- a/src/controls/wrapWithFixedAnchor.ts
+++ b/src/controls/wrapWithFixedAnchor.ts
@@ -14,7 +14,13 @@ export function wrapWithFixedAnchor<T extends Transform>(
       centerPoint = target.getRelativeCenterPoint(),
       constraint = target.translateToOriginPoint(centerPoint, originX, originY),
       actionPerformed = actionHandler(eventData, transform, x, y);
-    target.setPositionByOrigin(constraint, originX, originY);
+    // flipping requires to change the transform origin, so we read from the mutated transform
+    // instead of leveraging the one destructured before
+    target.setPositionByOrigin(
+      constraint,
+      transform.originX,
+      transform.originY
+    );
     return actionPerformed;
   }) as TransformActionHandler<T>;
 }


### PR DESCRIPTION
## Motivation

This is a regression fix from v5.
During PR https://github.com/fabricjs/fabric.js/pull/8400 we changed a transform.originX/Y consumed before and after a custom function, with a version destructured.
The custom function gets transform in the arguments and can mutate the originX and originY, so we need to stick to use the values that are on the transform object.

closes #9258

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
