### PR TITLE
fix(StaticCanvas): disposing animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(StaticCanvas): disposing animations [#9361](https://github.com/fabricjs/fabric.js/pull/9361)
 - fix(IText): cursor width under group [#9341](https://github.com/fabricjs/fabric.js/pull/9341)
 - TS(Canvas): constructor optional el [#9348](https://github.com/fabricjs/fabric.js/pull/9348)
 

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -24,6 +24,7 @@ import {
   cancelAnimFrame,
   requestAnimFrame,
 } from '../util/animation/AnimationFrameProvider';
+import { runningAnimations } from '../util/animation/AnimationRegistry';
 import { uid } from '../util/internals/uid';
 import { createCanvasElement, toDataURL } from '../util/misc/dom';
 import { invertTransform, transformPoint } from '../util/misc/matrix';
@@ -1440,6 +1441,7 @@ export class StaticCanvas<
   dispose() {
     !this.disposed &&
       this.elements.cleanupDOM({ width: this.width, height: this.height });
+    runningAnimations.cancelByCanvas(this);
     this.disposed = true;
     return new Promise<boolean>((resolve, reject) => {
       const task = () => {

--- a/src/util/animation/AnimationRegistry.ts
+++ b/src/util/animation/AnimationRegistry.ts
@@ -1,4 +1,4 @@
-import type { Canvas } from '../../canvas/Canvas';
+import type { StaticCanvas } from '../../canvas/StaticCanvas';
 import type { FabricObject } from '../../shapes/Object/FabricObject';
 import type { AnimationBase } from './AnimationBase';
 
@@ -25,17 +25,18 @@ class AnimationRegistry extends Array<AnimationBase> {
   }
 
   /**
-   * Cancel all running animations attached to a Canvas on the next frame
-   * @param {Canvas} canvas
+   * Cancel all running animations attached to a canvas on the next frame
+   * @param {StaticCanvas} canvas
    */
-  cancelByCanvas(canvas: Canvas) {
+  cancelByCanvas(canvas: StaticCanvas) {
     if (!canvas) {
       return [];
     }
     const animations = this.filter(
       (animation) =>
-        typeof animation.target === 'object' &&
-        (animation.target as FabricObject)?.canvas === canvas
+        animation.target === canvas ||
+        (typeof animation.target === 'object' &&
+          (animation.target as FabricObject)?.canvas === canvas)
     );
     animations.forEach((animation) => animation.abort());
     return animations;

--- a/test/unit/canvas_dispose.js
+++ b/test/unit/canvas_dispose.js
@@ -173,6 +173,33 @@ function assertCanvasDisposing(klass) {
         });
         animate();
     });
+
+    QUnit.test('disposing during animation should cancel it by target', function (assert) {
+        const done = assert.async();
+        const canvas = new klass(null, { renderOnAddRemove: false });
+        let called = 0;
+        const animate = () => fabric.util.animate({
+            target: canvas,
+            onChange() {
+                if (called === 1) {
+                    assert.equal(fabric.runningAnimations[0].target, canvas, 'should register the animation by target');
+                    canvas.dispose().then(() => {
+                        assert.deepEqual(fabric.runningAnimations, [], 'should cancel the animation');
+                        done();
+                    });
+                    assert.ok(canvas.disposed, 'should flag `disposed`');
+                }
+                called++;
+                canvas.contextTopDirty = true;
+                canvas.hasLostContext = true;
+                canvas.renderAll();
+            },
+            onComplete() {
+                animate();
+            }
+        });
+        animate();
+    });
 }
 
 function testStaticCanvasDisposing() {


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation


> Why not instead abort any pending request? After all, there may even be other async stuff pending, such as animations scheduled with `requestAnimationFrame`, other than `canvas.requestRenderAll()`. I was thinking today that maybe we could dispose any pending request done with `fabric.util.requestAnimFrame`, to also have a reason to use that vs the native one.

This is done in dispose. There is an option when creating an animation to attach a target property, later on dispose calls the `cancelByCanvas` method on the running animations array. **It should have at least. Now Isee it doesn't.**

_Originally posted by @ShaMan123 in https://github.com/fabricjs/fabric.js/issues/8299#issuecomment-1728542235_
            

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

Dispose running animations that are targetted to the canvas

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
