### PR TITLE
refactor(Group) Layout manager, make the layout owned by the group.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false,
-    "source.removeUnusedImports": true
+    "source.organizeImports": "never",
+    "source.removeUnusedImports": "explicit"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": "never",
-    "source.removeUnusedImports": "explicit"
+    "source.organizeImports": false,
+    "source.removeUnusedImports": true
   }
 }

--- a/src/LayoutManager/LayoutManager.spec.ts
+++ b/src/LayoutManager/LayoutManager.spec.ts
@@ -4,6 +4,8 @@ import { Group } from '../shapes/Group';
 import { FabricObject } from '../shapes/Object/FabricObject';
 import { LayoutManager } from './LayoutManager';
 import { FitContentLayout } from './LayoutStrategies/FitContentLayout';
+import { FixedLayout } from './LayoutStrategies/FixedLayout';
+
 import {
   LAYOUT_TYPE_INITIALIZATION,
   LAYOUT_TYPE_ADDED,
@@ -627,7 +629,6 @@ describe('Layout Manager', () => {
       canvas.add(grandParent);
       jest.spyOn(canvas, 'fire');
       grandParent.triggerLayout({
-        manager,
         bubbles: false,
         deep: false,
       });
@@ -681,7 +682,6 @@ describe('Layout Manager', () => {
       canvas.add(grandParent);
       jest.spyOn(canvas, 'fire');
       grandParent.triggerLayout({
-        manager,
         bubbles: false,
         deep: true,
       });
@@ -803,6 +803,7 @@ describe('Layout Manager', () => {
         width: 100,
         height: 300,
         strokeWidth: 0,
+        layoutManager: new LayoutManager(new FixedLayout()),
       });
       expect(group).toMatchObject({ width: 100, height: 300 });
       expect(child.getCenterPoint()).toMatchObject({ x: 100, y: 100 });

--- a/src/LayoutManager/types.ts
+++ b/src/LayoutManager/types.ts
@@ -7,7 +7,6 @@ import type { Point } from '../Point';
 import type { Group } from '../shapes/Group';
 import type { ITextEvents } from '../shapes/IText/ITextBehavior';
 import type { FabricObject } from '../shapes/Object/FabricObject';
-import type { LayoutManager } from './LayoutManager';
 import type { LayoutStrategy } from './LayoutStrategies/LayoutStrategy';
 import type {
   LAYOUT_TYPE_INITIALIZATION,
@@ -70,7 +69,6 @@ type ImperativeLayoutCommonOptions = {
 
 export type ImperativeLayoutOptions = ImperativeLayoutCommonOptions & {
   strategy?: LayoutStrategy;
-  manager?: LayoutManager;
 };
 
 export type CommonLayoutContext = {

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -3,7 +3,6 @@ import { classRegistry } from '../ClassRegistry';
 import type { GroupProps } from './Group';
 import { Group } from './Group';
 import type { FabricObject } from './Object/FabricObject';
-import { LayoutManager } from '../LayoutManager';
 import {
   LAYOUT_TYPE_ADDED,
   LAYOUT_TYPE_REMOVED,
@@ -40,21 +39,6 @@ export class ActiveSelection extends Group {
   multiSelectionStacking: MultiSelectionStacking = 'canvas-stacking';
 
   static type = 'ActiveSelection';
-
-  /**
-   * @override {@link layoutManager}
-   */
-  constructor(
-    objects: FabricObject[] = [],
-    options: Partial<ActiveSelectionOptions> = {},
-    objectsRelativeToGroup?: boolean
-  ) {
-    super(
-      objects,
-      { layoutManager: new LayoutManager(), ...options },
-      objectsRelativeToGroup
-    );
-  }
 
   /**
    * @private

--- a/src/shapes/Group.spec.ts
+++ b/src/shapes/Group.spec.ts
@@ -1,4 +1,4 @@
-import { FixedLayout, LayoutManager } from '../LayoutManager';
+import { FixedLayout } from '../LayoutManager';
 import { Group } from './Group';
 import { FabricObject } from './Object/FabricObject';
 
@@ -14,37 +14,23 @@ describe('Group', () => {
     expect(group._objects).toHaveLength(3);
   });
 
-  it.each([true, false])(
-    'triggerLayout should preform layout, layoutManager is defined %s',
-    (defined) => {
-      const manager = new LayoutManager();
-      const performLayout = jest.spyOn(manager, 'performLayout');
+  it('triggerLayout should preform layout, layoutManager is defined', () => {
+    const group = new Group();
+    expect(group.layoutManager).toBeDefined();
+    const performLayout = jest.spyOn(group.layoutManager, 'performLayout');
 
-      const group = new Group();
-      expect(group.layoutManager).toBeUndefined();
-      defined && (group.layoutManager = manager);
-
-      group.triggerLayout({ manager });
-      const fixedLayout = new FixedLayout();
-      group.triggerLayout({ manager, strategy: fixedLayout });
-      manager.strategy = new FixedLayout();
-      group.triggerLayout({ manager });
-      expect(performLayout).toHaveBeenCalledTimes(3);
-      expect(performLayout).toHaveBeenNthCalledWith(1, {
-        strategy: manager.strategy,
-        target: group,
-        type: 'imperative',
-      });
-      expect(performLayout).toHaveBeenNthCalledWith(2, {
-        strategy: fixedLayout,
-        target: group,
-        type: 'imperative',
-      });
-      expect(performLayout).toHaveBeenNthCalledWith(3, {
-        strategy: fixedLayout,
-        target: group,
-        type: 'imperative',
-      });
-    }
-  );
+    group.triggerLayout();
+    const fixedLayout = new FixedLayout();
+    group.triggerLayout({ strategy: fixedLayout });
+    expect(performLayout).toHaveBeenCalledTimes(2);
+    expect(performLayout).toHaveBeenNthCalledWith(1, {
+      target: group,
+      type: 'imperative',
+    });
+    expect(performLayout).toHaveBeenNthCalledWith(2, {
+      strategy: fixedLayout,
+      target: group,
+      type: 'imperative',
+    });
+  });
 });

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -21,7 +21,6 @@ import type {
   LayoutAfterEvent,
 } from '../LayoutManager/types';
 import { LayoutManager } from '../LayoutManager/LayoutManager';
-import { FitContentLayout } from '../LayoutManager/LayoutStrategies/FitContentLayout';
 import {
   LAYOUT_TYPE_ADDED,
   LAYOUT_TYPE_IMPERATIVE,
@@ -139,7 +138,7 @@ export class Group
     // perform initial layout
     const layoutManager =
       // not destructured on purpose here.
-      options.layoutManager || new LayoutManager(new FitContentLayout());
+      options.layoutManager || new LayoutManager();
     layoutManager.performLayout({
       type: LAYOUT_TYPE_INITIALIZATION,
       objectsRelativeToGroup,

--- a/src/util/misc/groupSVGElements.ts
+++ b/src/util/misc/groupSVGElements.ts
@@ -1,9 +1,9 @@
-import { LayoutManager } from '../../LayoutManager';
 import type { GroupProps } from '../../shapes/Group';
 import { Group } from '../../shapes/Group';
 import type { FabricObject } from '../../shapes/Object/FabricObject';
 
 /**
+ * TODO experiment with different layout manager and svg results ( fixed fit content )
  * Groups SVG elements (usually those retrieved from SVG document)
  * @static
  * @param {FabricObject[]} elements FabricObject(s) parsed from svg, to group
@@ -16,8 +16,5 @@ export const groupSVGElements = (
   if (elements && elements.length === 1) {
     return elements[0];
   }
-  return new Group(elements, {
-    layoutManager: new LayoutManager(),
-    ...options,
-  });
+  return new Group(elements, options);
 };


### PR DESCRIPTION
## Motivation

The current version of Layout manager allows for a developer to either pass or not pass a layout manager when creating a group.
So the group can have it one or not.
It will create one on the fly when creating the group, and accepting one when using trigger layout.
This bring to some added up difficulty for the api:
- you do not know if a group has its own layout manager or not
- If you don't have a layout manager on a group you do not know with which strategy the group has been sized
- when using triggerLayout you could pass a layoutManager with strategy A but also pass a strategy B in the options

Now all of this freedom maybe has its own usefulness, but for a first release i don't want it.

This PR changes the following

- when you create a group, if you don't pass a LayoutManager, you get the default fit content and it gets attached to the group
- when calling triggerLayout you can pass a strategy but the LayoutManager used will be the one that is owned in the group
