### PR TITLE
feat(FabricObject): attached/detached events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- feat(FabricObject): attached/detached events [#9342](https://github.com/fabricjs/fabric.js/pull/9342)
+
 ## [6.0.0-b3]
 
 - fix(Textbox): implemente a fix for the style shifting issues on new lines [#9197](https://github.com/fabricjs/fabric.js/pull/9197)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - feat(FabricObject): attached/detached events [#9342](https://github.com/fabricjs/fabric.js/pull/9342)
 
-## [6.0.0-b3]
+## [6.0.0-beta13]
 
 - fix(Textbox): implemente a fix for the style shifting issues on new lines [#9197](https://github.com/fabricjs/fabric.js/pull/9197)
 - Fix(Control) fix a regression in `wrap with fixed anchor`, regression from #8400 [#9326](https://github.com/fabricjs/fabric.js/pull/9326)

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -250,6 +250,8 @@ export interface ObjectEvents
   // tree
   added: { target: Group | Canvas | StaticCanvas };
   removed: { target: Group | Canvas | StaticCanvas };
+  attached: { target: Canvas | StaticCanvas };
+  detached: { target: Canvas | StaticCanvas };
 
   // erasing
   'erasing:end': { path: FabricObject };

--- a/src/shapes/ActiveSelection.spec.ts
+++ b/src/shapes/ActiveSelection.spec.ts
@@ -71,19 +71,21 @@ describe('ActiveSelection', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('sets coords after attaching to canvas', () => {
+  it('sets coords and canvas ref after attaching to canvas', () => {
+    const activeSelection = new ActiveSelection([
+      new FabricObject({
+        left: 100,
+        top: 100,
+        width: 100,
+        height: 100,
+      }),
+    ]);
     const canvas = new Canvas(null, {
-      activeSelection: new ActiveSelection([
-        new FabricObject({
-          left: 100,
-          top: 100,
-          width: 100,
-          height: 100,
-        }),
-      ]),
+      activeSelection,
       viewportTransform: [2, 0, 0, 0.5, 400, 150],
     });
     expect(canvas.getActiveSelection().lineCoords).toMatchSnapshot();
     expect(canvas.getActiveSelection().aCoords).toMatchSnapshot();
+    expect(activeSelection.canvas).toBe(canvas);
   });
 });

--- a/src/shapes/Object/Object.spec.ts
+++ b/src/shapes/Object/Object.spec.ts
@@ -58,4 +58,20 @@ describe('Object', () => {
     expect(fObj.top).toBe(0);
     expect(fObj.left).toBe(0);
   });
+
+  it('setting canvas should fire attached/detached events', () => {
+    const object = new FabricObject();
+    const canvasMock1 = { name: 'canvas1' };
+    const canvasMock2 = { name: 'canvas2' };
+    const spy = jest.spyOn(object, 'fire');
+    object.set({ canvas: canvasMock1 });
+    object.set({ canvas: canvasMock2 });
+    object.set({ canvas: undefined });
+    expect(spy.mock.calls).toEqual([
+      ['attached', { target: canvasMock1 }],
+      ['detached', { target: canvasMock1 }],
+      ['attached', { target: canvasMock2 }],
+      ['detached', { target: canvasMock2 }],
+    ]);
+  });
 });

--- a/src/shapes/__snapshots__/ActiveSelection.spec.ts.snap
+++ b/src/shapes/__snapshots__/ActiveSelection.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ActiveSelection sets coords after attaching to canvas 1`] = `
+exports[`ActiveSelection sets coords and canvas ref after attaching to canvas 1`] = `
 {
   "bl": Point {
     "x": 600,
@@ -21,7 +21,7 @@ exports[`ActiveSelection sets coords after attaching to canvas 1`] = `
 }
 `;
 
-exports[`ActiveSelection sets coords after attaching to canvas 2`] = `
+exports[`ActiveSelection sets coords and canvas ref after attaching to canvas 2`] = `
 {
   "bl": Point {
     "x": 100,


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

There are cases where an objects needs the canvas ref to do some work, such as subscribing to events.
The `added` event is not sufficient if we are dealing with nested objects.

This PR is well related to the active selection initialization process because before recent changes initialization would be done with the canvas ref passed in options and now you don't need to do that and maybe even can't (if you pass the active selection ref to the canvas constructor as options) so the event is needed for the change to be less breaking for apps that relied on the canvas ref. Meaning you simply add an `attached` event listener and do your work there,. That would be the migration path.

Also I have discussed this with @jiayihu who was strongly urging fabric to have some kind of trigger for object initialization that is not the constructor. This is needed for several use cases.
Using subclassing sometimes makes the constructor very hard to deal with because you can't hook into it. Having a lifecycle in the contructor is not an accepted practice so it seems, I am guessing because of the order of execution some properties might not be set yet etc., let alone the TS `declare` nightmare.
A good example is Text classes. They call `initDimensions` in the constructor. It is reasonable to assume that a subclass of Textbox will want to do some work before calling that but it can't. This PR doesn't fix this use case but it provides a workaround saying something like "The first call is a waste, nevermind, I won't call it or use it until the object is attached to the canvas, then I am sure I can subclass even more and not face this issue".
BTW, fabric faces this issue (caused also by using `set` in the super class) and deals with it by adding a flag `initialized` which I know @asturur does not like.
This is another good example of a use case that can't be fixed with this approach but can be worked around somehow.

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

When the canvas ref changes the attached/detached events are fired.
Making it easy to do related work.
These events have a meaning also in terms of rendering.
When they fire you know for sure the object will render or will stop rendering.

## Changes

<!-- before the fix vs. after -->

I patched an active selection test to make it more complete.


## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
