### PR TITLE
fix(): compositionEnd event handler is not registered correctly. (regression from f91362c )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): compositionEnd event handler is not registered correctly. (regression from f91362c ) [#9610](https://github.com/fabricjs/fabric.js/pull/9610)
 - ci(): Add a test case from the multiple selection use case for groups [#9599](https://github.com/fabricjs/fabric.js/pull/9599)
 - refactor(env): Change the way the environment and retina are initialized [#9480](https://github.com/fabricjs/fabric.js/pull/9480)
 - chore(TS): fix type of modifed event that could cause unexpected behaviour in dev code [#9596](https://github.com/fabricjs/fabric.js/pull/9596)

--- a/src/shapes/IText/ITextKeyBehavior.ts
+++ b/src/shapes/IText/ITextKeyBehavior.ts
@@ -90,7 +90,7 @@ export abstract class ITextKeyBehavior<
       paste: 'paste',
       compositionstart: 'onCompositionStart',
       compositionupdate: 'onCompositionUpdate',
-      onCompositionUpdate: 'onCompositionEnd',
+      compositionend: 'onCompositionEnd',
     } as Record<string, keyof this>).map(([eventName, handler]) =>
       textarea.addEventListener(
         eventName,
@@ -186,8 +186,8 @@ export abstract class ITextKeyBehavior<
     }
     // decisions about style changes.
     const nextText = this._splitTextIntoLines(
-        this.hiddenTextarea.value
-      ).graphemeText,
+      this.hiddenTextarea.value
+    ).graphemeText,
       charCount = this._text.length,
       nextCharCount = nextText.length,
       selectionStart = this.selectionStart,
@@ -636,9 +636,8 @@ export abstract class ITextKeyBehavior<
    * @param {KeyboardEvent} e Event object
    */
   _moveCursorLeftOrRight(direction: 'Left' | 'Right', e: KeyboardEvent) {
-    const actionName = `moveCursor${direction}${
-      e.shiftKey ? 'WithShift' : 'WithoutShift'
-    }` as const;
+    const actionName = `moveCursor${direction}${e.shiftKey ? 'WithShift' : 'WithoutShift'
+      }` as const;
     this._currentCursorOpacity = 1;
     if (this[actionName](e)) {
       this.abortCursorAnimation();

--- a/src/shapes/IText/ITextKeyBehavior.ts
+++ b/src/shapes/IText/ITextKeyBehavior.ts
@@ -186,8 +186,8 @@ export abstract class ITextKeyBehavior<
     }
     // decisions about style changes.
     const nextText = this._splitTextIntoLines(
-      this.hiddenTextarea.value
-    ).graphemeText,
+        this.hiddenTextarea.value
+      ).graphemeText,
       charCount = this._text.length,
       nextCharCount = nextText.length,
       selectionStart = this.selectionStart,
@@ -636,8 +636,9 @@ export abstract class ITextKeyBehavior<
    * @param {KeyboardEvent} e Event object
    */
   _moveCursorLeftOrRight(direction: 'Left' | 'Right', e: KeyboardEvent) {
-    const actionName = `moveCursor${direction}${e.shiftKey ? 'WithShift' : 'WithoutShift'
-      }` as const;
+    const actionName = `moveCursor${direction}${
+      e.shiftKey ? 'WithShift' : 'WithoutShift'
+    }` as const;
     this._currentCursorOpacity = 1;
     if (this[actionName](e)) {
       this.abortCursorAnimation();


### PR DESCRIPTION
Textbox Chinese input with ctrl+a select all question

The inCompositionMode variable was not set to false after input was completed

This is because the input of the event name compositionend binding is incorrect

The current binding method in the code

![image](https://github.com/fabricjs/fabric.js/assets/29246287/6895275c-1d30-49b0-bfe2-d7d7205175f5)
