### PR TITLE
CI(): fix build caching

### DIFF
--- a/.github/actions/build-fabric-cached/action.yml
+++ b/.github/actions/build-fabric-cached/action.yml
@@ -4,11 +4,12 @@ runs:
   using: 'composite'
   steps:
     - name: Get cache build
+      if: github.event_name == 'pull_request'
       id: build-cache
       uses: actions/cache@v3
       with:
         path: ./dist
-        key: npm-${{ github.event.pull_request.head.sha }}
+        key: build-${{ github.event.pull_request.head.sha }}
     - name: Build fabric.js dist folder
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: npm run build -- -f

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,7 +158,8 @@ jobs:
           path: .nyc_output
       - run: ls -l .nyc_output
       - run: npm run coverage:report
-      - uses: ShaMan123/lcov-reporter-action@v1.1.1
+      - uses: ShaMan123/lcov-reporter-action@v1.2.2
+        if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           delete-old-comments: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [next]
 
 - fix(Object): fixes centeredScaling prop type [#9401](https://github.com/fabricjs/fabric.js/pull/9401)
-- CI(): fix build caching [#9404](https://github.com/fabricjs/fabric.js/pull/9404)
+- CI(): fix build caching + tests when merging to master [#9404](https://github.com/fabricjs/fabric.js/pull/9404)
 - chore(): export poly control utils [#9400](https://github.com/fabricjs/fabric.js/pull/9400)
 - fix(Canvas): in/out event names were swapped [#9396](https://github.com/fabricjs/fabric.js/pull/9396)
 - fix(Canvas): `setActiveObject` should update `canvas#_activeSelection` [#9336](https://github.com/fabricjs/fabric.js/pull/9336)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
 
 - fix(Object): fixes centeredScaling prop type [#9401](https://github.com/fabricjs/fabric.js/pull/9401)
+- CI(): fix build caching [#9404](https://github.com/fabricjs/fabric.js/pull/9404)
 - chore(): export poly control utils [#9400](https://github.com/fabricjs/fabric.js/pull/9400)
 - fix(Canvas): in/out event names were swapped [#9396](https://github.com/fabricjs/fabric.js/pull/9396)
 - fix(Canvas): `setActiveObject` should update `canvas#_activeSelection` [#9336](https://github.com/fabricjs/fabric.js/pull/9336)


### PR DESCRIPTION

<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

closes #9403 

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

The build caching was producing a cache for the push to master event.
That is not desired because each time the build changes.
The cache key was wrong (`npm-`). It was generic so the stale cache was used for a long time.

<!-- What you are proposing -->

## Changes

Cache the build only for PRs

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
