### PR TITLE
fix(Object): support specyfing toCanvasElement canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Object): support specyfing toCanvasElement canvas [#9652](https://github.com/fabricjs/fabric.js/pull/9652)
 - fix(textStyles): Split text into graphemes correctly [#9646](https://github.com/fabricjs/fabric.js/pull/9646)
 - fix(ActiveSelection): static default inheritance [#9635](https://github.com/fabricjs/fabric.js/pull/9635)
 - fix(StaticCanvas): StaticCanvas setDimensions typings [#9618](https://github.com/fabricjs/fabric.js/pull/9618)

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -1360,7 +1360,15 @@ export class FabricObject<
    * @param {Boolean} [options.viewportTransform] Account for canvas viewport transform
    * @return {HTMLCanvasElement} Returns DOM element <canvas> with the FabricObject
    */
-  toCanvasElement(options: any = {}) {
+  toCanvasElement(
+    options: any = {},
+    createToCanvas = (el: HTMLCanvasElement) =>
+      new StaticCanvas(el, {
+        enableRetinaScaling: false,
+        renderOnAddRemove: false,
+        skipOffscreen: false,
+      })
+  ) {
     const origParams = saveObjectTransform(this),
       originalGroup = this.group,
       originalShadow = this.shadow,
@@ -1401,11 +1409,7 @@ export class FabricObject<
     // we need to make it so.
     el.width = Math.ceil(width);
     el.height = Math.ceil(height);
-    const canvas = new StaticCanvas(el, {
-      enableRetinaScaling: false,
-      renderOnAddRemove: false,
-      skipOffscreen: false,
-    });
+    const canvas = createToCanvas(el);
     if (options.format === 'jpeg') {
       canvas.backgroundColor = '#fff';
     }

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -1358,23 +1358,24 @@ export class FabricObject<
    * @param {Boolean} [options.withoutTransform] Remove current object transform ( no scale , no angle, no flip, no skew ). Introduced in 2.3.4
    * @param {Boolean} [options.withoutShadow] Remove current object shadow. Introduced in 2.4.2
    * @param {Boolean} [options.viewportTransform] Account for canvas viewport transform
+   * @param {(el: HTMLCanvasElement) => Canvas} [options.canvasProvider] Create the output canvas
    * @return {HTMLCanvasElement} Returns DOM element <canvas> with the FabricObject
    */
-  toCanvasElement(
-    options: any = {},
-    createToCanvas = (el: HTMLCanvasElement) =>
-      new StaticCanvas(el, {
-        enableRetinaScaling: false,
-        renderOnAddRemove: false,
-        skipOffscreen: false,
-      })
-  ) {
+  toCanvasElement(options: any = {}) {
     const origParams = saveObjectTransform(this),
       originalGroup = this.group,
       originalShadow = this.shadow,
       abs = Math.abs,
       retinaScaling = options.enableRetinaScaling ? getDevicePixelRatio() : 1,
-      multiplier = (options.multiplier || 1) * retinaScaling;
+      multiplier = (options.multiplier || 1) * retinaScaling,
+      canvasProvider: (el: HTMLCanvasElement) => StaticCanvas =
+        options.canvasProvider ||
+        ((el: HTMLCanvasElement) =>
+          new StaticCanvas(el, {
+            enableRetinaScaling: false,
+            renderOnAddRemove: false,
+            skipOffscreen: false,
+          }));
     delete this.group;
     if (options.withoutTransform) {
       resetObjectTransform(this);
@@ -1409,7 +1410,7 @@ export class FabricObject<
     // we need to make it so.
     el.width = Math.ceil(width);
     el.height = Math.ceil(height);
-    const canvas = createToCanvas(el);
+    const canvas = canvasProvider(el);
     if (options.format === 'jpeg') {
       canvas.backgroundColor = '#fff';
     }


### PR DESCRIPTION
It's fundamentally wrong to assume `StaticCanvas` is enough for rendering any generic object to a new canvas `toCanvasElement`. The object typically assumes the canvas reference is the usual canvas, e.g. `fabric.Canvas`, so it's unsafe to replace it with a StaticCanvas. I could even just do this in the object:

```ts
_render() {
  if (canvas.getActiveObject() === this) {
    // Draw some border
  }
}
```

This is just a quick fix so that one can use a different canvas if needed. It's difficult for fabric to know exactly what canvas class should be used. Something like `new this.canvas.constructor(el)` would not work.