### PR TITLE
Split text into graphemes correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(textStyles): Split text into graphemes correctly [#9646](https://github.com/fabricjs/fabric.js/pull/9646)
 - fix(ActiveSelection): static default inheritance [#9635](https://github.com/fabricjs/fabric.js/pull/9635)
 - fix(StaticCanvas): StaticCanvas setDimensions typings [#9618](https://github.com/fabricjs/fabric.js/pull/9618)
 - refactor(): Align gradient with class registry usage, part of #9144 [#9627](https://github.com/fabricjs/fabric.js/pull/9627)

--- a/src/shapes/Text/StyledText.spec.ts
+++ b/src/shapes/Text/StyledText.spec.ts
@@ -35,3 +35,21 @@ describe('setSelectionStyles', () => {
     });
   });
 });
+
+describe('toObject', () => {
+  it('Will serialize text with grpahemes in mind', () => {
+    const text = new FabricText('🤩🤩\nHello', {
+      styles: {
+        1: {
+          0: {
+            fontSize: 40,
+          },
+        },
+      },
+    });
+    const serializedStyles = text.toObject().styles;
+    expect(serializedStyles).toEqual([
+      { start: 2, end: 3, style: { fontSize: 40 } },
+    ]);
+  });
+});

--- a/src/shapes/Text/StyledText.spec.ts
+++ b/src/shapes/Text/StyledText.spec.ts
@@ -1,4 +1,5 @@
 import { FabricText } from './Text';
+import { graphemeSplit } from '../../util/lang_string';
 
 describe('setSelectionStyles', () => {
   test('will set properties at the correct position', () => {
@@ -37,7 +38,7 @@ describe('setSelectionStyles', () => {
 });
 
 describe('toObject', () => {
-  it('Will serialize text with grpahemes in mind', () => {
+  it('Will serialize text with graphemes in mind', () => {
     const text = new FabricText('🤩🤩\nHello', {
       styles: {
         1: {
@@ -51,5 +52,8 @@ describe('toObject', () => {
     expect(serializedStyles).toEqual([
       { start: 2, end: 3, style: { fontSize: 40 } },
     ]);
+    expect(serializedStyles[0].start).toEqual(
+      graphemeSplit(text.textLines[0]).length
+    );
   });
 });

--- a/src/util/misc/textStyles.ts
+++ b/src/util/misc/textStyles.ts
@@ -4,6 +4,7 @@ import type {
   TextStyleDeclaration,
 } from '../../shapes/Text/StyledText';
 import { cloneDeep } from '../internals/cloneDeep';
+import { graphemeSplit } from '../lang_string';
 
 export type TextStyleArray = {
   start: number;
@@ -57,14 +58,15 @@ export const stylesToArray = (
 
   //loop through each textLine
   for (let i = 0; i < textLines.length; i++) {
+    const chars = graphemeSplit(textLines[i]);
     if (!styles[i]) {
       //no styles exist for this line, so add the line's length to the charIndex total and reset prevStyle
-      charIndex += textLines[i].length;
+      charIndex += chars.length;
       prevStyle = {};
       continue;
     }
     //loop through each character of the current line
-    for (let c = 0; c < textLines[i].length; c++) {
+    for (let c = 0; c < chars.length; c++) {
       charIndex++;
       const thisStyle = styles[i][c];
       //check if style exists for this character
@@ -108,8 +110,10 @@ export const stylesFromArray = (
     styleIndex = 0;
   //loop through each textLine
   for (let i = 0; i < textLines.length; i++) {
+    const chars = graphemeSplit(textLines[i]);
+
     //loop through each character of the current line
-    for (let c = 0; c < textLines[i].length; c++) {
+    for (let c = 0; c < chars.length; c++) {
       charIndex++;
       //check if there's a style collection that includes the current character
       if (


### PR DESCRIPTION
Use `graphemeSplit` to correctly split chars into graphemes correctly for textStyles conversion.

This bug doesn't cause actually any issue to fabric, which I why I could not write any test. Fabric uses the textStyles utils only for `toObject` and `fromObject`, but since the bug is present in both directions `fromObject(toObject(textStyles)) === textStyles`, but it's technically wrong. If you use a text like `👨‍👩‍👦‍👦`, it will be looped through as 4 distinct chars, but it's a single grapheme.

I know we should use `object.graphemeSplit` to actually use the overriden implementation from the consumer, but there's a comment that says there should be a way to provide the `graphemeSplit` implementation directly to fabric. So for now I think this is enough as reminder that `textStyles` should do grapheme splitting as well. If needed, we can change the functions to accept `textLines: string[][]` as array of grapheme-split text lines.

Also nobody reported this issue. I knew about it only because at work we use the `TextStyleArray` format both for serialization and for the React UI state, e.g. to show the text formatting buttons for the selected text. 