### PR TITLE
fix(Canvas): control down/up pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Canvas): control down/up pointer [#9463](https://github.com/fabricjs/fabric.js/pull/9463)
 - feat(util): expose `calcPlaneRotation` [#9419](https://github.com/fabricjs/fabric.js/pull/9419)
 - refactor(Canvas): BREAKING remove button from mouse events, delegate to event.button property [#9449](https://github.com/fabricjs/fabric.js/pull/9449)
 - patch(Canvas): move event mouse:up:before earlier in the logic for more control [#9434](https://github.com/fabricjs/fabric.js/pull/9434)

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -834,7 +834,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
         const mouseUpHandler =
           control && control.getMouseUpHandler(e, target, control);
         if (mouseUpHandler) {
-          pointer = this.getPointer(e);
+          pointer = this.getPointer(e, true);
           mouseUpHandler.call(control, e, transform!, pointer.x, pointer.y);
         }
       }
@@ -855,7 +855,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
             transform.target,
             originalControl
           );
-      pointer = pointer || this.getPointer(e);
+      pointer = pointer || this.getPointer(e, true);
       originalMouseUpHandler &&
         originalMouseUpHandler.call(
           originalControl,
@@ -1110,7 +1110,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
       if (target === this._activeObject && (corner || !grouped)) {
         this._setupCurrentTransform(e, target, alreadySelected);
         const control = target.controls[corner],
-          pointer = this.getPointer(e),
+          pointer = this.getPointer(e, true),
           mouseDownHandler =
             control && control.getMouseDownHandler(e, target, control);
         if (mouseDownHandler) {


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

The pointer for mouseDownHandler/mouseUpHandler should be from the viewport

https://github.com/fabricjs/fabric.js/pull/8519/files#diff-72332330d8e00b2fda6e57d000a93e4e8dd8a46fdc8bcbdb3320c23b1509f8b5L748-L752

the bug exists on v5:
https://github.com/fabricjs/fabric.js/blob/5.x/src/mixins/canvas_events.mixin.js#L468-L472

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
