### PR TITLE
chore(): rm `isClick` artifacts leftovers from #9434

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - chore(): expose `sendVectorToPlane` [#9479](https://github.com/fabricjs/fabric.js/pull/9479)
 - BREAKING: remove absolute true/false from the api. [#9395](https://github.com/fabricjs/fabric.js/pull/9395)
 - refactor(Canvas): BREAKING deprecate `getPointer`, add new getScenePoint and getViewportPoint methods, removed `restorePointerVpt`, extended mouse events data [#9175](https://github.com/fabricjs/fabric.js/pull/9175)
+- patch(): rm `isClick` artifacts [#9478](https://github.com/fabricjs/fabric.js/pull/9478)
 - fix(Object): Fix detection of falsy shadows in Object.needsItsOwnCache method [#9469](https://github.com/fabricjs/fabric.js/pull/9469)
 - feat(util): expose `calcPlaneRotation` [#9419](https://github.com/fabricjs/fabric.js/pull/9419)
 - refactor(Canvas): BREAKING remove button from mouse events, delegate to event.button property [#9449](https://github.com/fabricjs/fabric.js/pull/9449)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - chore(): expose `sendVectorToPlane` [#9479](https://github.com/fabricjs/fabric.js/pull/9479)
 - BREAKING: remove absolute true/false from the api. [#9395](https://github.com/fabricjs/fabric.js/pull/9395)
 - refactor(Canvas): BREAKING deprecate `getPointer`, add new getScenePoint and getViewportPoint methods, removed `restorePointerVpt`, extended mouse events data [#9175](https://github.com/fabricjs/fabric.js/pull/9175)
-- patch(): rm `isClick` artifacts [#9478](https://github.com/fabricjs/fabric.js/pull/9478)
+- chore(): rm isClick artifacts leftovers from #9434 [#9478](https://github.com/fabricjs/fabric.js/pull/9478)
 - fix(Object): Fix detection of falsy shadows in Object.needsItsOwnCache method [#9469](https://github.com/fabricjs/fabric.js/pull/9469)
 - feat(util): expose `calcPlaneRotation` [#9419](https://github.com/fabricjs/fabric.js/pull/9419)
 - refactor(Canvas): BREAKING remove button from mouse events, delegate to event.button property [#9449](https://github.com/fabricjs/fabric.js/pull/9449)

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -242,7 +242,6 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     const target = this._hoveredTarget;
     const shared = {
       e,
-      isClick: false,
       ...getEventPoints(this, e),
     };
     this.fire('mouse:out', { ...shared, target });
@@ -1296,7 +1295,6 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
         e,
         target: oldTarget,
         nextTarget: target,
-        isClick: false,
         ...getEventPoints(this, e),
       };
       fireCanvas && this.fire(canvasOut, outOpt);
@@ -1308,7 +1306,6 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
         e,
         target,
         previousTarget: oldTarget,
-        isClick: false,
         ...getEventPoints(this, e),
       };
       fireCanvas && this.fire(canvasIn, inOpt);
@@ -1511,7 +1508,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
    * - selects objects that are contained in (and possibly intersecting) the selection bounding box
    * - sets the active object
    * ---
-   * runs on mouse up
+   * runs on mouse up after a mouse move
    */
   protected handleSelection(e: TPointerEvent) {
     if (!this.selection || !this._groupSelector) {
@@ -1522,8 +1519,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
       point2 = point1.add(new Point(deltaX, deltaY)),
       tl = point1.min(point2),
       br = point1.max(point2),
-      size = br.subtract(tl),
-      isClick = point1.eq(point2);
+      size = br.subtract(tl);
 
     const collectedObjects = this.collectObjects(
       {
@@ -1535,13 +1531,10 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
       { includeIntersecting: !this.selectionFullyContained }
     ) as FabricObject[];
 
-    const objects = isClick
-      ? collectedObjects[0]
-        ? [collectedObjects[0]]
-        : []
-      : collectedObjects.length > 1
-      ? collectedObjects.filter((object) => !object.onSelect({ e })).reverse()
-      : collectedObjects;
+    const objects =
+      collectedObjects.length > 1
+        ? collectedObjects.filter((object) => !object.onSelect({ e })).reverse()
+        : collectedObjects;
 
     // set active object
     if (objects.length === 1) {

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -1532,9 +1532,16 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     ) as FabricObject[];
 
     const objects =
-      collectedObjects.length > 1
+      // though this method runs only after mouse move the pointer could do a mouse up on the same position as mouse down
+      // should it be handled as is?
+      point1.eq(point2)
+        ? collectedObjects[0]
+          ? [collectedObjects[0]]
+          : []
+        : collectedObjects.length > 1
         ? collectedObjects.filter((object) => !object.onSelect({ e })).reverse()
-        : collectedObjects;
+        : // `setActiveObject` will call `onSelect(collectedObjects[0])` in this case
+          collectedObjects;
 
     // set active object
     if (objects.length === 1) {

--- a/src/canvas/__tests__/__snapshots__/eventData.test.ts.snap
+++ b/src/canvas/__tests__/__snapshots__/eventData.test.ts.snap
@@ -219,7 +219,6 @@ exports[`Canvas event data HTML event "dragenter" should fire a corresponding ca
       "e": MouseEvent {
         "isTrusted": false,
       },
-      "isClick": false,
       "pointer": Point {
         "x": 50,
         "y": 50,
@@ -302,7 +301,6 @@ exports[`Canvas event data HTML event "dragover" should fire a corresponding can
       "e": MouseEvent {
         "isTrusted": false,
       },
-      "isClick": false,
       "pointer": Point {
         "x": 50,
         "y": 50,
@@ -585,7 +583,6 @@ exports[`Canvas event data HTML event "mouseout" should fire a corresponding can
       "e": MouseEvent {
         "isTrusted": false,
       },
-      "isClick": false,
       "pointer": Point {
         "x": 50,
         "y": 50,
@@ -715,7 +712,6 @@ exports[`should fire mouse over/out events on target 1`] = `
       "e": MouseEvent {
         "isTrusted": false,
       },
-      "isClick": false,
       "pointer": Point {
         "x": 5,
         "y": 5,
@@ -769,7 +765,6 @@ exports[`should fire mouse over/out events on target 1`] = `
       "e": MouseEvent {
         "isTrusted": false,
       },
-      "isClick": false,
       "nextTarget": undefined,
       "pointer": Point {
         "x": 20,
@@ -828,7 +823,6 @@ exports[`should fire mouse over/out events on target 2`] = `
       "e": MouseEvent {
         "isTrusted": false,
       },
-      "isClick": false,
       "pointer": Point {
         "x": 5,
         "y": 5,
@@ -909,7 +903,6 @@ exports[`should fire mouse over/out events on target 2`] = `
       "e": MouseEvent {
         "isTrusted": false,
       },
-      "isClick": false,
       "nextTarget": undefined,
       "pointer": Point {
         "x": 20,

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -606,15 +606,16 @@
     assert.equal(canvas.getActiveObject(), rect1, 'rect1 is set as activeObject');
   });
 
-  QUnit.test('handleSelection collect topmost object if no dragging occurs', function (assert) {
+  QUnit.test('handleSelection collects all intersecting objects', function (assert) {
     var rect1 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
     var rect2 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
     var rect3 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
-    canvas.add(rect1, rect2, rect3);
+    var rect4 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 10 });
+    canvas.add(rect1, rect2, rect3, rect4);
     setGroupSelector(canvas, { x: 1, y: 1, deltaX: 0, deltaY: 0 });
     assert.ok(canvas.handleSelection({}), 'selection occurred');
-    assert.equal(canvas.getActiveObjects().length, 1, 'a rect that contains all objects collects them all');
-    assert.equal(canvas.getActiveObjects()[0], rect3, 'rect3 is collected');
+    assert.equal(canvas.getActiveObjects().length, 3, 'a rect that contains all objects collects them all');
+    assert.deepEqual(canvas.getActiveObjects(), [rect1, rect2, rect3], 'rect4 is not collected');
   });
 
   QUnit.test('handleSelection does not collect objects that have onSelect returning true', function(assert) {

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -606,16 +606,15 @@
     assert.equal(canvas.getActiveObject(), rect1, 'rect1 is set as activeObject');
   });
 
-  QUnit.test('handleSelection collects all intersecting objects', function (assert) {
+  QUnit.test('handleSelection collect topmost object if no dragging occurs', function (assert) {
     var rect1 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
     var rect2 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
     var rect3 = new fabric.Rect({ width: 10, height: 10, top: 0, left: 0 });
-    var rect4 = new fabric.Rect({ width: 10, height: 10, top: 10, left: 10 });
-    canvas.add(rect1, rect2, rect3, rect4);
+    canvas.add(rect1, rect2, rect3);
     setGroupSelector(canvas, { x: 1, y: 1, deltaX: 0, deltaY: 0 });
     assert.ok(canvas.handleSelection({}), 'selection occurred');
-    assert.equal(canvas.getActiveObjects().length, 3, 'a rect that contains all objects collects them all');
-    assert.deepEqual(canvas.getActiveObjects(), [rect1, rect2, rect3], 'rect4 is not collected');
+    assert.equal(canvas.getActiveObjects().length, 1, 'a rect that contains all objects collects them all');
+    assert.equal(canvas.getActiveObjects()[0], rect3, 'rect3 is collected');
   });
 
   QUnit.test('handleSelection does not collect objects that have onSelect returning true', function(assert) {

--- a/test/unit/draggable_text.js
+++ b/test/unit/draggable_text.js
@@ -271,7 +271,6 @@ function assertDragEventStream(name, a, b) {
                         absolutePointer: new fabric.Point(30, 15),
                         viewportPoint: new fabric.Point(30, 15),
                         scenePoint: new fabric.Point(30, 15),
-                        isClick: false,
                         previousTarget: undefined
                     },
                     ...dragEvents.slice(0, 32).map(e => ({
@@ -304,7 +303,6 @@ function assertDragEventStream(name, a, b) {
                         absolutePointer: new fabric.Point(123, 15),
                         viewportPoint: new fabric.Point(123, 15),
                         scenePoint: new fabric.Point(123, 15),
-                        isClick: false,
                         nextTarget: undefined
                     },
                     {
@@ -366,7 +364,6 @@ function assertDragEventStream(name, a, b) {
                         absolutePointer: new fabric.Point(210, 15),
                         viewportPoint: new fabric.Point(210, 15),
                         scenePoint: new fabric.Point(210, 15),
-                        isClick: false,
                         previousTarget: undefined
                     },
                     ...dragEvents.slice(0, 6).map(e => ({
@@ -390,7 +387,6 @@ function assertDragEventStream(name, a, b) {
                         absolutePointer: new fabric.Point(220, -5),
                         viewportPoint: new fabric.Point(220, -5),
                         scenePoint: new fabric.Point(220, -5),
-                        isClick: false,
                         nextTarget: undefined
                     },
                 ]);
@@ -466,8 +462,6 @@ function assertDragEventStream(name, a, b) {
                         absolutePointer: new fabric.Point(100, 15),
                         viewportPoint: new fabric.Point(100, 15),
                         scenePoint: new fabric.Point(100, 15),
-                        isClick: false,
-                        previousTarget: undefined
                     },
                     ...dragEvents.slice(0, 2).map(e => ({
                         e,
@@ -537,7 +531,6 @@ function assertDragEventStream(name, a, b) {
                         absolutePointer: new fabric.Point(230, 15),
                         viewportPoint: new fabric.Point(230, 15),
                         scenePoint: new fabric.Point(230, 15),
-                        isClick: false,
                         previousTarget: undefined
                     },
                     ...dragEvents.slice(0, 2).map(e => ({
@@ -600,7 +593,6 @@ function assertDragEventStream(name, a, b) {
                         absolutePointer: new fabric.Point(230, 15),
                         viewportPoint: new fabric.Point(230, 15),
                         scenePoint: new fabric.Point(230, 15),
-                        isClick: false,
                         previousTarget: undefined
                     },
                     ...dragEvents.slice(0, 2).map(e => ({

--- a/test/unit/draggable_text.js
+++ b/test/unit/draggable_text.js
@@ -462,6 +462,7 @@ function assertDragEventStream(name, a, b) {
                         absolutePointer: new fabric.Point(100, 15),
                         viewportPoint: new fabric.Point(100, 15),
                         scenePoint: new fabric.Point(100, 15),
+                        previousTarget: undefined
                     },
                     ...dragEvents.slice(0, 2).map(e => ({
                         e,


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

I missed `isClick` props in #9434

<!-- What you are proposing -->

## Changes

- rm remaining `isClick` props from events that are not mouseup
- ~rm `isClick` check inside `handleSelection` because it runs inside a condition that checks that already in mouse up~


<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
