### PR TITLE
fix(FabricObject): Remove unwanted set type warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix() Remove unwanted set type warning [#9569](https://github.com/fabricjs/fabric.js/pull/9569)
 - refactor(): Separate defaults for base fabric object vs interactive object. Also some moving around of variables [#9474](https://github.com/fabricjs/fabric.js/pull/9474)
 - refactor(): Change how LayoutManager handles restoring groups [#9522](https://github.com/fabricjs/fabric.js/pull/9522)
 - fix(BaseConfiguration): set `devicePixelRatio` from window [#9470](https://github.com/fabricjs/fabric.js/pull/9470)

--- a/src/Pattern/Pattern.ts
+++ b/src/Pattern/Pattern.ts
@@ -192,7 +192,7 @@ export class Pattern {
   /* _TO_SVG_END_ */
 
   static async fromObject(
-    { source, ...serialized }: SerializedPatternOptions,
+    { type, source, ...serialized }: SerializedPatternOptions,
     options: Abortable
   ): Promise<Pattern> {
     const img = await loadImage(source, {

--- a/src/Pattern/types.ts
+++ b/src/Pattern/types.ts
@@ -13,5 +13,6 @@ type ExportedKeys =
 export type PatternOptions = Partial<Pick<Pattern, ExportedKeys>>;
 
 export type SerializedPatternOptions = PatternOptions & {
+  type: 'pattern';
   source: string;
 };

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -642,6 +642,7 @@ export class Group
    * @returns {Promise<Group>}
    */
   static fromObject<T extends TOptions<SerializedGroupProps>>({
+    type,
     objects = [],
     ...options
   }: T) {

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -790,7 +790,7 @@ export class FabricImage<
    * @returns {Promise<FabricImage>}
    */
   static fromObject<T extends TOptions<SerializedImageProps>>(
-    { filters: f, resizeFilter: rf, src, crossOrigin, ...object }: T,
+    { filters: f, resizeFilter: rf, src, crossOrigin, type, ...object }: T,
     options: Abortable = {}
   ) {
     return Promise.all([

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -1566,7 +1566,7 @@ export class FabricObject<
    * @returns {Promise<FabricObject>}
    */
   static _fromObject<S extends FabricObject>(
-    object: Record<string, unknown>,
+    { type, ...object }: Record<string, unknown>,
     { extraParam, ...options }: Abortable & { extraParam?: string } = {}
   ): Promise<S> {
     return enlivenObjectEnlivables<any>(cloneDeep(object), options).then(

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -1575,7 +1575,7 @@ export class FabricObject<
         // from the resulting enlived options, extract options.extraParam to arg0
         // to avoid accidental overrides later
         if (extraParam) {
-          const { [extraParam]: arg0, type, ...rest } = allOptions;
+          const { [extraParam]: arg0, ...rest } = allOptions;
           // @ts-expect-error different signature
           return new this(arg0, rest);
         } else {

--- a/test/unit/rect.js
+++ b/test/unit/rect.js
@@ -204,10 +204,10 @@
   });
 
   QUnit.test('toObject without default values', function(assert) {
-    var options = { type: 'Rect', width: 69, height: 50, left: 10, top: 20, version: fabric.version, };
+    var options = { width: 69, height: 50, left: 10, top: 20, version: fabric.version, };
     var rect = new fabric.Rect(options);
     rect.includeDefaultValues = false;
-    assert.deepEqual(rect.toObject(), options);
+    assert.deepEqual(rect.toObject(), { type: 'Rect', ...options });
   });
 
   QUnit.test('paintFirst life cycle', function(assert) {


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

Warning when trying to write the type property is useful only to warn the developer intentionally messing with it.
restoring fromObject wasn't fully guarded from triggering it, now all the standard cases should be covered.

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
