### PR TITLE
fix(): bubble dirty flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false,
-    "source.removeUnusedImports": true
+    "source.organizeImports": "never",
+    "source.removeUnusedImports": "explicit"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": "never",
-    "source.removeUnusedImports": "explicit"
+    "source.organizeImports": false,
+    "source.removeUnusedImports": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- fix(): bubble dirty flag [#9540](https://github.com/fabricjs/fabric.js/pull/9540)
+- fix(): bubble dirty flag for group only when true [#9540](https://github.com/fabricjs/fabric.js/pull/9540)
 - test() Backport a test to capture a failing text style situation [#9531](https://github.com/fabricjs/fabric.js/pull/9531)
 
 ## [6.0.0-beta16]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): bubble dirty flag [#9540](https://github.com/fabricjs/fabric.js/pull/9540)
 - test() Backport a test to capture a failing text style situation [#9531](https://github.com/fabricjs/fabric.js/pull/9531)
 
 ## [6.0.0-beta16]

--- a/src/shapes/Object/Object.spec.ts
+++ b/src/shapes/Object/Object.spec.ts
@@ -1,6 +1,7 @@
 import { Shadow } from '../../Shadow';
 import { Rect } from '../Rect';
 import { FabricObject } from './Object';
+import { Group } from '../Group';
 
 describe('Object', () => {
   it('rotate with centered rotation', () => {
@@ -98,6 +99,24 @@ describe('Object', () => {
       rect.fill = '';
       rect.shadow = new Shadow({ color: 'green' });
       expect(rect.needsItsOwnCache()).toBe(false);
+    });
+  });
+  describe('set method and dirty flag bubbling', () => {
+    it('when dirty is true it bubbles', () => {
+      const rect = new Rect({ width: 100, height: 100 });
+      const group = new Group([rect]);
+      group.dirty = false;
+      expect(group.dirty).toBe(false);
+      rect.set('dirty', true);
+      expect(group.dirty).toBe(true);
+    });
+    it('when dirty is false it does not bubble', () => {
+      const rect = new Rect({ width: 100, height: 100 });
+      const group = new Group([rect]);
+      group.dirty = true;
+      expect(group.dirty).toBe(true);
+      rect.set('dirty', false);
+      expect(group.dirty).toBe(true);
     });
   });
 });

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -707,6 +707,9 @@ export class FabricObject<
     } else if (key === 'shadow' && value && !(value instanceof Shadow)) {
       value = new Shadow(value);
     } else if (key === 'dirty' && this.group && value) {
+      // a dirty child makes the parent dirty
+      // but a non dirty child will not make the parent non dirty.
+      // the parent could be dirty for some other reason
       this.group.set('dirty', value);
     }
 

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -706,7 +706,7 @@ export class FabricObject<
       // i don't like this automatic initialization here
     } else if (key === 'shadow' && value && !(value instanceof Shadow)) {
       value = new Shadow(value);
-    } else if (key === 'dirty' && this.group) {
+    } else if (key === 'dirty' && this.group && value) {
       this.group.set('dirty', value);
     }
 


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
-->

## Motivation

<!-- Why you are proposing -->
<!-- You can use the @closes notation to mark issues that will be resolved by this PR -->

#9527

Safeguard flagging dirty from an infinite loop
This can happen when customizing group caching

## Description

Bubble the dirty flag only if it is true.
This is a fix not only to safeguard.
`child.set({ dirty: false })` should never bubble that to its group
<!-- What you are proposing -->

## Changes

<!-- before the fix vs. after -->

## Gist

<!-- Technical stuff if necessary -->

## In Action

<!-- Show case your accomplishment -->
<!-- Upload screenshots, screencasts and live examples showing your fix in contrast to the current state -->
