### PR TITLE
feat(Circle): Add counterclockwise parameter to Circle class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- feat(Circle): Add counterclockwise parameter to Circle class [#9670](https://github.com/fabricjs/fabric.js/pull/9670)
+
 ## [6.0.0-beta19]
 
 - feat(LayoutManager): Expose objects registration [#9661](https://github.com/fabricjs/fabric.js/pull/9661)

--- a/src/shapes/Circle.ts
+++ b/src/shapes/Circle.ts
@@ -19,20 +19,26 @@ interface UniqueCircleProps {
   radius: number;
 
   /**
-   * degrees of start of the circle.
-   * probably will change to degrees in next major version
-   * @type Number 0 - 359
+   * Angle for the start of the circle, in degrees.
+   * @type TDegree 0 - 359
    * @default 0
    */
   startAngle: number;
 
   /**
-   * End angle of the circle
-   * probably will change to degrees in next major version
-   * @type Number 1 - 360
+   * Angle for the end of the circle, in degrees
+   * @type TDegree 1 - 360
    * @default 360
    */
   endAngle: number;
+
+  /**
+   * Orientation for the direction of the circle.
+   * Setting to true will switch the arc of the circle to traverse from startAngle to endAngle in a counter-clockwise direction.
+   * Note: this will only change how the circle is drawn, and does not affect rotational transformation.
+   * @default false
+   */
+  counterClockwise: boolean;
 }
 
 export interface SerializedCircleProps
@@ -41,12 +47,18 @@ export interface SerializedCircleProps
 
 export interface CircleProps extends FabricObjectProps, UniqueCircleProps {}
 
-const CIRCLE_PROPS = ['radius', 'startAngle', 'endAngle'] as const;
+const CIRCLE_PROPS = [
+  'radius',
+  'startAngle',
+  'endAngle',
+  'counterClockwise',
+] as const;
 
 export const circleDefaultValues: UniqueCircleProps = {
   radius: 0,
   startAngle: 0,
   endAngle: 360,
+  counterClockwise: false,
 };
 
 export class Circle<
@@ -60,6 +72,7 @@ export class Circle<
   declare radius: number;
   declare startAngle: number;
   declare endAngle: number;
+  declare counterClockwise: boolean;
 
   static type = 'Circle';
 
@@ -101,7 +114,7 @@ export class Circle<
       this.radius,
       degreesToRadians(this.startAngle),
       degreesToRadians(this.endAngle),
-      false
+      this.counterClockwise
     );
     this._renderPaintInOrder(ctx);
   }
@@ -169,14 +182,10 @@ export class Circle<
         startY = sin(start) * radius,
         endX = cos(end) * radius,
         endY = sin(end) * radius,
-        largeFlag = angle > 180 ? '1' : '0';
+        largeFlag = angle > 180 ? 1 : 0,
+        sweepFlag = this.counterClockwise ? 0 : 1;
       return [
-        `<path d="M ${startX} ${startY}`,
-        ` A ${radius} ${radius}`,
-        ' 0 ',
-        `${largeFlag} 1`,
-        ` ${endX} ${endY}`,
-        '" ',
+        `<path d="M ${startX} ${startY} A ${radius} ${radius} 0 ${largeFlag} ${sweepFlag} ${endX} ${endY}" `,
         'COMMON_PARTS',
         ' />\n',
       ];

--- a/test/unit/circle.js
+++ b/test/unit/circle.js
@@ -117,6 +117,7 @@
       radius:                   0,
       startAngle:               0,
       endAngle:                 360,
+      counterClockwise:         false,
       skewX:                    0,
       skewY:                    0,
       strokeUniform:            false
@@ -159,11 +160,19 @@
   });
 
   QUnit.test('toSVG with half circle', function(assert) {
-    var circle = new fabric.Circle({ width: 100, height: 100, radius: 10, endAngle: fabric.util.radiansToDegrees(Math.PI) });
+    var circle = new fabric.Circle({ width: 100, height: 100, radius: 10, endAngle: 180 });
     var svg = circle.toSVG();
     var svgClipPath = circle.toClipPathSVG();
     assert.equal(svg, '<g transform=\"matrix(1 0 0 1 10.5 10.5)\"  >\n<path d=\"M 10 0 A 10 10 0 0 1 -10 0\" style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"   />\n</g>\n');
     assert.equal(svgClipPath, '\t<path d=\"M 10 0 A 10 10 0 0 1 -10 0\" transform=\"matrix(1 0 0 1 10.5 10.5)\"  />\n', 'half circle as clipPath');
+  });
+
+  QUnit.test('toSVG with counterclockwise half circle', function (assert) {
+    var circle = new fabric.Circle({ width: 100, height: 100, radius: 10, endAngle: 180, counterClockwise: true });
+    var svg = circle.toSVG();
+    var svgClipPath = circle.toClipPathSVG();
+    assert.equal(svg, '<g transform=\"matrix(1 0 0 1 10.5 10.5)\"  >\n<path d=\"M 10 0 A 10 10 0 0 0 -10 0\" style=\"stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;\"   />\n</g>\n');
+    assert.equal(svgClipPath, '\t<path d=\"M 10 0 A 10 10 0 0 0 -10 0\" transform=\"matrix(1 0 0 1 10.5 10.5)\"  />\n', 'half circle as clipPath');
   });
 
   QUnit.test('fromElement', function(assert) {


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

This resolves issue #9653 to implement orientation to the circle. I have also taken the liberty of tidying the documentation, per #9654 , to emphasize that the angle is in degrees and will stay that way.

## In Action

I used `npm start node` and the following code snippet for `index.mjs`:

```js
const canvas = new fabric.StaticCanvas(null, { width: 500, height: 500 });
    const circle1 = new fabric.Circle({
      left: 100,
      top: 100,
      radius: 20,
      originX: 'center',
      originY: 'center',
      fill: 'rgba(0,0,0,0)',
      noScaleCache: false,
      strokeUniform: true,
      strokeWidth: 1,
      stroke: '#00ff00',
      selectable: false,
      hasControls: false,
      lockScalingX: true,
      lockScalingY: true,
      startAngle: 45,
      endAngle: 270,
    })
    const circle2 = new fabric.Circle({
      left: 200,
      top: 100,
      radius: 20,
      originX: 'center',
      originY: 'center',
      fill: 'rgba(0,0,0,0)',
      noScaleCache: false,
      strokeUniform: true,
      strokeWidth: 1,
      stroke: '#00ff00',
      selectable: false,
      hasControls: false,
      lockScalingX: true,
      lockScalingY: true,
      startAngle: 45,
      endAngle: 270,
      clockwise: false,
    })
    canvas.add(circle1, circle2);
    canvas.renderAll();
```

This is the resulting snapshot:

![2024-02-15_21-17-31](https://github.com/fabricjs/fabric.js/assets/9062490/8368194b-94dd-4e3c-b548-b4a7e605a114)

Note that they sweep out complementary angles.

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
