### PR TITLE
fix(Canvas): in/out event names were swapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Canvas): Fix canvas in out event firing being swapped [#9396](https://github.com/fabricjs/fabric.js/pull/9396)
 - patch(Control): pass object to `calcCornerCoords` [#9376](https://github.com/fabricjs/fabric.js/pull/9376)
 - fix(Canvas): invalidate `_objectsToRender` on stack change [#9387](https://github.com/fabricjs/fabric.js/pull/9387)
 - ci(e2e): fix babel compiling error [#9388](https://github.com/fabricjs/fabric.js/pull/9388)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
-- fix(Canvas): `setActiveObject` should update `canvas#_activeSelection` [#9336](https://github.com/fabricjs/fabric.js/pull/9336)
-
 ## [next]
 
-- fix(Canvas): Fix canvas in out event firing being swapped [#9396](https://github.com/fabricjs/fabric.js/pull/9396)
+- fix(Canvas): in/out event names were swapped [#9396](https://github.com/fabricjs/fabric.js/pull/9396)
+- fix(Canvas): `setActiveObject` should update `canvas#_activeSelection` [#9336](https://github.com/fabricjs/fabric.js/pull/9336)
 - patch(Coords): calc oCoords only with canvas ref [#9380](https://github.com/fabricjs/fabric.js/pull/9380)
 - patch(Control): pass object to `calcCornerCoords` [#9376](https://github.com/fabricjs/fabric.js/pull/9376)
 - fix(Canvas): invalidate `_objectsToRender` on stack change [#9387](https://github.com/fabricjs/fabric.js/pull/9387)
@@ -26,7 +25,7 @@
 - fix(IText): cursor width under group [#9341](https://github.com/fabricjs/fabric.js/pull/9341)
 - TS(Canvas): constructor optional el [#9348](https://github.com/fabricjs/fabric.js/pull/9348)
 
-## [6.0.0-b13]
+## [6.0.0-beta13]
 
 - fix(Textbox): implemente a fix for the style shifting issues on new lines [#9197](https://github.com/fabricjs/fabric.js/pull/9197)
 - Fix(Control) fix a regression in `wrap with fixed anchor`, regression from #8400 [#9326](https://github.com/fabricjs/fabric.js/pull/9326)

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -145,11 +145,11 @@ interface SimpleEventHandler<T extends Event = TPointerEvent>
 }
 
 interface InEvent {
-  previousTarget?: FabricObject;
+  previousTarget: FabricObject | undefined;
 }
 
 interface OutEvent {
-  nextTarget?: FabricObject;
+  nextTarget: FabricObject | undefined;
 }
 
 export interface DragEventData extends TEvent<DragEvent> {

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -145,11 +145,11 @@ interface SimpleEventHandler<T extends Event = TPointerEvent>
 }
 
 interface InEvent {
-  previousTarget: FabricObject | undefined;
+  previousTarget?: FabricObject;
 }
 
 interface OutEvent {
-  nextTarget: FabricObject | undefined;
+  nextTarget?: FabricObject;
 }
 
 export interface DragEventData extends TEvent<DragEvent> {

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -1325,7 +1325,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     const targetChanged = oldTarget !== target;
 
     if (oldTarget && targetChanged) {
-      const outOpt = {
+      const outOpt: CanvasEvents[typeof canvasOut] = {
         ...data,
         e,
         target: oldTarget,
@@ -1338,7 +1338,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
       oldTarget.fire(targetOut, outOpt);
     }
     if (target && targetChanged) {
-      const inOpt: TPointerEventInfo = {
+      const inOpt: CanvasEvents[typeof canvasIn] = {
         ...data,
         e,
         target,

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -1322,7 +1322,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
         pointer: this.getPointer(e, true),
         absolutePointer: this.getPointer(e),
       };
-      fireCanvas && this.fire(canvasIn, outOpt);
+      fireCanvas && this.fire(canvasOut, outOpt);
       oldTarget.fire(targetOut, outOpt);
     }
     if (target && targetChanged) {
@@ -1335,7 +1335,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
         pointer: this.getPointer(e, true),
         absolutePointer: this.getPointer(e),
       };
-      fireCanvas && this.fire(canvasOut, inOpt);
+      fireCanvas && this.fire(canvasIn, inOpt);
       target.fire(targetIn, inOpt);
     }
   }

--- a/src/canvas/__tests__/__snapshots__/eventData.test.ts.snap
+++ b/src/canvas/__tests__/__snapshots__/eventData.test.ts.snap
@@ -187,7 +187,7 @@ exports[`Canvas event data HTML event "dragenter" should fire a corresponding ca
     },
   ],
   [
-    "drag:leave",
+    "drag:enter",
     {
       "absolutePointer": Point {
         "x": -30,
@@ -260,7 +260,7 @@ exports[`Canvas event data HTML event "dragover" should fire a corresponding can
     },
   ],
   [
-    "drag:leave",
+    "drag:enter",
     {
       "absolutePointer": Point {
         "x": -30,
@@ -571,6 +571,197 @@ exports[`Canvas event data HTML event "wheel" should fire a corresponding canvas
       "pointer": Point {
         "x": 50,
         "y": 50,
+      },
+      "subTargets": [],
+      "target": undefined,
+      "transform": null,
+    },
+  ],
+]
+`;
+
+exports[`should fire mouse over/out events on target 1`] = `
+[
+  [
+    "mouseover",
+    {
+      "absolutePointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "pointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "previousTarget": undefined,
+      "target": "target",
+    },
+  ],
+  [
+    "mousemove",
+    {
+      "absolutePointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "button": 1,
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "pointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "subTargets": [],
+      "target": "target",
+      "transform": null,
+    },
+  ],
+  [
+    "mouseout",
+    {
+      "absolutePointer": Point {
+        "x": 20,
+        "y": 20,
+      },
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "nextTarget": undefined,
+      "pointer": Point {
+        "x": 20,
+        "y": 20,
+      },
+      "target": "target",
+    },
+  ],
+]
+`;
+
+exports[`should fire mouse over/out events on target 2`] = `
+[
+  [
+    "mouse:move:before",
+    {
+      "absolutePointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "button": 1,
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "pointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "subTargets": [],
+      "target": undefined,
+      "transform": null,
+    },
+  ],
+  [
+    "mouse:over",
+    {
+      "absolutePointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "pointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "previousTarget": undefined,
+      "target": "target",
+    },
+  ],
+  [
+    "mouse:move",
+    {
+      "absolutePointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "button": 1,
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "pointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "subTargets": [],
+      "target": "target",
+      "transform": null,
+    },
+  ],
+  [
+    "mouse:move:before",
+    {
+      "absolutePointer": Point {
+        "x": 20,
+        "y": 20,
+      },
+      "button": 1,
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "pointer": Point {
+        "x": 20,
+        "y": 20,
+      },
+      "subTargets": [],
+      "target": undefined,
+      "transform": null,
+    },
+  ],
+  [
+    "mouse:out",
+    {
+      "absolutePointer": Point {
+        "x": 20,
+        "y": 20,
+      },
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "nextTarget": undefined,
+      "pointer": Point {
+        "x": 20,
+        "y": 20,
+      },
+      "target": "target",
+    },
+  ],
+  [
+    "mouse:move",
+    {
+      "absolutePointer": Point {
+        "x": 20,
+        "y": 20,
+      },
+      "button": 1,
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "isClick": false,
+      "pointer": Point {
+        "x": 20,
+        "y": 20,
       },
       "subTargets": [],
       "target": undefined,

--- a/src/canvas/__tests__/eventData.test.ts
+++ b/src/canvas/__tests__/eventData.test.ts
@@ -110,7 +110,7 @@ it('A selected subtarget should not fire an event twice', () => {
     subTargetCheck: true,
     interactive: true,
   });
-  const canvas = new Canvas(null);
+  const canvas = new Canvas();
   canvas.add(group);
   const targetSpy = jest.fn();
   target.on('mousedown', targetSpy);
@@ -121,4 +121,21 @@ it('A selected subtarget should not fire an event twice', () => {
     clientY: 0,
   } as unknown as TPointerEvent);
   expect(targetSpy).toHaveBeenCalledTimes(1);
+});
+
+it('should fire mouse over/out events on target', () => {
+  const target = new FabricObject({ width: 10, height: 10 });
+  const canvas = new Canvas();
+  canvas.add(target);
+
+  jest.spyOn(target, 'toJSON').mockReturnValue('target');
+
+  const targetSpy = jest.spyOn(target, 'fire');
+  const canvasSpy = jest.spyOn(canvas, 'fire');
+  const enter = new MouseEvent('mousemove', { clientX: 5, clientY: 5 });
+  const exit = new MouseEvent('mousemove', { clientX: 20, clientY: 20 });
+  canvas._onMouseMove(enter);
+  canvas._onMouseMove(exit);
+  expect(targetSpy.mock.calls).toMatchSnapshot();
+  expect(canvasSpy.mock.calls).toMatchSnapshot();
 });


### PR DESCRIPTION
Event names were swapped during the migration. 