### PR TITLE
fix(IText): cursor width under group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- fix(IText): cursor width under group [#9341](https://github.com/fabricjs/fabric.js/pull/9341)
+
 ## [6.0.0-b3]
 
 - fix(Textbox): implemente a fix for the style shifting issues on new lines [#9197](https://github.com/fabricjs/fabric.js/pull/9197)

--- a/src/shapes/IText/IText.test.ts
+++ b/src/shapes/IText/IText.test.ts
@@ -1,0 +1,32 @@
+import '../../../jest.extend';
+import { Group } from '../Group';
+import { IText } from './IText';
+
+describe('IText', () => {
+  test.each([
+    { scale: 1, zoom: 1 },
+    { scale: 1, zoom: 50 },
+    { scale: 200, zoom: 1 },
+    { scale: 200, zoom: 50 },
+    { scale: 200, zoom: 1 / 200 },
+  ])(
+    'cursor width under a group scaled by $scale and canvas zoomed by $zoom',
+    ({ scale, zoom }) => {
+      const text = new IText('testing', { cursorWidth: 100 });
+      const group = new Group([text]);
+      group.set({ scaleX: scale, scaleY: scale });
+      group.setCoords();
+      const fillRect = jest.fn();
+      const getZoom = jest.fn().mockReturnValue(zoom);
+      const mockContext = { fillRect };
+      const mockCanvas = { contextTop: mockContext, getZoom };
+      jest.replaceProperty(text, 'canvas', mockCanvas);
+
+      text.renderCursorAt(1);
+      expect(fillRect.mock.calls).toMatchSnapshot({
+        cloneDeepWith: (value) =>
+          typeof value === 'number' ? Math.round(value * 10) / 10 : undefined,
+      });
+    }
+  );
+});

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -500,7 +500,7 @@ export class IText<
       charIndex =
         cursorLocation.charIndex > 0 ? cursorLocation.charIndex - 1 : 0,
       charHeight = this.getValueOfPropertyAt(lineIndex, charIndex, 'fontSize'),
-      multiplier = this.scaleX * this.canvas!.getZoom(),
+      multiplier = this.getObjectScaling().x * this.canvas!.getZoom(),
       cursorWidth = this.cursorWidth / multiplier,
       dy = this.getValueOfPropertyAt(lineIndex, charIndex, 'deltaY'),
       topOffset =

--- a/src/shapes/IText/__snapshots__/IText.test.ts.snap
+++ b/src/shapes/IText/__snapshots__/IText.test.ts.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IText cursor width under a group scaled by 1 and canvas zoomed by 1 1`] = `
+[
+  [
+    -92.2,
+    -18.6,
+    100,
+    40,
+  ],
+]
+`;
+
+exports[`IText cursor width under a group scaled by 1 and canvas zoomed by 50 1`] = `
+[
+  [
+    -43.2,
+    -18.6,
+    2,
+    40,
+  ],
+]
+`;
+
+exports[`IText cursor width under a group scaled by 200 and canvas zoomed by 0.005 1`] = `
+[
+  [
+    -92.2,
+    -18.6,
+    100,
+    40,
+  ],
+]
+`;
+
+exports[`IText cursor width under a group scaled by 200 and canvas zoomed by 1 1`] = `
+[
+  [
+    -42.5,
+    -18.6,
+    0.5,
+    40,
+  ],
+]
+`;
+
+exports[`IText cursor width under a group scaled by 200 and canvas zoomed by 50 1`] = `
+[
+  [
+    -42.2,
+    -18.6,
+    0,
+    40,
+  ],
+]
+`;

--- a/src/shapes/IText/__snapshots__/IText.test.ts.snap
+++ b/src/shapes/IText/__snapshots__/IText.test.ts.snap
@@ -1,56 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IText cursor width under a group scaled by 1 and canvas zoomed by 1 1`] = `
-[
-  [
-    -92.2,
-    -18.6,
-    100,
-    40,
-  ],
-]
+exports[`IText cursor drawing width group scaled by 1 and rotated by 0 , text scaled by 1 and rotated by 0, and canvas zoomed by 1 1`] = `
+{
+  "height": "40.000",
+  "width": "100.000",
+}
 `;
 
-exports[`IText cursor width under a group scaled by 1 and canvas zoomed by 50 1`] = `
-[
-  [
-    -43.2,
-    -18.6,
-    2,
-    40,
-  ],
-]
+exports[`IText cursor drawing width group scaled by 1 and rotated by 0 , text scaled by 2 and rotated by 0, and canvas zoomed by 50 1`] = `
+{
+  "height": "40.000",
+  "width": "1.000",
+}
 `;
 
-exports[`IText cursor width under a group scaled by 200 and canvas zoomed by 0.005 1`] = `
-[
-  [
-    -92.2,
-    -18.6,
-    100,
-    40,
-  ],
-]
+exports[`IText cursor drawing width group scaled by 200 and rotated by 0 , text scaled by 1 and rotated by 0, and canvas zoomed by 0.005 1`] = `
+{
+  "height": "40.000",
+  "width": "100.000",
+}
 `;
 
-exports[`IText cursor width under a group scaled by 200 and canvas zoomed by 1 1`] = `
-[
-  [
-    -42.5,
-    -18.6,
-    0.5,
-    40,
-  ],
-]
+exports[`IText cursor drawing width group scaled by 200 and rotated by 0 , text scaled by 1 and rotated by 0, and canvas zoomed by 1 1`] = `
+{
+  "height": "40.000",
+  "width": "0.500",
+}
 `;
 
-exports[`IText cursor width under a group scaled by 200 and canvas zoomed by 50 1`] = `
-[
-  [
-    -42.2,
-    -18.6,
-    0,
-    40,
-  ],
-]
+exports[`IText cursor drawing width group scaled by 200 and rotated by 0 , text scaled by 2 and rotated by 90, and canvas zoomed by 0.005 1`] = `
+{
+  "height": "40.000",
+  "width": "50.000",
+}
+`;
+
+exports[`IText cursor drawing width group scaled by 200 and rotated by 30 , text scaled by 1 and rotated by 30, and canvas zoomed by 50 1`] = `
+{
+  "height": "40.000",
+  "width": "0.010",
+}
+`;
+
+exports[`IText cursor drawing width group scaled by 200 and rotated by 45 , text scaled by 2 and rotated by 0, and canvas zoomed by 1 1`] = `
+{
+  "height": "40.000",
+  "width": "0.250",
+}
 `;


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

@jiayihu 

Found while editing text in a scaled group

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->



## Description

<!-- What you are proposing -->

Text cursor width doesn't take into account group transform.
Another miss of the group rewrite.
I saw that draggable text has the same issue

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
