### PR TITLE
fix(): `exactBoundingBox` stroke calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
 
 - fix() Addressing path cloning slowness ( partially ) [#9573](https://github.com/fabricjs/fabric.js/pull/9573)
+- fix(): `exactBoundingBox` stroke calculations [#9572](https://github.com/fabricjs/fabric.js/pull/9572)
 - feat(): Add save/restore ability to group LayoutManager [#9564](https://github.com/fabricjs/fabric.js/pull/9564)
 - fix() Remove unwanted set type warning [#9569](https://github.com/fabricjs/fabric.js/pull/9569)
 - refactor(): Separate defaults for base fabric object vs interactive object. Also some moving around of variables [#9474](https://github.com/fabricjs/fabric.js/pull/9474)

--- a/src/LayoutManager/LayoutStrategies/utils.ts
+++ b/src/LayoutManager/LayoutStrategies/utils.ts
@@ -34,14 +34,17 @@ export const getObjectBounds = (
   const objectCenter = t
     ? object.getRelativeCenterPoint().transform(t)
     : object.getRelativeCenterPoint();
-  const strokeUniformVector = strokeUniform
-    ? sendVectorToPlane(
-        new Point(strokeWidth, strokeWidth),
-        undefined,
-        destinationGroup.calcTransformMatrix()
-      )
-    : ZERO;
-  const scalingStrokeWidth = strokeUniform ? 0 : strokeWidth;
+  const accountForStroke = !object['isStrokeAccountedForInDimensions']();
+  const strokeUniformVector =
+    strokeUniform && accountForStroke
+      ? sendVectorToPlane(
+          new Point(strokeWidth, strokeWidth),
+          undefined,
+          destinationGroup.calcTransformMatrix()
+        )
+      : ZERO;
+  const scalingStrokeWidth =
+    !strokeUniform && accountForStroke ? strokeWidth : 0;
   const sizeVector = sizeAfterTransform(
     width + scalingStrokeWidth,
     height + scalingStrokeWidth,

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -1,4 +1,4 @@
-import { Point } from '../../Point';
+import { Point, ZERO } from '../../Point';
 import type { TCornerPoint, TDegree } from '../../typedefs';
 import { FabricObject } from './Object';
 import { degreesToRadians } from '../../util/misc/radiansDegreesConversion';
@@ -434,13 +434,14 @@ export class InteractiveFabricObject<
           this.height,
           calcDimensionsMatrix(options)
         ),
-        stroke = (
-          this.strokeUniform
-            ? new Point().scalarAdd(this.canvas ? this.canvas.getZoom() : 1)
-            : // this is extremely confusing. options comes from the upper function
-              // and is the qrDecompose of a matrix that takes in account zoom too
-              new Point(options.scaleX, options.scaleY)
-        ).scalarMultiply(this.strokeWidth);
+        stroke = !this.isStrokeAccountedForInDimensions()
+          ? (this.strokeUniform
+              ? new Point().scalarAdd(this.canvas ? this.canvas.getZoom() : 1)
+              : // this is extremely confusing. options comes from the upper function
+                // and is the qrDecompose of a matrix that takes in account zoom too
+                new Point(options.scaleX, options.scaleY)
+            ).scalarMultiply(this.strokeWidth)
+          : ZERO;
       size = bbox
         .add(stroke)
         .scalarAdd(this.borderScaleFactor)

--- a/src/shapes/Object/ObjectGeometry.ts
+++ b/src/shapes/Object/ObjectGeometry.ts
@@ -179,6 +179,13 @@ export class ObjectGeometry<EventSpec extends ObjectEvents = ObjectEvents>
   }
 
   /**
+   * @deprecated intermidiate method to be removed, do not use
+   */
+  protected isStrokeAccountedForInDimensions() {
+    return false;
+  }
+
+  /**
    * @return {Point[]} [tl, tr, br, bl] in the scene plane
    */
   getCoords(): Point[] {

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -20,6 +20,9 @@ import { CENTER, LEFT, TOP } from '../constants';
 import type { CSSRules } from '../parser/typedefs';
 
 export const polylineDefaultValues: Partial<TClassProperties<Polyline>> = {
+  /**
+   * @deprecated transient option soon to be removed in favor of a different design
+   */
   exactBoundingBox: false,
 };
 
@@ -44,7 +47,7 @@ export class Polyline<
    * Calculate the exact bounding box taking in account strokeWidth on acute angles
    * this will be turned to true by default on fabric 6.0
    * maybe will be left in as an optimization since calculations may be slow
-   * @deprecated
+   * @deprecated transient option soon to be removed in favor of a different design
    * @type Boolean
    * @default false
    */
@@ -206,6 +209,13 @@ export class Polyline<
   }
 
   /**
+   * @deprecated intermidiate method to be removed, do not use
+   */
+  protected isStrokeAccountedForInDimensions() {
+    return this.exactBoundingBox;
+  }
+
+  /**
    * @override stroke is taken in account in size
    */
   _getNonTransformedDimensions() {
@@ -225,9 +235,9 @@ export class Polyline<
   _getTransformedDimensions(options: any = {}) {
     if (this.exactBoundingBox) {
       let size: Point;
-      /* When `strokeUniform = true`, any changes to the properties require recalculating the `width` and `height` because 
-        the stroke projections are affected. 
-        When `strokeUniform = false`, we don't need to recalculate for scale transformations, as the effect of scale on 
+      /* When `strokeUniform = true`, any changes to the properties require recalculating the `width` and `height` because
+        the stroke projections are affected.
+        When `strokeUniform = false`, we don't need to recalculate for scale transformations, as the effect of scale on
         projections follows a linear function (e.g. scaleX of 2 just multiply width by 2)*/
       if (
         Object.keys(options).some(


### PR DESCRIPTION
mark method

<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

cherry picked out of #9537 
`exactBoundingBox` should IMO become the standard of object geometry API, meaning, an object should expose it final width and height values including stroke and whatever. Fabric should not , therefore, attempt to perform any other calculation besides sending the size vector to the relevant plane.
This will make geometry easier, straight forward, same for subclassing and will confine the logic to a single place instead of having a number of placing messing around with stroke calculations, all of them not compatible with stroke uniform etc.

I do not think this PR is good. It is an ugly patch.
A good solution would be to stick to what I have outlined above and remove all stroke calculations from fabric apart from the method that determines the size of an object on the object prototype

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
