### PR TITLE
fix(Control): method binding for mouseUpHandler, mouseDownHandler, and actionHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - chore(): cleanup logs and error messages [#9369](https://github.com/fabricjs/fabric.js/pull/9369)
 - feature(Object) BREAKING: Remove lines parameter from object.containsPoint [#9375](https://github.com/fabricjs/fabric.js/pull/9375)
 - patch(Control): move hit detection to shouldActivate [#9374](https://github.com/fabricjs/fabric.js/pull/9374)
-- fix(Control): method binding [#9370](https://github.com/fabricjs/fabric.js/pull/9370)
+- fix(Control): method binding for mouseUpHandler, mouseDownHandler, and actionHandler [#9370](https://github.com/fabricjs/fabric.js/pull/9370)
 - fix(StaticCanvas): disposing animations [#9361](https://github.com/fabricjs/fabric.js/pull/9361)
 - fix(IText): cursor width under group [#9341](https://github.com/fabricjs/fabric.js/pull/9341)
 - TS(Canvas): constructor optional el [#9348](https://github.com/fabricjs/fabric.js/pull/9348)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - chore(): cleanup logs and error messages [#9369](https://github.com/fabricjs/fabric.js/pull/9369)
 - feature(Object) BREAKING: Remove lines parameter from object.containsPoint [#9375](https://github.com/fabricjs/fabric.js/pull/9375)
 - patch(Control): move hit detection to shouldActivate [#9374](https://github.com/fabricjs/fabric.js/pull/9374)
+- fix(Control): method binding [#9370](https://github.com/fabricjs/fabric.js/pull/9370)
 - fix(StaticCanvas): disposing animations [#9361](https://github.com/fabricjs/fabric.js/pull/9361)
 - fix(IText): cursor width under group [#9341](https://github.com/fabricjs/fabric.js/pull/9341)
 - TS(Canvas): constructor optional el [#9348](https://github.com/fabricjs/fabric.js/pull/9348)

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -844,12 +844,12 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
         this.setActiveObject(target, e);
         shouldRender = true;
       } else {
-        const control = target.controls[corner as string];
+        const control = target.controls[corner];
         const mouseUpHandler =
           control && control.getMouseUpHandler(e, target, control);
         if (mouseUpHandler) {
           pointer = this.getPointer(e);
-          mouseUpHandler(e, transform!, pointer.x, pointer.y);
+          mouseUpHandler.call(control, e, transform!, pointer.x, pointer.y);
         }
       }
       target.isMoving = false;
@@ -871,7 +871,13 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
           );
       pointer = pointer || this.getPointer(e);
       originalMouseUpHandler &&
-        originalMouseUpHandler(e, transform, pointer.x, pointer.y);
+        originalMouseUpHandler.call(
+          originalControl,
+          e,
+          transform,
+          pointer.x,
+          pointer.y
+        );
     }
     this._setCursorFromEvent(e, target);
     this._handleEvent(e, 'up', LEFT_CLICK, isClick);
@@ -1132,7 +1138,13 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
           mouseDownHandler =
             control && control.getMouseDownHandler(e, target, control);
         if (mouseDownHandler) {
-          mouseDownHandler(e, this._currentTransform!, pointer.x, pointer.y);
+          mouseDownHandler.call(
+            control,
+            e,
+            this._currentTransform!,
+            pointer.x,
+            pointer.y
+          );
         }
       }
     }

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -605,7 +605,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
       control = !!corner && target.controls[corner],
       actionHandler =
         alreadySelected && control
-          ? control.getActionHandler(e, target, control)
+          ? control.getActionHandler(e, target, control)?.bind(control)
           : dragHandler,
       action = getActionFromCorner(alreadySelected, corner, e, target),
       origin = this._getOriginFromCorner(target, corner),

--- a/src/controls/Control.spec.ts
+++ b/src/controls/Control.spec.ts
@@ -1,0 +1,28 @@
+import { Control } from './Control';
+
+describe('Controls', () => {
+  test('method binding', () => {
+    const actionHandler = jest.fn();
+    const mouseDownHandler = jest.fn();
+    const mouseUpHandler = jest.fn();
+
+    const control = new Control({
+      actionHandler,
+      mouseDownHandler,
+      mouseUpHandler,
+    });
+
+    control.getActionHandler()();
+    expect(actionHandler.mock.contexts).toEqual([control]);
+
+    control.getMouseDownHandler()();
+    expect(mouseDownHandler.mock.contexts).toEqual([control]);
+
+    control.getMouseUpHandler()();
+    expect(mouseUpHandler.mock.contexts).toEqual([control]);
+
+    const b = new Control({ actionHandler });
+    expect(b.getMouseDownHandler()).toBeUndefined();
+    expect(b.getMouseUpHandler()).toBeUndefined();
+  });
+});

--- a/src/controls/Control.spec.ts
+++ b/src/controls/Control.spec.ts
@@ -1,3 +1,5 @@
+import { Canvas } from '../canvas/Canvas';
+import { FabricObject } from '../shapes/Object/FabricObject';
 import { Control } from './Control';
 
 describe('Controls', () => {
@@ -12,17 +14,28 @@ describe('Controls', () => {
       mouseUpHandler,
     });
 
-    control.getActionHandler()();
-    expect(actionHandler.mock.contexts).toEqual([control]);
+    const target = new FabricObject({
+      controls: { test: control, test2: control },
+    });
+    jest.spyOn(target, '_findTargetCorner').mockReturnValue('test');
+    jest.spyOn(target, 'getActiveControl').mockReturnValue('test');
 
-    control.getMouseDownHandler()();
+    const canvas = new Canvas();
+    canvas.setActiveObject(target);
+
+    const downEvent = new MouseEvent('mousedown', { clientX: 0, clientY: 0 });
+    const moveEvent = new MouseEvent('mousemove', { clientX: 0, clientY: 0 });
+    const upEvent = new MouseEvent('mouseup', { clientX: 0, clientY: 0 });
+
+    canvas.getSelectionElement().dispatchEvent(downEvent);
+    // eslint-disable-next-line no-restricted-globals
+    const doc = document;
+    doc.dispatchEvent(moveEvent);
+    canvas._currentTransform!.corner = 'test2';
+    doc.dispatchEvent(upEvent);
+
     expect(mouseDownHandler.mock.contexts).toEqual([control]);
-
-    control.getMouseUpHandler()();
-    expect(mouseUpHandler.mock.contexts).toEqual([control]);
-
-    const b = new Control({ actionHandler });
-    expect(b.getMouseDownHandler()).toBeUndefined();
-    expect(b.getMouseUpHandler()).toBeUndefined();
+    expect(actionHandler.mock.contexts).toEqual([control]);
+    expect(mouseUpHandler.mock.contexts).toEqual([control, control]);
   });
 });

--- a/src/controls/Control.ts
+++ b/src/controls/Control.ts
@@ -196,7 +196,7 @@ export class Control {
     fabricObject: InteractiveFabricObject,
     control: Control
   ): TransformActionHandler | undefined {
-    return this.actionHandler.bind(this);
+    return this.actionHandler;
   }
 
   /**
@@ -211,7 +211,7 @@ export class Control {
     fabricObject: InteractiveFabricObject,
     control: Control
   ): ControlActionHandler | undefined {
-    return this.mouseDownHandler?.bind(this);
+    return this.mouseDownHandler;
   }
 
   /**
@@ -227,7 +227,7 @@ export class Control {
     fabricObject: InteractiveFabricObject,
     control: Control
   ): ControlActionHandler | undefined {
-    return this.mouseUpHandler?.bind(this);
+    return this.mouseUpHandler;
   }
 
   /**

--- a/src/controls/Control.ts
+++ b/src/controls/Control.ts
@@ -196,7 +196,7 @@ export class Control {
     fabricObject: InteractiveFabricObject,
     control: Control
   ): TransformActionHandler | undefined {
-    return this.actionHandler;
+    return this.actionHandler.bind(this);
   }
 
   /**
@@ -211,7 +211,7 @@ export class Control {
     fabricObject: InteractiveFabricObject,
     control: Control
   ): ControlActionHandler | undefined {
-    return this.mouseDownHandler;
+    return this.mouseDownHandler?.bind(this);
   }
 
   /**
@@ -227,7 +227,7 @@ export class Control {
     fabricObject: InteractiveFabricObject,
     control: Control
   ): ControlActionHandler | undefined {
-    return this.mouseUpHandler;
+    return this.mouseUpHandler?.bind(this);
   }
 
   /**


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

Creating controls and subclassing them I found that I can't override actionHandler, mouseDownhandle, mouseUpHandler for 2 reasons:
1. The methods do not get called bound to the instance
2. They are not defined as method by TS but as properties so it troubles me 

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

<!-- What you are proposing -->

Bind the handler when getting them.
I must say I am not sure I understand the need og `getActionHandler` etc.

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
