### PR TITLE
ci(): try pull_request_target event to give access to fork prs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: ./.github/actions/cached-install
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: npm run build
   stats:
     name: Build stats
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: npm ci
       - name: build stats
         run: npm run build
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: ./.github/actions/cached-install
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: npm run lint
   prettier:
     runs-on: ubuntu-latest
@@ -87,5 +87,5 @@ jobs:
         uses: actions/checkout@v3
       - uses: ./.github/actions/cached-install
         with:
-          node-version: 18.x
+          node-version: 20.x
       - run: npm run prettier:check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [master]
     paths-ignore: [CHANGELOG.md]
+  pull_request_target:
+    branches: [master]
+    types: [opened, edited]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore: [CHANGELOG.md]
   pull_request_target:
     branches: [master]
-    types: [opened, edited]
+    paths-ignore: [CHANGELOG.md]
 
 jobs:
   build:

--- a/.github/workflows/changelog_required.yml
+++ b/.github/workflows/changelog_required.yml
@@ -3,6 +3,8 @@ name: '📋'
 on:
   pull_request:
     branches: [master]
+  pull_request_target:
+    branches: [master]
 
 jobs:
   changelog:

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [master]
     types: [opened, edited]
+  pull_request_target:
+    branches: [master]
+    types: [opened, edited]
 
 jobs:
   changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): try pull_request_target event to give access to fork prs [#9455](https://github.com/fabricjs/fabric.js/pull/9455)
 - BREAKING refactor(Canvas): remove `button` property from mouse events
 - patch(Canvas): move event mouse:up:before earlier in the logic for more control [#9434](https://github.com/fabricjs/fabric.js/pull/9434)
 


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

This is trying to solve the issue in #8336 

The pull_request_target should allow the PR to run on the workflow of the base branch of the pr, so not allowing forks to commit changes to workflows, making the workflows they run trusted and so writable.

I have no idea how it works in combination with the pull_request event, i guess we can find out

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->
