### PR TITLE
BREAKING(Object) Remove lines parameter from object.containsPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- BREAKING(Object) Remove lines parameter from object.containsPoint [#9375](https://github.com/fabricjs/fabric.js/pull/9375)
+- feature(Object) BREAKING: Remove lines parameter from object.containsPoint [#9375](https://github.com/fabricjs/fabric.js/pull/9375)
 - patch(Control): move hit detection to shouldActivate [#9374](https://github.com/fabricjs/fabric.js/pull/9374)
 - fix(StaticCanvas): disposing animations [#9361](https://github.com/fabricjs/fabric.js/pull/9361)
 - fix(IText): cursor width under group [#9341](https://github.com/fabricjs/fabric.js/pull/9341)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- BREAKING(Object) Remove lines parameter from object.containsPoint [#9375](https://github.com/fabricjs/fabric.js/pull/9375)
 - patch(Control): move hit detection to shouldActivate [#9374](https://github.com/fabricjs/fabric.js/pull/9374)
 - fix(StaticCanvas): disposing animations [#9361](https://github.com/fabricjs/fabric.js/pull/9361)
 - fix(IText): cursor width under group [#9341](https://github.com/fabricjs/fabric.js/pull/9341)

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -329,9 +329,8 @@ export function createCollectionMixin<TBase extends Constructor>(Base: TBase) {
           object.visible &&
           ((includeIntersecting && object.intersectsWithRect(tl, br, true)) ||
             object.isContainedWithinRect(tl, br, true) ||
-            (includeIntersecting &&
-              object.containsPoint(tl, undefined, true)) ||
-            (includeIntersecting && object.containsPoint(br, undefined, true)))
+            (includeIntersecting && object.containsPoint(tl, true)) ||
+            (includeIntersecting && object.containsPoint(br, true)))
         ) {
           objects.push(object);
         }

--- a/src/shapes/Object/ObjectGeometry.ts
+++ b/src/shapes/Object/ObjectGeometry.ts
@@ -285,7 +285,7 @@ export class ObjectGeometry<EventSpec extends ObjectEvents = ObjectEvents>
    * Checks if object is fully contained within area of another object
    * @param {Object} other Object to test
    * @param {Boolean} [absolute] use coordinates without viewportTransform
-   * @param {Boolean} [calculate] use coordinates of current position instead of store ones
+   * @param {Boolean} [calculate] use coordinates of current position instead of stored ones
    * @return {Boolean} true if object is fully contained within area of another object
    */
   isContainedWithinObject(
@@ -295,6 +295,8 @@ export class ObjectGeometry<EventSpec extends ObjectEvents = ObjectEvents>
   ): boolean {
     const points = this.getCoords(absolute, calculate);
     for (let i = 0; i < 4; i++) {
+      // bug/confusing: this containsPoint should receive 'calculate' as well.
+      // will come later because it needs to come with tests
       if (!other.containsPoint(points[i], absolute)) {
         return false;
       }

--- a/src/util/intersection/findCrossPoint.ts
+++ b/src/util/intersection/findCrossPoint.ts
@@ -21,7 +21,7 @@ export type TBBoxLines = {
  * @param {Object} lines Coordinates of the object being evaluated
  * @return {number} number of crossPoint
  */
-export const findCrossPoints = (point: XY, lines: TBBoxLines): number => {
+const findCrossPoints = (point: XY, lines: TBBoxLines): number => {
   let xcount = 0;
 
   for (const lineKey in lines) {
@@ -66,7 +66,7 @@ export const findCrossPoints = (point: XY, lines: TBBoxLines): number => {
  * @private
  * @param {Object} lineCoords or aCoords Coordinates of the object corners
  */
-export const getImageLines = ({ tl, tr, bl, br }: TCornerPoint): TBBoxLines => {
+const getImageLines = ({ tl, tr, bl, br }: TCornerPoint): TBBoxLines => {
   const lines = {
     topline: {
       o: tl,


### PR DESCRIPTION
## Motivation

Passing lines to containsPoint was confusing, used internally to save a very simple calculation in a loop of 4 ( so 1 instead of 4 ).

This makes containsPoint simpler.