### PR TITLE
update(findTarget): Select the active object that is covered by other objects

### DIFF
--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -729,24 +729,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
         activeObject === this.searchPossibleTargets([activeObject], pointer)
       ) {
         // active object is not an active selection
-        if (!this.preserveObjectStacking) {
-          return activeObject;
-        } else {
-          const subTargets = this.targets;
-          this.targets = [];
-          const target = this.searchPossibleTargets(this._objects, pointer);
-          if (
-            e[this.altSelectionKey as ModifierKey] &&
-            target &&
-            target !== activeObject
-          ) {
-            // alt selection: select active object even though it is not the top most target
-            // restore targets
-            this.targets = subTargets;
-            return activeObject;
-          }
-          return target;
-        }
+        return activeObject;
       }
     }
 


### PR DESCRIPTION
When I set `preserveObjectStacking` to true, if I drag an active object behind an object with a higher stacking order, I am unable to continue selecting the active object by clicking on the overlapping area. I found that the issue lies in the `findTarget` function, so I removed the relevant code to make it support my requirement. The image below shows the before and after effects, as well as an example demo.


https://github.com/fabricjs/fabric.js/assets/11306583/db5bfa74-1f58-49c2-89bf-0a8ed917442f

[demo](https://codepen.io/zhe-he-the-vuer/pen/poGoGjM)



Alternative solution: If you want to keep the part that I removed but still support the requirement shown in the image, could it be possible to introduce a parameter that allows users to customize it?