### PR TITLE
fix(): fire Poly control events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): fire Poly control events [#9504](https://github.com/fabricjs/fabric.js/pull/9504)
 - test(FabricObject): add a snapshot of the default values so that reordering and shuffling is verified. [#9492](https://github.com/fabricjs/fabric.js/pull/9492)
 - feat(FabricObject, Canvas) BREAKING: remove calculate true/false from the api. [#9483](https://github.com/fabricjs/fabric.js/pull/9483)
 - chore(): remove some Type assertions [#8950](https://github.com/fabricjs/fabric.js/pull/8950)

--- a/e2e/tests/controls/polygon-controls/index.spec.ts
+++ b/e2e/tests/controls/polygon-controls/index.spec.ts
@@ -30,58 +30,30 @@ for (const exact of [true, false]) {
       name: toSnapshotName('initial', exact),
     });
 
-    const modifyPoly = (
-      title: string,
-      controlName: string,
-      delta: { x: number; y: number }
-    ) =>
-      test.step(title, async () => {
-        const eventStreamHandle =
-          await test.step('subscribe to poly events', () =>
-            starUtil.evaluateHandle((object) => {
-              const events: { action: string; corner: string }[] = [];
-              const disposer = object.on(
-                'modifyPoly',
-                ({ transform: { action, corner } }) =>
-                  events.push({ action, corner })
-              );
-              object.once('modified', ({ transform: { action, corner } }) => {
-                disposer();
-                events.push({ action, corner });
-              });
-              return events;
-            }));
-
-        const controlPoint = await starUtil.getObjectControlPoint(controlName);
-        await page.mouse.move(controlPoint.x, controlPoint.y);
-        await page.mouse.down();
-        await page.mouse.move(
-          controlPoint.x + delta.x,
-          controlPoint.y + delta.y,
-          {
-            steps: 40,
-          }
-        );
-        await page.mouse.up();
-
-        expect(await canvasUtil.screenshot()).toMatchSnapshot({
-          name: toSnapshotName(`moved_controls_${controlName}`, exact),
-        });
-
-        const events = await eventStreamHandle.jsonValue();
-        expect(events.length).toBeGreaterThan(0);
-        expect(events).toMatchObject(
-          new Array(events.length).fill({
-            action: 'modifyPoly',
-            corner: controlName,
-          })
-        );
+    await test.step('drag the p2 control', async () => {
+      const p2ControlPoint = await starUtil.getObjectControlPoint('p2');
+      await page.mouse.move(p2ControlPoint.x, p2ControlPoint.y);
+      await page.mouse.down();
+      await page.mouse.move(p2ControlPoint.x + 300, p2ControlPoint.y + 100, {
+        steps: 40,
       });
+      await page.mouse.up();
+      expect(await canvasUtil.screenshot()).toMatchSnapshot({
+        name: toSnapshotName('moved_controls_p2', exact),
+      });
+    });
 
-    await modifyPoly('drag the p2 control', 'p2', { x: 300, y: 100 });
-    await modifyPoly('drag in the p4 control in the opposite direction', 'p4', {
-      x: -300,
-      y: -100,
+    await test.step('drag in the opposite direction', async () => {
+      const p4ControlPoint = await starUtil.getObjectControlPoint('p4');
+      await page.mouse.move(p4ControlPoint.x, p4ControlPoint.y);
+      await page.mouse.down();
+      await page.mouse.move(p4ControlPoint.x - 300, p4ControlPoint.y - 100, {
+        steps: 40,
+      });
+      await page.mouse.up();
+      expect(await canvasUtil.screenshot()).toMatchSnapshot({
+        name: toSnapshotName('moved_controls_p4', exact),
+      });
     });
   });
 }

--- a/e2e/tests/controls/polygon-controls/index.spec.ts
+++ b/e2e/tests/controls/polygon-controls/index.spec.ts
@@ -1,83 +1,60 @@
 import { expect, test } from '@playwright/test';
+import type { Polygon } from '../../../..';
 import setup from '../../../setup';
 import { CanvasUtil } from '../../../utils/CanvasUtil';
 import { ObjectUtil } from '../../../utils/ObjectUtil';
 
 setup();
 
-test('polygon controls can modify polygon - exact false', async ({ page }) => {
-  const canvasUtil = new CanvasUtil(page);
-  const starUtil = new ObjectUtil(page, 'star');
+const toSnapshotName = (name: string, exact: boolean) =>
+  `${name}${exact ? '-exact' : ''}.png`;
 
-  expect(await canvasUtil.screenshot()).toMatchSnapshot({
-    name: 'initial.png',
-  });
+for (const exact of [true, false]) {
+  test(`polygon controls can modify polygon - exactBoundingBox ${exact}`, async ({
+    page,
+  }) => {
+    const canvasUtil = new CanvasUtil(page);
+    const starUtil = new ObjectUtil<Polygon>(page, 'star');
 
-  const p2ControlPoint = await starUtil.getObjectControlPoint('p2');
+    exact &&
+      (await starUtil.executeInBrowser((object) => {
+        object.strokeLineJoin = 'miter';
+        object.strokeWidth = 30;
+        object.exactBoundingBox = true;
+        object.setDimensions();
+        object.set('dirty', true);
+        object.canvas.renderAll();
+      }));
 
-  // drag the p2 control
-  await page.mouse.move(p2ControlPoint.x, p2ControlPoint.y);
-  await page.mouse.down();
-  await page.mouse.move(p2ControlPoint.x + 300, p2ControlPoint.y + 100, {
-    steps: 40,
-  });
-  await page.mouse.up();
-  expect(await canvasUtil.screenshot()).toMatchSnapshot({
-    name: 'moved_controls_p2.png',
-  });
+    expect(await canvasUtil.screenshot()).toMatchSnapshot({
+      name: toSnapshotName('initial', exact),
+    });
 
-  // drag in the opposite direction
-  const p4ControlPoint = await starUtil.getObjectControlPoint('p4');
-  await page.mouse.move(p4ControlPoint.x, p4ControlPoint.y);
-  await page.mouse.down();
-  await page.mouse.move(p4ControlPoint.x - 300, p4ControlPoint.y - 100, {
-    steps: 40,
-  });
-  await page.mouse.up();
-  expect(await canvasUtil.screenshot()).toMatchSnapshot({
-    name: 'moved_controls_p4.png',
-  });
-});
+    const p2ControlPoint = await starUtil.getObjectControlPoint('p2');
 
-test('polygon controls can modify polygon - exact true', async ({ page }) => {
-  const canvasUtil = new CanvasUtil(page);
-  const starUtil = new ObjectUtil(page, 'star');
+    await test.step('drag the p2 control', async () => {
+      await page.mouse.move(p2ControlPoint.x, p2ControlPoint.y);
+      await page.mouse.down();
+      await page.mouse.move(p2ControlPoint.x + 300, p2ControlPoint.y + 100, {
+        steps: 40,
+      });
+      await page.mouse.up();
+      expect(await canvasUtil.screenshot()).toMatchSnapshot({
+        name: toSnapshotName('moved_controls_p2', exact),
+      });
+    });
 
-  await starUtil.executeInBrowser((object) => {
-    object.strokeLineJoin = 'miter';
-    object.strokeWidth = 30;
-    object.exactBoundingBox = true;
-    object.setDimensions();
-    object.set('dirty', true);
-    object.canvas.renderAll();
+    await test.step('drag in the opposite direction', async () => {
+      const p4ControlPoint = await starUtil.getObjectControlPoint('p4');
+      await page.mouse.move(p4ControlPoint.x, p4ControlPoint.y);
+      await page.mouse.down();
+      await page.mouse.move(p4ControlPoint.x - 300, p4ControlPoint.y - 100, {
+        steps: 40,
+      });
+      await page.mouse.up();
+      expect(await canvasUtil.screenshot()).toMatchSnapshot({
+        name: toSnapshotName('moved_controls_p4', exact),
+      });
+    });
   });
-
-  expect(await canvasUtil.screenshot()).toMatchSnapshot({
-    name: 'initial-exact.png',
-  });
-
-  const p2ControlPoint = await starUtil.getObjectControlPoint('p2');
-
-  // drag the p2 control
-  await page.mouse.move(p2ControlPoint.x, p2ControlPoint.y);
-  await page.mouse.down();
-  await page.mouse.move(p2ControlPoint.x + 300, p2ControlPoint.y + 100, {
-    steps: 40,
-  });
-  await page.mouse.up();
-  expect(await canvasUtil.screenshot()).toMatchSnapshot({
-    name: 'moved_controls_p2_exact.png',
-  });
-
-  // drag in the opposite direction
-  const p4ControlPoint = await starUtil.getObjectControlPoint('p4');
-  await page.mouse.move(p4ControlPoint.x, p4ControlPoint.y);
-  await page.mouse.down();
-  await page.mouse.move(p4ControlPoint.x - 300, p4ControlPoint.y - 100, {
-    steps: 40,
-  });
-  await page.mouse.up();
-  expect(await canvasUtil.screenshot()).toMatchSnapshot({
-    name: 'moved_controls_p4_exact.png',
-  });
-});
+}

--- a/e2e/utils/CanvasUtil.ts
+++ b/e2e/utils/CanvasUtil.ts
@@ -1,3 +1,4 @@
+import type { JSHandle } from '@playwright/test';
 import { type LocatorScreenshotOptions, type Page } from '@playwright/test';
 import type { Canvas } from 'fabric';
 import os from 'node:os';
@@ -31,15 +32,24 @@ export class CanvasUtil {
       .screenshot({ omitBackground: true, ...options });
   }
 
+  evaluateSelf() {
+    return this.page.evaluateHandle<Canvas>(
+      ([selector]) => canvasMap.get(document.querySelector(selector)),
+      [this.selector]
+    );
+  }
+
   async executeInBrowser<C, R>(
     runInBrowser: (canvas: Canvas, context: C) => R,
     context?: C
   ): Promise<R> {
-    return (
-      await this.page.evaluateHandle<Canvas>(
-        ([selector]) => canvasMap.get(document.querySelector(selector)),
-        [this.selector]
-      )
-    ).evaluate(runInBrowser, context);
+    return (await this.evaluateSelf()).evaluate(runInBrowser, context);
+  }
+
+  async evaluateHandle<C, R>(
+    runInBrowser: (canvas: Canvas, context: C) => R,
+    context?: C
+  ): Promise<JSHandle<R>> {
+    return (await this.evaluateSelf()).evaluateHandle(runInBrowser, context);
   }
 }

--- a/e2e/utils/ObjectUtil.ts
+++ b/e2e/utils/ObjectUtil.ts
@@ -1,9 +1,9 @@
-import type { Page } from '@playwright/test';
+import type { JSHandle, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
-import type { Object as FabricObject } from 'fabric';
+import type { FabricObject } from 'fabric';
 import type { before, beforeAll } from 'test';
 
-export class ObjectUtil<T = FabricObject> {
+export class ObjectUtil<T extends FabricObject = FabricObject> {
   constructor(
     readonly page: Page,
     /**
@@ -12,16 +12,25 @@ export class ObjectUtil<T = FabricObject> {
     readonly objectId: string
   ) {}
 
+  evaluateSelf() {
+    return this.page.evaluateHandle<FabricObject>(
+      ([objectId]) => objectMap.get(objectId),
+      [this.objectId]
+    );
+  }
+
   async executeInBrowser<C, R>(
     runInBrowser: (object: T, context: C) => R,
     context?: C
   ): Promise<R> {
-    return (
-      await this.page.evaluateHandle<FabricObject>(
-        ([objectId]) => objectMap.get(objectId),
-        [this.objectId]
-      )
-    ).evaluate(runInBrowser, context);
+    return (await this.evaluateSelf()).evaluate(runInBrowser, context);
+  }
+
+  async evaluateHandle<C, R>(
+    runInBrowser: (object: T, context: C) => R,
+    context?: C
+  ): Promise<JSHandle<R>> {
+    return (await this.evaluateSelf()).evaluateHandle(runInBrowser, context);
   }
 
   getObjectCenter() {

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -99,7 +99,8 @@ export type TModificationEvents =
   | 'scaling'
   | 'rotating'
   | 'skewing'
-  | 'resizing';
+  | 'resizing'
+  | 'modifyPoly';
 
 export interface ModifiedEvent<E extends Event = TPointerEvent>
   extends TEvent<E> {

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -53,7 +53,7 @@ export type Transform = {
   target: FabricObject;
   action: string;
   actionHandler?: TransformActionHandler;
-  corner: string | 0;
+  corner: string;
   scaleX: number;
   scaleY: number;
   skewX: number;

--- a/src/controls/polyControl.spec.ts
+++ b/src/controls/polyControl.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import { Point } from '../Point';
 import { Canvas } from '../canvas/Canvas';
 import { Polygon } from '../shapes/Polygon';

--- a/src/controls/polyControl.spec.ts
+++ b/src/controls/polyControl.spec.ts
@@ -1,0 +1,43 @@
+import { Point } from '../Point';
+import { Canvas } from '../canvas/Canvas';
+import { Polygon } from '../shapes/Polygon';
+import { createPolyControls } from './polyControl';
+
+describe('polyControl', () => {
+  it('should fire events', () => {
+    const poly = new Polygon(
+      [new Point(), new Point(50, 0), new Point(50, 50), new Point(0, 50)],
+      { controls: createPolyControls(4) }
+    );
+    const canvas = new Canvas();
+    canvas.add(poly);
+    canvas.setActiveObject(poly);
+    const spy = jest.fn();
+    poly.on('modifyPoly', spy);
+    poly.on('modified', spy);
+    canvas
+      .getSelectionElement()
+      .dispatchEvent(new MouseEvent('mousedown', { clientX: 50, clientY: 50 }));
+    canvas._setupCurrentTransform(
+      new MouseEvent('mousedown', { clientX: 50, clientY: 50 }),
+      poly,
+      true
+    );
+    document.dispatchEvent(
+      new MouseEvent('mousemove', { clientX: 55, clientY: 55 })
+    );
+    document.dispatchEvent(
+      new MouseEvent('mouseup', { clientX: 55, clientY: 55 })
+    );
+
+    expect(
+      spy.mock.calls.map(
+        ([
+          {
+            transform: { action },
+          },
+        ]) => action
+      )
+    ).toMatchObject(['modifyPoly', 'modifyPoly']);
+  });
+});

--- a/src/controls/polyControl.ts
+++ b/src/controls/polyControl.ts
@@ -10,6 +10,9 @@ import type {
   TransformActionHandler,
 } from '../EventTypeDefs';
 import { getLocalPoint } from './util';
+import { wrapWithFireEvent } from './wrapWithFireEvent';
+
+const ACTION_NAME = 'modifyPoly';
 
 type TTransformAnchor = Transform & { pointIndex: number };
 
@@ -105,7 +108,10 @@ export const factoryPolyActionHandler = (
 };
 
 export const createPolyActionHandler = (pointIndex: number) =>
-  factoryPolyActionHandler(pointIndex, polyActionHandler);
+  wrapWithFireEvent(
+    ACTION_NAME,
+    factoryPolyActionHandler(pointIndex, polyActionHandler)
+  );
 
 export function createPolyControls(
   poly: Polyline,
@@ -126,7 +132,7 @@ export function createPolyControls(
     idx++
   ) {
     controls[`p${idx}`] = new Control({
-      actionName: 'modifyPoly',
+      actionName: ACTION_NAME,
       positionHandler: createPolyPositionHandler(idx),
       actionHandler: createPolyActionHandler(idx),
       ...options,


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation 

#9503 
PolyControl do not have a wrapWithFireEvent

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

## Description

Fire an event when modifiying a poly via a poly control.


TODO:
- I have found while testing that `wrapWithFireEvent` will fire a stale `transform` object on the first call because `transform.actionPerformed` is not yet set on `transform` but is `true`. It is set after `wrapWithFireEvent` is called. That needs fixing.

<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->
- add `wrapWithFireEvent`
- adapt poly control test


## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
