### PR TITLE
BREAKING(): Brush `onMouseDown` `onMouseMove` `onMouseUp` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- BREAKING(): Brush `onMouseDown` `onMouseMove` `onMouseUp` signature [#9501](https://github.com/fabricjs/fabric.js/pull/9501)
 - test(FabricObject): add a snapshot of the default values so that reordering and shuffling is verified. [#9492](https://github.com/fabricjs/fabric.js/pull/9492)
 - feat(FabricObject, Canvas) BREAKING: remove calculate true/false from the api. [#9483](https://github.com/fabricjs/fabric.js/pull/9483)
 - chore(): remove some Type assertions [#8950](https://github.com/fabricjs/fabric.js/pull/8950)

--- a/src/brushes/BaseBrush.ts
+++ b/src/brushes/BaseBrush.ts
@@ -3,6 +3,7 @@ import type { Point } from '../Point';
 import type { Shadow } from '../Shadow';
 import type { Canvas } from '../canvas/Canvas';
 import type { TBrushEventData } from './typedefs';
+import { TPointerEvent } from '../EventTypeDefs';
 
 /**
  * @see {@link http://fabricjs.com/freedrawing|Freedrawing demo}
@@ -64,12 +65,8 @@ export abstract class BaseBrush {
    * @type Boolean
    * @default false
    */
-
   limitedToCanvasSize = false;
 
-  /**
-   * @todo add type
-   */
   declare canvas: Canvas;
 
   constructor(canvas: Canvas) {
@@ -77,8 +74,25 @@ export abstract class BaseBrush {
   }
 
   abstract _render(): void;
-  abstract onMouseDown(pointer: Point, ev: TBrushEventData): void;
-  abstract onMouseMove(pointer: Point, ev: TBrushEventData): void;
+
+  discardActiveObjectOnMouseDown(e: TPointerEvent) {
+    const { canvas } = this;
+    if (canvas.getActiveObject()) {
+      canvas.discardActiveObject(e);
+      canvas.requestRenderAll();
+    }
+  }
+
+  onMouseDown(ev: TBrushEventData): void {
+    this.discardActiveObjectOnMouseDown(ev.e);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onMouseMove(ev: TBrushEventData): void {
+    const { canvas } = this;
+    canvas.setCursor(canvas.freeDrawingCursor);
+  }
+
   /**
    * @returns true if brush should continue blocking interaction
    */

--- a/src/brushes/BaseBrush.ts
+++ b/src/brushes/BaseBrush.ts
@@ -3,7 +3,7 @@ import type { Point } from '../Point';
 import type { Shadow } from '../Shadow';
 import type { Canvas } from '../canvas/Canvas';
 import type { TBrushEventData } from './typedefs';
-import { TPointerEvent } from '../EventTypeDefs';
+import type { TPointerEvent } from '../EventTypeDefs';
 
 /**
  * @see {@link http://fabricjs.com/freedrawing|Freedrawing demo}
@@ -67,6 +67,8 @@ export abstract class BaseBrush {
    */
   limitedToCanvasSize = false;
 
+  cursor: CSSStyleDeclaration['cursor'] = 'crosshair';
+
   declare canvas: Canvas;
 
   constructor(canvas: Canvas) {
@@ -75,7 +77,7 @@ export abstract class BaseBrush {
 
   abstract _render(): void;
 
-  discardActiveObjectOnMouseDown(e: TPointerEvent) {
+  enterDrawingMode(e: TPointerEvent) {
     const { canvas } = this;
     if (canvas.getActiveObject()) {
       canvas.discardActiveObject(e);
@@ -83,14 +85,12 @@ export abstract class BaseBrush {
     }
   }
 
-  onMouseDown(ev: TBrushEventData): void {
-    this.discardActiveObjectOnMouseDown(ev.e);
-  }
+  abstract onMouseDown(ev: TBrushEventData): void;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onMouseMove(ev: TBrushEventData): void {
     const { canvas } = this;
-    canvas.setCursor(canvas.freeDrawingCursor);
+    canvas.setCursor(canvas.freeDrawingCursor ?? this.cursor);
   }
 
   /**

--- a/src/brushes/CircleBrush.ts
+++ b/src/brushes/CircleBrush.ts
@@ -6,7 +6,7 @@ import { Group } from '../shapes/Group';
 import { getRandomInt } from '../util/internals';
 import type { Canvas } from '../canvas/Canvas';
 import { BaseBrush } from './BaseBrush';
-import type { CircleBrushPoint } from './typedefs';
+import type { CircleBrushPoint, TBrushEventData } from './typedefs';
 import { CENTER } from '../constants';
 
 export class CircleBrush extends BaseBrush {
@@ -44,14 +44,12 @@ export class CircleBrush extends BaseBrush {
     ctx.fill();
   }
 
-  /**
-   * Invoked on mouse down
-   */
-  onMouseDown(pointer: Point) {
+  onMouseDown(ev: TBrushEventData) {
+    super.onMouseDown(ev);
     this.points = [];
     this.canvas.clearContext(this.canvas.contextTop);
     this._setShadow();
-    this.drawDot(pointer);
+    this.drawDot(ev.scenePoint);
   }
 
   /**
@@ -68,26 +66,26 @@ export class CircleBrush extends BaseBrush {
     ctx.restore();
   }
 
-  /**
-   * Invoked on mouse move
-   * @param {Point} pointer
-   */
-  onMouseMove(pointer: Point) {
-    if (this.limitedToCanvasSize === true && this._isOutSideCanvas(pointer)) {
+  onMouseMove(ev: TBrushEventData) {
+    const { scenePoint } = ev;
+    if (
+      this.limitedToCanvasSize === true &&
+      this._isOutSideCanvas(scenePoint)
+    ) {
       return;
     }
+
+    super.onMouseMove(ev);
+
     if (this.needsFullRender()) {
       this.canvas.clearContext(this.canvas.contextTop);
-      this.addPoint(pointer);
+      this.addPoint(scenePoint);
       this._render();
     } else {
-      this.drawDot(pointer);
+      this.drawDot(scenePoint);
     }
   }
 
-  /**
-   * Invoked on mouse up
-   */
   onMouseUp() {
     const originalRenderOnAddRemove = this.canvas.renderOnAddRemove;
     this.canvas.renderOnAddRemove = false;

--- a/src/brushes/CircleBrush.ts
+++ b/src/brushes/CircleBrush.ts
@@ -44,12 +44,11 @@ export class CircleBrush extends BaseBrush {
     ctx.fill();
   }
 
-  onMouseDown(ev: TBrushEventData) {
-    super.onMouseDown(ev);
+  onMouseDown({ scenePoint }: TBrushEventData) {
     this.points = [];
     this.canvas.clearContext(this.canvas.contextTop);
     this._setShadow();
-    this.drawDot(ev.scenePoint);
+    this.drawDot(scenePoint);
   }
 
   /**

--- a/src/brushes/PencilBrush.ts
+++ b/src/brushes/PencilBrush.ts
@@ -61,13 +61,10 @@ export class PencilBrush extends BaseBrush {
     return midPoint;
   }
 
-  onMouseDown(ev: TBrushEventData) {
-    const { e, scenePoint } = ev;
+  onMouseDown({ e, scenePoint }: TBrushEventData) {
     if (!this.canvas._isMainEvent(e)) {
       return;
     }
-
-    super.onMouseDown(ev);
 
     this.drawStraightLine = !!this.straightLineKey && e[this.straightLineKey];
     this._prepareForDrawing(scenePoint);

--- a/src/brushes/PencilBrush.ts
+++ b/src/brushes/PencilBrush.ts
@@ -1,4 +1,4 @@
-import type { ModifierKey, TEvent } from '../EventTypeDefs';
+import type { ModifierKey } from '../EventTypeDefs';
 import type { Point } from '../Point';
 import { Shadow } from '../Shadow';
 import { Path } from '../shapes/Path';
@@ -6,6 +6,7 @@ import { getSmoothPathFromPoints, joinPath } from '../util/path';
 import type { Canvas } from '../canvas/Canvas';
 import { BaseBrush } from './BaseBrush';
 import type { TSimplePathData } from '../util/path/typedefs';
+import { TBrushEventData } from './typedefs';
 
 /**
  * @private
@@ -60,35 +61,40 @@ export class PencilBrush extends BaseBrush {
     return midPoint;
   }
 
-  /**
-   * Invoked on mouse down
-   * @param {Point} pointer
-   */
-  onMouseDown(pointer: Point, { e }: TEvent) {
+  onMouseDown(ev: TBrushEventData) {
+    const { e, scenePoint } = ev;
     if (!this.canvas._isMainEvent(e)) {
       return;
     }
+
+    super.onMouseDown(ev);
+
     this.drawStraightLine = !!this.straightLineKey && e[this.straightLineKey];
-    this._prepareForDrawing(pointer);
+    this._prepareForDrawing(scenePoint);
     // capture coordinates immediately
     // this allows to draw dots (when movement never occurs)
-    this._addPoint(pointer);
+    this._addPoint(scenePoint);
     this._render();
   }
 
-  /**
-   * Invoked on mouse move
-   * @param {Point} pointer
-   */
-  onMouseMove(pointer: Point, { e }: TEvent) {
+  onMouseMove(ev: TBrushEventData) {
+    const { e, scenePoint } = ev;
     if (!this.canvas._isMainEvent(e)) {
       return;
     }
+
     this.drawStraightLine = !!this.straightLineKey && e[this.straightLineKey];
-    if (this.limitedToCanvasSize === true && this._isOutSideCanvas(pointer)) {
+
+    if (
+      this.limitedToCanvasSize === true &&
+      this._isOutSideCanvas(scenePoint)
+    ) {
       return;
     }
-    if (this._addPoint(pointer) && this._points.length > 1) {
+
+    super.onMouseMove(ev);
+
+    if (this._addPoint(scenePoint) && this._points.length > 1) {
       if (this.needsFullRender()) {
         // redraw curve
         // clear top canvas
@@ -115,10 +121,7 @@ export class PencilBrush extends BaseBrush {
     }
   }
 
-  /**
-   * Invoked on mouse up
-   */
-  onMouseUp({ e }: TEvent) {
+  onMouseUp({ e }: TBrushEventData) {
     if (!this.canvas._isMainEvent(e)) {
       return true;
     }

--- a/src/brushes/PencilBrush.ts
+++ b/src/brushes/PencilBrush.ts
@@ -6,7 +6,7 @@ import { getSmoothPathFromPoints, joinPath } from '../util/path';
 import type { Canvas } from '../canvas/Canvas';
 import { BaseBrush } from './BaseBrush';
 import type { TSimplePathData } from '../util/path/typedefs';
-import { TBrushEventData } from './typedefs';
+import type { TBrushEventData } from './typedefs';
 
 /**
  * @private

--- a/src/brushes/SprayBrush.ts
+++ b/src/brushes/SprayBrush.ts
@@ -86,13 +86,12 @@ export class SprayBrush extends BaseBrush {
     this.sprayChunk = [];
   }
 
-  onMouseDown(ev: TBrushEventData) {
-    super.onMouseDown(ev);
+  onMouseDown({ scenePoint }: TBrushEventData) {
     this.sprayChunks = [];
     this.canvas.clearContext(this.canvas.contextTop);
     this._setShadow();
 
-    this.addSprayChunk(ev.scenePoint);
+    this.addSprayChunk(scenePoint);
     this.renderChunck(this.sprayChunk);
   }
 

--- a/src/brushes/SprayBrush.ts
+++ b/src/brushes/SprayBrush.ts
@@ -5,7 +5,7 @@ import { Rect } from '../shapes/Rect';
 import { getRandomInt } from '../util/internals';
 import type { Canvas } from '../canvas/Canvas';
 import { BaseBrush } from './BaseBrush';
-import type { SprayBrushPoint } from './typedefs';
+import type { SprayBrushPoint, TBrushEventData } from './typedefs';
 import { CENTER } from '../constants';
 
 /**
@@ -86,34 +86,30 @@ export class SprayBrush extends BaseBrush {
     this.sprayChunk = [];
   }
 
-  /**
-   * Invoked on mouse down
-   * @param {Point} pointer
-   */
-  onMouseDown(pointer: Point) {
+  onMouseDown(ev: TBrushEventData) {
+    super.onMouseDown(ev);
     this.sprayChunks = [];
     this.canvas.clearContext(this.canvas.contextTop);
     this._setShadow();
 
-    this.addSprayChunk(pointer);
+    this.addSprayChunk(ev.scenePoint);
     this.renderChunck(this.sprayChunk);
   }
 
-  /**
-   * Invoked on mouse move
-   * @param {Point} pointer
-   */
-  onMouseMove(pointer: Point) {
-    if (this.limitedToCanvasSize === true && this._isOutSideCanvas(pointer)) {
+  onMouseMove(ev: TBrushEventData) {
+    const { scenePoint } = ev;
+    if (
+      this.limitedToCanvasSize === true &&
+      this._isOutSideCanvas(scenePoint)
+    ) {
       return;
     }
-    this.addSprayChunk(pointer);
+
+    super.onMouseMove(ev);
+    this.addSprayChunk(scenePoint);
     this.renderChunck(this.sprayChunk);
   }
 
-  /**
-   * Invoked on mouse up
-   */
   onMouseUp() {
     const originalRenderOnAddRemove = this.canvas.renderOnAddRemove;
     this.canvas.renderOnAddRemove = false;

--- a/src/brushes/typedefs.ts
+++ b/src/brushes/typedefs.ts
@@ -1,7 +1,10 @@
 import type { TEvent } from '../EventTypeDefs';
 import type { Point } from '../Point';
 
-export type TBrushEventData = TEvent & { pointer: Point };
+export interface TBrushEventData extends TEvent {
+  scenePoint: Point;
+  viewportPoint: Point;
+}
 
 export type CircleBrushPoint = {
   x: number;

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -997,7 +997,9 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     }
 
     if (this.isDrawingMode && this.freeDrawingBrush) {
+      const isActive = this._isCurrentlyDrawing;
       this._isCurrentlyDrawing = true;
+      !isActive && this.freeDrawingBrush.enterDrawingMode(e);
       this.freeDrawingBrush.onMouseDown(buildEvent(this, e));
 
       this._handleEvent(e, 'down');

--- a/src/canvas/CanvasOptions.ts
+++ b/src/canvas/CanvasOptions.ts
@@ -1,8 +1,8 @@
 import type { ModifierKey, TOptionalModifierKey } from '../EventTypeDefs';
+import type { BaseBrush } from '../brushes/BaseBrush';
 import type { ActiveSelection } from '../shapes/ActiveSelection';
 import type { TOptions } from '../typedefs';
 import type { StaticCanvasOptions } from './StaticCanvasOptions';
-
 export interface CanvasTransformOptions {
   /**
    * When true, objects can be transformed by one side (unproportionately)
@@ -162,10 +162,11 @@ export interface CanvasCursorOptions {
 
   /**
    * Cursor value used during free drawing
+   * @deprecated use {@link BaseBrush#cursor} instead
    * @type String
    * @default crosshair
    */
-  freeDrawingCursor: CSSStyleDeclaration['cursor'];
+  freeDrawingCursor?: CSSStyleDeclaration['cursor'];
 
   /**
    * Cursor value used for disabled elements ( corners with disabled action )
@@ -283,7 +284,6 @@ export const canvasDefaults: TOptions<CanvasOptions> = {
   hoverCursor: 'move',
   moveCursor: 'move',
   defaultCursor: 'default',
-  freeDrawingCursor: 'crosshair',
   notAllowedCursor: 'not-allowed',
 
   perPixelTargetFind: false,

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -894,7 +894,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
    * );
    *
    */
-  getViewportPoint(e: TPointerEvent) {
+  getViewportPoint(e: TPointerEvent | DragEvent) {
     if (this._pointer) {
       return this._pointer;
     }
@@ -913,7 +913,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
    * );
    *
    */
-  getScenePoint(e: TPointerEvent) {
+  getScenePoint(e: TPointerEvent | DragEvent) {
     if (this._absolutePointer) {
       return this._absolutePointer;
     }
@@ -930,7 +930,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
    * @param {Boolean} [fromViewport] whether to return the point from the viewport or in the scene
    * @return {Point}
    */
-  getPointer(e: TPointerEvent, fromViewport = false): Point {
+  getPointer(e: TPointerEvent | DragEvent, fromViewport = false): Point {
     const upperCanvasEl = this.upperCanvasEl,
       bounds = upperCanvasEl.getBoundingClientRect();
     let pointer = getPointer(e),

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -161,6 +161,9 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
   declare hoverCursor: CSSStyleDeclaration['cursor'];
   declare moveCursor: CSSStyleDeclaration['cursor'];
   declare defaultCursor: CSSStyleDeclaration['cursor'];
+  /**
+   * @deprecated use {@link BaseBrush#cursor} instead
+   */
   declare freeDrawingCursor: CSSStyleDeclaration['cursor'];
   declare notAllowedCursor: CSSStyleDeclaration['cursor'];
 

--- a/test/unit/brushes.js
+++ b/test/unit/brushes.js
@@ -71,10 +71,6 @@
         });
         QUnit.test('fabric pencil brush multiple points not discarded', function(assert) {
           var brush = new fabric.PencilBrush(canvas);
-          const e = { target: canvas.upperCanvasEl };
-          var pointer = canvas.getScenePoint({ ...e, clientX: 10, clientY: 10});
-          var pointer2 = canvas.getScenePoint({ ...e, clientX: 15, clientY: 15});
-          var pointer3 = canvas.getScenePoint({ ...e, clientX: 20, clientY: 20});
           brush.onMouseDown(buildEvent(canvas, 10, 10));
           brush.onMouseMove(buildEvent(canvas, 15, 15));
           brush.onMouseMove(buildEvent(canvas, 20, 20));

--- a/test/unit/brushes.js
+++ b/test/unit/brushes.js
@@ -6,6 +6,21 @@
       canvas.cancelRequestedRender();
     });
 
+    const buildEvent = (canvas, x, y) => {
+      const e = {
+        clientX: x,
+        clientY: y,
+        target: canvas.upperCanvasEl
+      };
+      const viewportPoint = canvas.getViewportPoint(e);
+      const scenePoint = canvas.getScenePoint(e);
+      return {
+        e,
+        viewportPoint,
+        scenePoint,
+      };
+    };
+
     QUnit.test('fabric brush constructor', function(assert) {
       assert.ok(fabric.BaseBrush);
 
@@ -39,21 +54,17 @@
         });
         QUnit.test('fabric pencil brush draw point', function(assert) {
           var brush = new fabric.PencilBrush(canvas);
-          const e = { target: canvas.upperCanvasEl };
-          var pointer = canvas.getScenePoint({ ...e, clientX: 10, clientY: 10 });
-          brush.onMouseDown(pointer, { e });
+          brush.onMouseDown(buildEvent(canvas, 10, 10));
           var pathData = brush.convertPointsToSVGPath(brush._points);
           assert.deepEqual(pathData, parsePath('M 9.999 10 L 10.001 10'), 'path data create a small line that looks like a point');
         });
         QUnit.test('fabric pencil brush multiple points', function(assert) {
           var brush = new fabric.PencilBrush(canvas);
-          const e = { target: canvas.upperCanvasEl };
-          var pointer = canvas.getScenePoint({ ...e, clientX: 10, clientY: 10 });
-          brush.onMouseDown(pointer, { e });
-          brush.onMouseMove(pointer, { e });
-          brush.onMouseMove(pointer, { e });
-          brush.onMouseMove(pointer, { e });
-          brush.onMouseMove(pointer, { e });
+          brush.onMouseDown(buildEvent(canvas, 10, 10));
+          brush.onMouseMove(buildEvent(canvas, 10, 10));
+          brush.onMouseMove(buildEvent(canvas, 10, 10));
+          brush.onMouseMove(buildEvent(canvas, 10, 10));
+          brush.onMouseMove(buildEvent(canvas, 10, 10));
           var pathData = brush.convertPointsToSVGPath(brush._points);
           assert.deepEqual(pathData, parsePath('M 9.999 10 L 10.001 10'), 'path data create a small line that looks like a point');
           assert.equal(brush._points.length, 2, 'concident points are discarded');
@@ -64,11 +75,11 @@
           var pointer = canvas.getScenePoint({ ...e, clientX: 10, clientY: 10});
           var pointer2 = canvas.getScenePoint({ ...e, clientX: 15, clientY: 15});
           var pointer3 = canvas.getScenePoint({ ...e, clientX: 20, clientY: 20});
-          brush.onMouseDown(pointer, { e });
-          brush.onMouseMove(pointer2, { e });
-          brush.onMouseMove(pointer3, { e });
-          brush.onMouseMove(pointer2, { e });
-          brush.onMouseMove(pointer3, { e });
+          brush.onMouseDown(buildEvent(canvas, 10, 10));
+          brush.onMouseMove(buildEvent(canvas, 15, 15));
+          brush.onMouseMove(buildEvent(canvas, 20, 20));
+          brush.onMouseMove(buildEvent(canvas, 15, 15));
+          brush.onMouseMove(buildEvent(canvas, 20, 20));
           var pathData = brush.convertPointsToSVGPath(brush._points);
           assert.deepEqual(
             pathData,
@@ -79,17 +90,11 @@
         });
         QUnit.test('fabric pencil brush multiple points outside canvas', function(assert) {
           var brush = new fabric.PencilBrush(canvas);
-          const e = { target: canvas.upperCanvasEl };
-          var pointer = canvas.getScenePoint({ ...e, clientX: 10, clientY: 10});
-          var pointer2 = canvas.getScenePoint({ ...e, clientX: 15, clientY: 100});
-          var pointer3 = canvas.getScenePoint({ ...e, clientX: 20, clientY: 160});
-          var pointer4 = canvas.getScenePoint({ ...e, clientX: 320, clientY: 100});
-          var pointer5 = canvas.getScenePoint({ ...e, clientX: 100, clientY: 100});
-          brush.onMouseDown(pointer, { e });
-          brush.onMouseMove(pointer2, { e });
-          brush.onMouseMove(pointer3, { e });
-          brush.onMouseMove(pointer4, { e });
-          brush.onMouseMove(pointer5, { e });
+          brush.onMouseDown(buildEvent(canvas, 10, 10));
+          brush.onMouseMove(buildEvent(canvas, 15, 100));
+          brush.onMouseMove(buildEvent(canvas, 20, 160));
+          brush.onMouseMove(buildEvent(canvas, 320, 100));
+          brush.onMouseMove(buildEvent(canvas, 100, 100));
           var pathData = brush.convertPointsToSVGPath(brush._points);
           assert.deepEqual(
             pathData,
@@ -101,17 +106,11 @@
         QUnit.test('fabric pencil brush multiple points outside canvas, limitedToCanvasSize true', function(assert) {
           var brush = new fabric.PencilBrush(canvas);
           brush.limitedToCanvasSize = true;
-          const e = { target: canvas.upperCanvasEl };
-          var pointer = canvas.getScenePoint({ ...e, clientX: 10, clientY: 10});
-          var pointer2 = canvas.getScenePoint({ ...e, clientX: 15, clientY: 100});
-          var pointer3 = canvas.getScenePoint({ ...e, clientX: 20, clientY: 160});
-          var pointer4 = canvas.getScenePoint({ ...e, clientX: 320, clientY: 100});
-          var pointer5 = canvas.getScenePoint({ ...e, clientX: 100, clientY: 100});
-          brush.onMouseDown(pointer, { e });
-          brush.onMouseMove(pointer2, { e });
-          brush.onMouseMove(pointer3, { e });
-          brush.onMouseMove(pointer4, { e });
-          brush.onMouseMove(pointer5, { e });
+          brush.onMouseDown(buildEvent(canvas, 10, 10));
+          brush.onMouseMove(buildEvent(canvas, 15, 100));
+          brush.onMouseMove(buildEvent(canvas, 20, 160));
+          brush.onMouseMove(buildEvent(canvas, 320, 100));
+          brush.onMouseMove(buildEvent(canvas, 100, 100));
           var pathData = brush.convertPointsToSVGPath(brush._points);
           assert.deepEqual(
             pathData,
@@ -132,16 +131,12 @@
             added = opt.path;
           });
           var brush = new fabric.PencilBrush(canvas);
-          const e = { target: canvas.upperCanvasEl };
-          var pointer = canvas.getScenePoint({ ...e, clientX: 10, clientY: 10});
-          var pointer2 = canvas.getScenePoint({ ...e, clientX: 15, clientY: 15});
-          var pointer3 = canvas.getScenePoint({ ...e, clientX: 20, clientY: 20});
-          brush.onMouseDown(pointer, { e });
-          brush.onMouseMove(pointer2, { e });
-          brush.onMouseMove(pointer3, { e });
-          brush.onMouseMove(pointer2, { e });
-          brush.onMouseMove(pointer3, { e });
-          brush.onMouseUp({ e });
+          brush.onMouseDown(buildEvent(canvas, 10, 10));
+          brush.onMouseMove(buildEvent(canvas, 15, 15));
+          brush.onMouseMove(buildEvent(canvas, 20, 20));
+          brush.onMouseMove(buildEvent(canvas, 15, 15));
+          brush.onMouseMove(buildEvent(canvas, 20, 20));
+          brush.onMouseUp(buildEvent(canvas, 20, 20));
           assert.equal(fireBeforePathCreatedEvent, true, 'before:path:created event is fired');
           assert.equal(firePathCreatedEvent, true, 'path:created event is fired');
           assert.ok(added instanceof fabric.Path, 'a path is added');

--- a/test/visual/freedraw.js
+++ b/test/visual/freedraw.js
@@ -1,23 +1,33 @@
-  function setBrush(canvas, brush) {
+  
+const buildEvent = (canvas, scenePoint) => {
+  return {
+    e: {
+      pointerId: 1,
+      target: canvas.upperCanvasEl
+    },
+    scenePoint,
+    viewportPoint: fabric.util.sendPointToPlane(scenePoint, canvas.viewportTransform)
+  };
+}
+
+  function pointDrawer(points, brush, fireUp = false, onMove = undefined) {
+    const { canvas } = brush;
     canvas.isDrawingMode = true;
     canvas.freeDrawingBrush = brush;
-  }
-  var options = { e: { pointerId: 1 } };
-  function pointDrawer(points, brush, fireUp = false, onMove = undefined) {
-    setBrush(brush.canvas, brush);
-    brush.onMouseDown(points[0], options);
+    brush.onMouseDown(buildEvent(canvas, points[0]));
     for (var i = 1; i < points.length; i++) {
       points[i].x = parseFloat(points[i].x);
       points[i].y = parseFloat(points[i].y);
-      brush.onMouseMove(points[i], options);
+      brush.onMouseMove(buildEvent(canvas, points[i]));
       onMove && onMove(points[i], i, points);
     }
     if (fireUp) {
-      brush.onMouseUp(options);
+      brush.onMouseUp(buildEvent(canvas, points[points.length - 1]));
     }
   }
+
   function fireMouseUp(brush) {
-    brush.onMouseUp(options);
+    brush.onMouseUp(buildEvent(canvas, points[points.length - 1]));
   }
 
   // function eraserDrawer(points, brush, fireUp = false) {

--- a/test/visual/freedraw.js
+++ b/test/visual/freedraw.js
@@ -27,6 +27,7 @@ const buildEvent = (canvas, scenePoint) => {
   }
 
   function fireMouseUp(brush) {
+    const { canvas } = brush;
     brush.onMouseUp(buildEvent(canvas, points[points.length - 1]));
   }
 


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

continues #9175 

## Description

<!-- What you are proposing -->

#9175 forgot about brush API
`onMouseDown` and `onMouseMove` use a scene point named `pointer`.
In order to fix this name conflict I decided to break the signature taking the opportunity to provide a better API while needing to break so the dev is aware of the change.


## Changes

- Brush API signature changes
  - `onMouseDown(pointer, { e, pointer })` => `onMouseDown({ e, scenePoint, viewportPoint })`
  - `onMouseMove(pointer, { e, pointer })` => `onMouseMove({ e, scenePoint, viewportPoint })`
  - `onMouseUp({ e, pointer })` => `onMouseUp({ e, scenePoint, viewportPoint })`
- rm `onMouse(Down|Move|Up)InDrawingMode` => move the bits of logic to BaseBrush:
  - `onMouseDownInDrawingMode` => expose `enterDrawingMode` to discard active object
  - `onMouseMoveInDrawingMode` => set cursor under `onMouseMove`
- dep `freeDrawingCursor` in favor of `BaseBrush#cursor`, still respecting `freeDrawingCursor`


<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
