### PR TITLE
docs(): DRAFT: Remove inheritance from docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "tslib": "^2.4.1",
         "typedoc": "^0.25.3",
         "typedoc-plugin-markdown": "^3.17.0",
+        "typedoc-plugin-no-inherit": "^1.4.0",
         "typescript": "^4.9.4",
         "v8-to-istanbul": "^9.1.0"
       },
@@ -11793,6 +11794,15 @@
         "typedoc": ">=0.24.0"
       }
     },
+    "node_modules/typedoc-plugin-no-inherit": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.4.0.tgz",
+      "integrity": "sha512-cAvqQ8X9xh1xztVoDKtF4nYRSBx9XwttN3OBbNNpA0YaJSRM8XvpVVhugq8FoO1HdWjF3aizS0JzdUOMDt0y9g==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": ">=0.23.0"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -20368,6 +20378,13 @@
       "requires": {
         "handlebars": "^4.7.7"
       }
+    },
+    "typedoc-plugin-no-inherit": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.4.0.tgz",
+      "integrity": "sha512-cAvqQ8X9xh1xztVoDKtF4nYRSBx9XwttN3OBbNNpA0YaJSRM8XvpVVhugq8FoO1HdWjF3aizS0JzdUOMDt0y9g==",
+      "dev": true,
+      "requires": {}
     },
     "typescript": {
       "version": "4.9.4",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "tslib": "^2.4.1",
     "typedoc": "^0.25.3",
     "typedoc-plugin-markdown": "^3.17.0",
+    "typedoc-plugin-no-inherit": "^1.4.0",
     "typescript": "^4.9.4",
     "v8-to-istanbul": "^9.1.0"
   },

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -27,6 +27,9 @@ export interface SerializedPolylineProps extends SerializedObjectProps {
   points: XY[];
 }
 
+/**
+ * @noInheritDoc
+ */
 export class Polyline<
   Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
   SProps extends SerializedPolylineProps = SerializedPolylineProps,

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -26,6 +26,9 @@ export interface RectProps extends FabricObjectProps, UniqueRectProps {}
 
 const RECT_PROPS = ['rx', 'ry'] as const;
 
+/**
+ * @noInheritDoc
+ */
 export class Rect<
     Props extends TOptions<RectProps> = Partial<RectProps>,
     SProps extends SerializedRectProps = SerializedRectProps,

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,6 +7,7 @@
   "tsconfig": "typedoc.config.json",
   "hideBreadcrumbs": "true",
   "hideInPageTOC": "true",
+  "hideMembersSymbol": "true",
   "publicPath": "/apidocs/",
-  "plugin": ["typedoc-plugin-markdown"]
+  "plugin": ["typedoc-plugin-no-inherit", "typedoc-plugin-markdown"]
 }


### PR DESCRIPTION
## Motivation

tsdocs generation as of now is ugly, pages are enormous and not really user friednly.
This plugin i m adding allow us to flag a class as documented without inheritance.
It should be recursive, but it isn't, but even if we have to add a tag to each class is still fine and in that case does its job.

The final goal is to move away all of this stuff into the website repository, but for now to move forward rather than refactoring the document stack is easier to keep it here.

Will be moved anyway