### PR TITLE
fix(Animation): safeguard zero values, fix rounding  issue, expose `promise` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Animation): safeguard zero values, fix rounding issue, expose `promise` property [#9518](https://github.com/fabricjs/fabric.js/pull/9518)
 - fix(): transferring object between active selections, expose `FabricObject#parent`, rm `isActiveSelection` [#8951](https://github.com/fabricjs/fabric.js/pull/8951)
   **BREAKING beta**:
   - rm(): `getParent` => `FabricObject#parent`

--- a/src/util/animation/AnimationBase.ts
+++ b/src/util/animation/AnimationBase.ts
@@ -101,6 +101,22 @@ export abstract class AnimationBase<
   };
 
   start() {
+    if (
+      this.byValue === 0 ||
+      (Array.isArray(this.byValue) &&
+        this.byValue.every((value) => value === 0))
+    ) {
+      // if `byValue` is 0 move to `completed`
+      this.durationProgress = this.valueProgress = 1;
+      this._state = 'completed';
+      this._onComplete(
+        this.endValue,
+        this.valueProgress,
+        this.durationProgress
+      );
+      return;
+    }
+
     const firstTick: FrameRequestCallback = (timestamp) => {
       if (this._state !== 'pending') return;
       this.startTime = timestamp || +new Date();

--- a/src/util/animation/ArrayAnimation.ts
+++ b/src/util/animation/ArrayAnimation.ts
@@ -11,6 +11,7 @@ export class ArrayAnimation extends AnimationBase<number[]> {
       ...options,
       startValue,
       byValue: endValue.map((value, i) => value - startValue[i]),
+      endValue,
     });
   }
   protected calculate(timeElapsed: number) {

--- a/src/util/animation/ColorAnimation.ts
+++ b/src/util/animation/ColorAnimation.ts
@@ -44,6 +44,7 @@ export class ColorAnimation extends AnimationBase<TRGBAColorSource> {
       byValue: endColor.map(
         (value, i) => value - startColor[i]
       ) as TRGBAColorSource,
+      endValue: endColor,
       easing,
       onChange: wrapColorCallback(onChange),
       onComplete: wrapColorCallback(onComplete),

--- a/src/util/animation/ValueAnimation.ts
+++ b/src/util/animation/ValueAnimation.ts
@@ -11,6 +11,7 @@ export class ValueAnimation extends AnimationBase<number> {
       ...otherOptions,
       startValue,
       byValue: endValue - startValue,
+      endValue,
     });
   }
 

--- a/src/util/animation/animate.test.ts
+++ b/src/util/animation/animate.test.ts
@@ -1,0 +1,112 @@
+import { animate } from '.';
+
+describe('animate', () => {
+  it('should complete if there is no diff to animate', () => {
+    const onStart = jest.fn();
+    const onChange = jest.fn();
+    const onComplete = jest.fn();
+    const animation = animate({
+      startValue: 10,
+      endValue: 10,
+      duration: 50,
+      onStart,
+      onChange,
+      onComplete,
+    });
+    expect(animation.isDone()).toBeTruthy();
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledWith(10, 1, 1);
+    expect(animation.promise).resolves.toBe(0);
+    expect(animation).toMatchObject({
+      delay: 0,
+      duration: 50,
+      startValue: 10,
+      endValue: 10,
+      byValue: 0,
+      value: 10,
+      valueProgress: 1,
+      durationProgress: 1,
+    });
+  });
+
+  it('should complete if duration <= 0', () => {
+    const onStart = jest.fn();
+    const onChange = jest.fn();
+    const onComplete = jest.fn();
+    const animation = animate({
+      startValue: 10,
+      endValue: 25,
+      duration: 0,
+      onStart,
+      onChange,
+      onComplete,
+    });
+    expect(animation.isDone()).toBeTruthy();
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledWith(25, 1, 1);
+    expect(animation.promise).resolves.toBe(0);
+    expect(animation).toMatchObject({
+      delay: 0,
+      duration: 0,
+      startValue: 10,
+      endValue: 25,
+      byValue: 15,
+      value: 25,
+      valueProgress: 1,
+      durationProgress: 1,
+    });
+  });
+
+  it('onComplete should pass the same ref to avoid rounding issues', async () => {
+    const onStart = jest.fn();
+    const onChange = jest.fn();
+    const onComplete = jest.fn();
+    const startValue = [1];
+    const endValue = [2];
+    const animation = animate({
+      startValue,
+      endValue,
+      duration: 200,
+      onStart,
+      onChange,
+      onComplete,
+    });
+    expect(animation.isDone()).toBeFalsy();
+    await animation.promise;
+    expect(onStart).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalled();
+    expect(onComplete.mock.calls[0][0]).toBe(endValue);
+    expect(onComplete).toHaveBeenCalledWith(endValue, 1, 1);
+    expect(animation).toMatchObject({
+      delay: 0,
+      duration: 200,
+      startValue,
+      endValue,
+      valueProgress: 1,
+      durationProgress: 1,
+    });
+  });
+
+  it('declarative aborting should reject animation promise', async () => {
+    const abort = jest.fn().mockImplementation((value) => value > 5);
+    const animation = animate({
+      startValue: 0,
+      endValue: 100,
+      duration: 50,
+      abort,
+    });
+    await expect(animation.promise).rejects.toBeUndefined();
+  });
+
+  it('imperative aborting should reject animation promise', async () => {
+    const animation = animate({
+      startValue: 0,
+      endValue: 100,
+      duration: 50,
+    });
+    animation.abort();
+    await expect(animation.promise).rejects.toBeUndefined();
+  });
+});

--- a/src/util/animation/types.ts
+++ b/src/util/animation/types.ts
@@ -100,6 +100,7 @@ export type TBaseAnimationOptions<T, TCallback = T, TEasing = T> = Partial<
 > & {
   startValue: T;
   byValue: T;
+  endValue: T;
 };
 
 export type TAnimationOptions<T, TCallback = T, TEasing = T> = Partial<


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

Making animation more robust to different use cases:

- `startValue === endValue`
- `duration <= 0` 
- rounding issues caused by `endValue` being recalculated in BaseAnimation instead of using  the passed value (small `byValue` and long `duration` maybe cause floating point imprecision)

## Description

- pass `endValue` to fix rounding issue
- expose `promise` that resolves/rejects on complete/abort
- handled the zero cases in `start` and complete the animation accordingly


<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
