### PR TITLE
fix(#9172): dep export `Object`, `Text`, `Image`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- fix(#9172): dep export `Object` [#9433](https://github.com/fabricjs/fabric.js/pull/9433)
+
 ## [6.0.0-beta13]
 
 - fix(Object): fixes centeredScaling prop type [#9401](https://github.com/fabricjs/fabric.js/pull/9401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- fix(#9172): dep export `Object` [#9433](https://github.com/fabricjs/fabric.js/pull/9433)
+- fix(#9172): dep export `Object`, `Text`, `Image` [#9433](https://github.com/fabricjs/fabric.js/pull/9433)
 
 ## [6.0.0-beta13]
 

--- a/fabric.ts
+++ b/fabric.ts
@@ -43,7 +43,13 @@ export { PatternBrush } from './src/brushes/PatternBrush';
 
 export {
   FabricObject,
-  _Object as Object,
+  /**
+   * @deprecated The old fabric.Object class can't be imported as Object because of conflict with the JS api
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
+   * For this reason it has been renamed to FabricObject.
+   * Please use `import { FabricObject }` in place of `import { Object as FabricObject }`
+   */
+  FabricObject as Object,
 } from './src/shapes/Object/FabricObject';
 
 export type {

--- a/fabric.ts
+++ b/fabric.ts
@@ -43,11 +43,16 @@ export { PatternBrush } from './src/brushes/PatternBrush';
 
 export {
   FabricObject,
+
   /**
-   * @deprecated The old fabric.Object class can't be imported as Object because of conflict with the JS api
-   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
-   * For this reason it has been renamed to FabricObject.
-   * Please use `import { FabricObject }` in place of `import { Object as FabricObject }`
+   * @deprecated Due to a naming conflict with the
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object JS API},
+   * `fabric.Object` has been renamed to `FabricObject`
+   *
+   * @example
+   * import { Object } from 'fabric'; // deprecated
+   * import { FabricObject } from 'fabric'; // migration path
+   *
    */
   FabricObject as Object,
 } from './src/shapes/Object/FabricObject';
@@ -81,7 +86,20 @@ export type {
   TPathSide,
   TextProps,
 } from './src/shapes/Text/Text';
-export { Text, FabricText } from './src/shapes/Text/Text';
+export {
+  FabricText,
+  /**
+   * @deprecated Due to a naming conflict with the
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/Text/Text Web API},
+   * `fabric.Text` has been renamed to `FabricText`
+   *
+   * @example
+   * import { Text } from 'fabric'; // deprecated
+   * import { FabricText } from 'fabric'; // migration path
+   *
+   */
+  FabricText as Text,
+} from './src/shapes/Text/Text';
 export type {
   ITextProps,
   SerializedITextProps,
@@ -114,7 +132,21 @@ export type {
   MultiSelectionStacking,
 } from './src/shapes/ActiveSelection';
 export { ActiveSelection } from './src/shapes/ActiveSelection';
-export { Image, FabricImage } from './src/shapes/Image';
+export {
+  FabricImage,
+
+  /**
+   * @deprecated Due to a naming conflict with the
+   * {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image Web API},
+   * `fabric.Image` has been renamed to `FabricImage`
+   *
+   * @example
+   * import { Image } from 'fabric'; // deprecated
+   * import { FabricImage } from 'fabric'; // migration path
+   *
+   */
+  FabricImage as Image,
+} from './src/shapes/Image';
 export type {
   ImageSource,
   SerializedImageProps,

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -859,11 +859,3 @@ export class FabricImage<
 
 classRegistry.setClass(FabricImage);
 classRegistry.setSVGClass(FabricImage);
-
-/**
- * @deprecated The old fabric.Image class can't be imported as Image because of conflict with Web API.
- * https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image
- * For this reason it has been renamed to FabricImage.
- * Please use `import { FabricImage }` in place of `import { Image as FabricImage }`
- */
-export class Image extends FabricImage {}

--- a/src/shapes/Object/FabricObject.ts
+++ b/src/shapes/Object/FabricObject.ts
@@ -27,11 +27,3 @@ classRegistry.setClass(FabricObject);
 classRegistry.setClass(FabricObject, 'object');
 
 export { cacheProperties } from './defaultValues';
-
-/**
- * @deprecated The old fabric.Object class can't be imported as Object because of conflict with the JS api
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
- * For this reason it has been renamed to FabricObject.
- * Please use `import { FabricObject }` in place of `import { Object as FabricObject }`
- */
-export class _Object extends FabricObject {}

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -1915,11 +1915,3 @@ export class FabricText<
 applyMixins(FabricText, [TextSVGExportMixin]);
 classRegistry.setClass(FabricText);
 classRegistry.setSVGClass(FabricText);
-
-/**
- * @deprecated The old fabric.Text class can't be imported as Text because of conflict with Web API.
- * https://developer.mozilla.org/en-US/docs/Web/API/Text/Text
- * For this reason it has been renamed to FabricText.
- * Please use `import { FabricText }` in place of `import { Text as FabricText }`
- */
-export class Text extends FabricText {}


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

https://github.com/fabricjs/fabric.js/commit/23430b187d2bc17540eafce17936c80958c274a5#r130686412

Creating a subclass is wrong in order to depreacte `Object`
The deprecated class is not part of the proto chain so it is not a deprecating change, it is breaking and useless because it can't be used, e.g. `instanceof`, prototype mutation etc. are all broken

## Description

<!-- What you are proposing -->

## Changes

I simply re-exported the class with a different name
I was sure that was mentioned in the comments of #9172 but I missed it

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

From VSCODE:
The deprecation is noticable, but the comment is not

![image](https://github.com/fabricjs/fabric.js/assets/34343793/4876a44e-9376-48cd-85d0-d4f881d44810)


<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
