### PR TITLE
fix: colorPropToSVG comply with svg specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fix(StaticCanvas): disposing animations [#9361](https://github.com/fabricjs/fabric.js/pull/9361)
 - fix(IText): cursor width under group [#9341](https://github.com/fabricjs/fabric.js/pull/9341)
 - TS(Canvas): constructor optional el [#9348](https://github.com/fabricjs/fabric.js/pull/9348)
+- fix(Utils): fix exported svg color [#9408](https://github.com/fabricjs/fabric.js/pull/9408)
 
 ## [6.0.0-beta13]
 

--- a/src/shapes/Text/TextSVGExportMixin.spec.ts
+++ b/src/shapes/Text/TextSVGExportMixin.spec.ts
@@ -1,0 +1,29 @@
+import { FabricText } from './Text';
+
+describe('TextSvgExport', () => {
+  it('exports text background color correctly', () => {
+    const myText = new FabricText('text', {
+      backgroundColor: 'rgba(100, 0, 100)',
+    });
+    const svgString = myText.toSVG();
+    expect(svgString.includes('fill="rgb(100,0,100)"')).toBe(true);
+    expect(svgString.includes('fill-opacity="1"')).toBe(false);
+  });
+
+  it('exports text background color opacity correctly', () => {
+    const myText = new FabricText('text', {
+      backgroundColor: 'rgba(100, 0, 100, 0.5)',
+    });
+    const svgString = myText.toSVG();
+    expect(svgString.includes('fill-opacity="0.5"')).toBe(true);
+  });
+
+  it('exports text svg styles correctly', () => {
+    const myText = new FabricText('text', { fill: 'rgba(100, 0, 100, 0.5)' });
+    const svgStyles = myText.getSvgStyles();
+    expect(svgStyles.includes('fill: rgb(100,0,100); fill-opacity: 0.5;')).toBe(
+      true
+    );
+    expect(svgStyles.includes('stroke="none"')).toBe(false);
+  });
+});

--- a/src/util/misc/svgParsing.ts
+++ b/src/util/misc/svgParsing.ts
@@ -141,18 +141,18 @@ export const matrixToSVG = (transform: TMat2D) =>
  */
 export const colorPropToSVG = (prop: string, value?: any) => {
   if (!value) {
-    return `${prop}: none; `;
+    return `${prop}="none" `;
   } else if (value.toLive) {
-    return `${prop}: url(#SVGID_${value.id}); `;
+    return `${prop}="url(#SVGID_${value.id})" `;
   } else {
     const color = new Color(value),
       opacity = color.getAlpha();
 
-    let str = `${prop}: ${color.toRgb()}; `;
+    let str = `${prop}="${color.toRgb()}" `;
 
     if (opacity !== 1) {
       //change the color in rgb + opacity
-      str += `${prop}-opacity: ${opacity.toString()}; `;
+      str += `${prop}-opacity="${opacity.toString()}" `;
     }
     return str;
   }

--- a/src/util/misc/svgParsing.ts
+++ b/src/util/misc/svgParsing.ts
@@ -1,3 +1,4 @@
+import { url } from 'inspector';
 import { Color } from '../../color/Color';
 import { config } from '../../config';
 import { DEFAULT_SVG_FONT_SIZE, NONE } from '../../constants';
@@ -82,6 +83,8 @@ export type MeetOrSlice = 'meet' | 'slice';
 
 export type MinMidMax = 'Min' | 'Mid' | 'Max' | 'none';
 
+export type ColorSeparator = ':' | '=';
+
 export type TPreserveArParsed = {
   meetOrSlice: MeetOrSlice;
   alignX: MinMidMax;
@@ -139,20 +142,20 @@ export const matrixToSVG = (transform: TMat2D) =>
  * @param value
  * @returns
  */
-export const colorPropToSVG = (prop: string, value?: any) => {
+export const colorPropToSVG = (prop: string, value?: any, separator: ColorSeparator = ':') => {
   if (!value) {
-    return `${prop}="none" `;
+    return separator === ':' ? `${prop}: none; ` : `${prop}="none" `;
   } else if (value.toLive) {
-    return `${prop}="url(#SVGID_${value.id})" `;
+    return separator === ':' ? `${prop}: url(#SVGID_${value.id}); ` : `${prop}="url(#SVGID_${value.id})" `;
   } else {
     const color = new Color(value),
       opacity = color.getAlpha();
 
-    let str = `${prop}="${color.toRgb()}" `;
+    let str = separator === ':' ? `${prop}: ${color.toRgb()}; ` : `${prop}="${color.toRgb()}" `;
 
     if (opacity !== 1) {
       //change the color in rgb + opacity
-      str += `${prop}-opacity="${opacity.toString()}" `;
+      str += separator === ':' ? `${prop}-opacity: ${opacity.toString()}; ` : `${prop}-opacity="${opacity.toString()}" `;
     }
     return str;
   }
@@ -163,7 +166,7 @@ export const createSVGRect = (
   { left, top, width, height }: TBBox,
   precision = config.NUM_FRACTION_DIGITS
 ) => {
-  const svgColor = colorPropToSVG('fill', color);
+  const svgColor = colorPropToSVG('fill', color, '=');
   const [x, y, w, h] = [left, top, width, height].map((value) =>
     toFixed(value, precision)
   );

--- a/src/util/misc/svgParsing.ts
+++ b/src/util/misc/svgParsing.ts
@@ -1,4 +1,3 @@
-import { url } from 'inspector';
 import { Color } from '../../color/Color';
 import { config } from '../../config';
 import { DEFAULT_SVG_FONT_SIZE, NONE } from '../../constants';

--- a/test/unit/text_to_svg.js
+++ b/test/unit/text_to_svg.js
@@ -70,15 +70,4 @@
     rect.clipPath = clipPath;
     assert.equalSVG(removeTranslate(rect.toSVG()), removeTranslate(EXPECTED));
   });
-  QUnit.test('toSVG with textbox as fill and backgroundColor', function(assert) {
-    fabric.config.configure({ NUM_FRACTION_DIGITS: 0 });
-    var EXPECTED = "\&quot;&lt;g transform=\\&quot;matrix(1 0 0 1 28.2734 23.1)\\&quot; style=\\&quot;\\&quot;  &gt;\n\t\t&lt;rect fill: rgb(255,255,0);  x=\\&quot;-27.7734\\&quot; y=\\&quot;-22.6\\&quot; width=\\&quot;55.5469\\&quot; height=\\&quot;45.2\\&quot;&gt;&lt;/rect&gt;\n\t\t&lt;text xml:space=\\&quot;preserve\\&quot; font-family=\\&quot;Times New Roman\\&quot; font-size=\\&quot;40\\&quot; font-style=\\&quot;normal\\&quot; font-weight=\\&quot;normal\\&quot; style=\\&quot;stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;\\&quot; &gt;&lt;tspan x=\\&quot;-27.7734\\&quot; y=\\&quot;12.5656\\&quot; &gt;test&lt;/tspan&gt;&lt;/text&gt;\n&lt;/g&gt;\n\&quot;"
-    var text = new fabric.Textbox('test', {
-      fill: 'red',
-      width: 10,
-      height: 10,
-      backgroundColor: 'yellow'
-    })
-    assert.equalSVG(removeTranslate(text.toSVG()), removeTranslate(EXPECTED))
-  })
 })();

--- a/test/unit/text_to_svg.js
+++ b/test/unit/text_to_svg.js
@@ -70,4 +70,15 @@
     rect.clipPath = clipPath;
     assert.equalSVG(removeTranslate(rect.toSVG()), removeTranslate(EXPECTED));
   });
+  QUnit.test('toSVG with textbox as fill and backgroundColor', function(assert) {
+    fabric.config.configure({ NUM_FRACTION_DIGITS: 0 });
+    var EXPECTED = "\&quot;&lt;g transform=\\&quot;matrix(1 0 0 1 28.2734 23.1)\\&quot; style=\\&quot;\\&quot;  &gt;\n\t\t&lt;rect fill: rgb(255,255,0);  x=\\&quot;-27.7734\\&quot; y=\\&quot;-22.6\\&quot; width=\\&quot;55.5469\\&quot; height=\\&quot;45.2\\&quot;&gt;&lt;/rect&gt;\n\t\t&lt;text xml:space=\\&quot;preserve\\&quot; font-family=\\&quot;Times New Roman\\&quot; font-size=\\&quot;40\\&quot; font-style=\\&quot;normal\\&quot; font-weight=\\&quot;normal\\&quot; style=\\&quot;stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,0,0); fill-rule: nonzero; opacity: 1; white-space: pre;\\&quot; &gt;&lt;tspan x=\\&quot;-27.7734\\&quot; y=\\&quot;12.5656\\&quot; &gt;test&lt;/tspan&gt;&lt;/text&gt;\n&lt;/g&gt;\n\&quot;"
+    var text = new fabric.Textbox('test', {
+      fill: 'red',
+      width: 10,
+      height: 10,
+      backgroundColor: 'yellow'
+    })
+    assert.equalSVG(removeTranslate(text.toSVG()), removeTranslate(EXPECTED))
+  })
 })();


### PR DESCRIPTION
## Motivation
@closes https://github.com/fabricjs/fabric.js/issues/9407

## Description

Change the output content of the colorPropToSVG function

## Changes
Change ':' to '='
<!-- before the fix vs. after -->

How to write tests correctly, I need a little help, old test component seem doesn't work. This change is very small. Can anyone help me add test? I'm a little busy recently, Sorry
