### PR TITLE
feat(LayoutManager): Expose objects registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- [draft]: regisrtation on demand [#9661](https://github.com/fabricjs/fabric.js/pull/9661)
+- [draft]: registration on demand [#9661](https://github.com/fabricjs/fabric.js/pull/9661)
 - fix(Object): support specyfing toCanvasElement canvas [#9652](https://github.com/fabricjs/fabric.js/pull/9652)
 - ci(): no `src` imports [#9657](https://github.com/fabricjs/fabric.js/pull/9657)
 - fix(textStyles): Split text into graphemes correctly [#9646](https://github.com/fabricjs/fabric.js/pull/9646)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- [draft]: registration on demand [#9661](https://github.com/fabricjs/fabric.js/pull/9661)
+- feat(LayoutManager): Expose objects registration [#9661](https://github.com/fabricjs/fabric.js/pull/9661)
 - fix(Object): support specyfing toCanvasElement canvas [#9652](https://github.com/fabricjs/fabric.js/pull/9652)
 - ci(): no `src` imports [#9657](https://github.com/fabricjs/fabric.js/pull/9657)
 - fix(textStyles): Split text into graphemes correctly [#9646](https://github.com/fabricjs/fabric.js/pull/9646)

--- a/src/LayoutManager/LayoutManager.spec.ts
+++ b/src/LayoutManager/LayoutManager.spec.ts
@@ -3,7 +3,9 @@ import { Point } from '../Point';
 import { StaticCanvas } from '../canvas/StaticCanvas';
 import { Group } from '../shapes/Group';
 import { FabricObject } from '../shapes/Object/FabricObject';
+import { Rect } from '../shapes/Rect';
 import { LayoutManager } from './LayoutManager';
+import { ClipPathLayout } from './LayoutStrategies/ClipPathLayout';
 import { FitContentLayout } from './LayoutStrategies/FitContentLayout';
 import { FixedLayout } from './LayoutStrategies/FixedLayout';
 import {
@@ -754,6 +756,73 @@ describe('Layout Manager', () => {
       ).toMatchObject([child]);
     });
 
+    describe('fromObject restore', () => {
+      const createTestData = (type: string) => ({
+        width: 2,
+        height: 3,
+        left: 6,
+        top: 4,
+        strokeWidth: 0,
+        objects: [
+          new Rect({
+            width: 100,
+            height: 100,
+            top: 0,
+            left: 0,
+            strokeWidth: 0,
+          }).toObject(),
+          new Rect({
+            width: 100,
+            height: 100,
+            top: 0,
+            left: 0,
+            strokeWidth: 0,
+          }).toObject(),
+        ],
+        clipPath: new Rect({
+          width: 50,
+          height: 50,
+          top: 0,
+          left: 0,
+          strokeWidth: 0,
+        }).toObject(),
+        layoutManager: {
+          type: 'layoutManager',
+          strategy: type,
+        },
+      });
+      describe('Fitcontent layout', () => {
+        it('should subscribe objects', async () => {
+          const group = await Group.fromObject(
+            createTestData(FitContentLayout.type)
+          );
+          expect(
+            Array.from(group.layoutManager['_subscriptions'].keys())
+          ).toMatchObject(group.getObjects());
+        });
+      });
+      describe('FixedLayout layout', () => {
+        it('should subscribe objects', async () => {
+          const group = await Group.fromObject(
+            createTestData(FixedLayout.type)
+          );
+          expect(
+            Array.from(group.layoutManager['_subscriptions'].keys())
+          ).toMatchObject(group.getObjects());
+        });
+      });
+      describe('ClipPathLayout layout', () => {
+        it('should subscribe objects', async () => {
+          const group = await Group.fromObject(
+            createTestData(ClipPathLayout.type)
+          );
+          expect(
+            Array.from(group.layoutManager['_subscriptions'].keys())
+          ).toMatchObject(group.getObjects());
+        });
+      });
+    });
+
     test.each([true, false])(
       'initialization edge case, legacy layout %s',
       (legacy) => {
@@ -766,7 +835,7 @@ describe('Layout Manager', () => {
           width: 200,
           height: 200,
           strokeWidth: 0,
-          layoutManager: !legacy ? new LayoutManager() : undefined,
+          layoutManager: legacy ? undefined : new LayoutManager(),
         });
         expect(group).toMatchObject({ width: 200, height: 200 });
         expect(child.getRelativeCenterPoint()).toMatchObject({ x: 0, y: 0 });

--- a/src/LayoutManager/LayoutManager.ts
+++ b/src/LayoutManager/LayoutManager.ts
@@ -64,7 +64,10 @@ export class LayoutManager {
   /**
    * subscribe to object layout triggers
    */
-  protected subscribe(object: FabricObject, context: { target: Group }) {
+  protected subscribe(
+    object: FabricObject,
+    context: RegistrationContext & Partial<StrictLayoutContext>
+  ) {
     const { target } = context;
     this.unsubscribe(object, context);
     const disposers = [
@@ -103,17 +106,23 @@ export class LayoutManager {
   /**
    * unsubscribe object layout triggers
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected unsubscribe(object: FabricObject, context?: { target: Group }) {
+  protected unsubscribe(
+    object: FabricObject,
+    context?: RegistrationContext & Partial<StrictLayoutContext>
+  ) {
     (this._subscriptions.get(object) || []).forEach((d) => d());
     this._subscriptions.delete(object);
   }
 
-  unsubscribeTargets(context: RegistrationContext) {
+  unsubscribeTargets(
+    context: RegistrationContext & Partial<StrictLayoutContext>
+  ) {
     context.targets.forEach((object) => this.unsubscribe(object, context));
   }
 
-  subscribeTargets(context: RegistrationContext) {
+  subscribeTargets(
+    context: RegistrationContext & Partial<StrictLayoutContext>
+  ) {
     context.targets.forEach((object) => this.subscribe(object, context));
   }
 

--- a/src/LayoutManager/types.ts
+++ b/src/LayoutManager/types.ts
@@ -132,6 +132,11 @@ export type StrictLayoutContext = LayoutContext & {
   stopPropagation(): void;
 };
 
+export type RegistrationContext = {
+  targets: FabricObject[];
+  target: Group;
+};
+
 export type LayoutBeforeEvent = {
   context: StrictLayoutContext;
 };

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -569,7 +569,10 @@ export class Group
   }
 
   dispose() {
-    this.layoutManager.unsubscribeTarget(this);
+    this.layoutManager.unsubscribeTargets({
+      targets: this.getObjects(),
+      target: this,
+    });
     this._activeObjects = [];
     this.forEachObject((object) => {
       this._watchObject(false, object);
@@ -672,6 +675,10 @@ export class Group
       } else {
         group.layoutManager = new LayoutManager();
       }
+      group.layoutManager.subscribeTargets({
+        target: group,
+        targets: group.getObjects(),
+      });
       group.setCoords();
       return group;
     });

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -676,6 +676,7 @@ export class Group
         group.layoutManager = new LayoutManager();
       }
       group.layoutManager.subscribeTargets({
+        type: LAYOUT_TYPE_INITIALIZATION,
         target: group,
         targets: group.getObjects(),
       });

--- a/src/shapes/Object/types/SerializedObjectProps.ts
+++ b/src/shapes/Object/types/SerializedObjectProps.ts
@@ -46,7 +46,7 @@ export interface SerializedObjectProps extends BaseProps, FillStrokeProps {
    * If you want 0,0 of a clipPath to align with an object center, use clipPath.originX/Y to 'center'
    * @type FabricObject
    */
-  clipPath?: Partial<SerializedObjectProps> & ClipPathProps;
+  clipPath?: Partial<SerializedObjectProps & ClipPathProps>;
 }
 
 export interface ClipPathProps {


### PR DESCRIPTION
## Description

When we stopped running the layout manager from group that comes from a json object, we removed also the object registration part and that broke interactive groups that won't react when the objects are transformed.

This PR fixes the issue by explicitly registering the objects.

This is a temporary fix, the final goal will probably be to deprecate the interactivity property of the group and add a setInteractive method that will also take care of event registration, since it doesn't seems right to have event handler registered anyway for objects that are non interactive.

There are probably other parts in the transform lifecycle where we can handle this but for now we are registering everything every time.

