### PR TITLE
chore(TS): use consistent and improved types for getDefaults and ownDefaults

### DIFF
--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -271,7 +271,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
    */
   protected declare _target?: FabricObject;
 
-  static ownDefaults: Record<string, any> = canvasDefaults;
+  static ownDefaults = canvasDefaults;
 
   static getDefaults(): Record<string, any> {
     return { ...super.getDefaults(), ...SelectableCanvas.ownDefaults };

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -7,12 +7,18 @@ import {
   LAYOUT_TYPE_ADDED,
   LAYOUT_TYPE_REMOVED,
 } from '../LayoutManager/constants';
+import type { TClassProperties } from '../typedefs';
 
 export type MultiSelectionStacking = 'canvas-stacking' | 'selection-order';
 
 export interface ActiveSelectionOptions extends GroupProps {
   multiSelectionStacking: MultiSelectionStacking;
 }
+
+const activeSelectionDefaultValues: Partial<TClassProperties<ActiveSelection>> =
+  {
+    multiSelectionStacking: 'canvas-stacking',
+  };
 
 /**
  * Used by Canvas to manage selection.
@@ -28,11 +34,9 @@ export interface ActiveSelectionOptions extends GroupProps {
 export class ActiveSelection extends Group {
   static type = 'ActiveSelection';
 
-  static ownDefaults: Record<string, any> = {
-    multiSelectionStacking: 'canvas-stacking',
-  };
+  static ownDefaults = activeSelectionDefaultValues;
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return { ...super.getDefaults(), ...ActiveSelection.ownDefaults };
   }
 

--- a/src/shapes/Circle.ts
+++ b/src/shapes/Circle.ts
@@ -54,7 +54,7 @@ const CIRCLE_PROPS = [
   'counterClockwise',
 ] as const;
 
-export const circleDefaultValues: UniqueCircleProps = {
+export const circleDefaultValues: Partial<TClassProperties<Circle>> = {
   radius: 0,
   startAngle: 0,
   endAngle: 360,
@@ -78,7 +78,7 @@ export class Circle<
 
   static cacheProperties = [...cacheProperties, ...CIRCLE_PROPS];
 
-  static ownDefaults: Record<string, any> = circleDefaultValues;
+  static ownDefaults = circleDefaultValues;
 
   static getDefaults(): Record<string, any> {
     return {

--- a/src/shapes/Ellipse.ts
+++ b/src/shapes/Ellipse.ts
@@ -8,7 +8,7 @@ import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
 import type { ObjectEvents } from '../EventTypeDefs';
 import type { CSSRules } from '../parser/typedefs';
 
-export const ellipseDefaultValues: UniqueEllipseProps = {
+export const ellipseDefaultValues: Partial<TClassProperties<Ellipse>> = {
   rx: 0,
   ry: 0,
 };
@@ -52,9 +52,9 @@ export class Ellipse<
 
   static cacheProperties = [...cacheProperties, ...ELLIPSE_PROPS];
 
-  static ownDefaults: Record<string, any> = ellipseDefaultValues;
+  static ownDefaults = ellipseDefaultValues;
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return {
       ...super.getDefaults(),
       ...Ellipse.ownDefaults,

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -62,7 +62,7 @@ export interface GroupProps extends FabricObjectProps, GroupOwnProps {
   layoutManager: LayoutManager;
 }
 
-export const groupDefaultValues = {
+export const groupDefaultValues: Partial<TClassProperties<Group>> = {
   strokeWidth: 0,
   subTargetCheck: false,
   interactive: false,

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -7,7 +7,7 @@ import {
   keysMap,
   keysMapRtl,
 } from './constants';
-import type { TFiller, TOptions } from '../../typedefs';
+import type { TClassProperties, TFiller, TOptions } from '../../typedefs';
 import { classRegistry } from '../../ClassRegistry';
 import type { SerializedTextProps, TextProps } from '../Text/Text';
 import {
@@ -26,7 +26,14 @@ type CursorBoundaries = {
   topOffset: number;
 };
 
-export const iTextDefaultValues = {
+// Declare IText protected properties to workaround TS
+const protectedDefaultValues = {
+  _selectionDirection: null,
+  _reSpace: /\s|\r?\n/,
+  inCompositionMode: false,
+};
+
+export const iTextDefaultValues: Partial<TClassProperties<IText>> = {
   selectionStart: 0,
   selectionEnd: 0,
   selectionColor: 'rgba(17,119,255,0.3)',
@@ -39,13 +46,11 @@ export const iTextDefaultValues = {
   cursorDuration: 600,
   caching: true,
   hiddenTextareaContainer: null,
-  _selectionDirection: null,
-  _reSpace: /\s|\r?\n/,
-  inCompositionMode: false,
   keysMap,
   keysMapRtl,
   ctrlKeysMapDown,
   ctrlKeysMapUp,
+  ...protectedDefaultValues,
 };
 
 // @TODO this is not complete
@@ -197,9 +202,9 @@ export class IText<
    */
   declare caching: boolean;
 
-  static ownDefaults: Record<string, any> = iTextDefaultValues;
+  static ownDefaults = iTextDefaultValues;
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return { ...super.getDefaults(), ...IText.ownDefaults };
   }
 

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -49,8 +49,7 @@ interface UniqueImageProps {
   resizeFilter?: Resize;
 }
 
-export const imageDefaultValues: Partial<UniqueImageProps> &
-  Partial<FabricObjectProps> = {
+export const imageDefaultValues: Partial<TClassProperties<FabricImage>> = {
   strokeWidth: 0,
   srcFromAttribute: false,
   minimumScaleTrigger: 0.5,
@@ -178,9 +177,9 @@ export class FabricImage<
 
   static cacheProperties = [...cacheProperties, ...IMAGE_PROPS];
 
-  static ownDefaults: Record<string, any> = imageDefaultValues;
+  static ownDefaults = imageDefaultValues;
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return {
       ...super.getDefaults(),
       ...FabricImage.ownDefaults,

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -134,7 +134,7 @@ export class InteractiveFabricObject<
 
   declare canvas?: Canvas;
 
-  static ownDefaults: Record<string, any> = interactiveObjectDefaultValues;
+  static ownDefaults = interactiveObjectDefaultValues;
 
   static getDefaults(): Record<string, any> {
     return {

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -293,7 +293,7 @@ export class FabricObject<
    */
   declare _transformDone?: boolean;
 
-  static ownDefaults: Record<string, any> = fabricObjectDefaultValues;
+  static ownDefaults = fabricObjectDefaultValues;
 
   static getDefaults(): Record<string, any> {
     return { ...FabricObject.ownDefaults };

--- a/src/shapes/Object/defaultValues.ts
+++ b/src/shapes/Object/defaultValues.ts
@@ -1,4 +1,7 @@
 import { TOP, LEFT } from '../../constants';
+import type { TClassProperties } from '../../typedefs';
+import type { InteractiveFabricObject } from './InteractiveObject';
+import type { FabricObject } from './Object';
 
 export const stateProperties = [
   TOP,
@@ -35,7 +38,9 @@ export const cacheProperties = [
   'clipPath',
 ];
 
-export const fabricObjectDefaultValues = {
+export const fabricObjectDefaultValues: Partial<
+  TClassProperties<FabricObject>
+> = {
   // see composeMatrix() to see order of transforms. First defaults listed based on this
   top: 0,
   left: 0,
@@ -79,7 +84,9 @@ export const fabricObjectDefaultValues = {
   dirty: true,
 } as const;
 
-export const interactiveObjectDefaultValues = {
+export const interactiveObjectDefaultValues: Partial<
+  TClassProperties<InteractiveFabricObject>
+> = {
   noScaleCache: true,
   lockMovementX: false,
   lockMovementY: false,

--- a/src/shapes/Polygon.ts
+++ b/src/shapes/Polygon.ts
@@ -2,11 +2,11 @@ import { classRegistry } from '../ClassRegistry';
 import { Polyline, polylineDefaultValues } from './Polyline';
 
 export class Polygon extends Polyline {
-  static ownDefaults: Record<string, any> = polylineDefaultValues;
+  static ownDefaults = polylineDefaultValues;
 
   static type = 'Polygon';
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return {
       ...super.getDefaults(),
       ...Polyline.ownDefaults,

--- a/src/shapes/Polyline.ts
+++ b/src/shapes/Polyline.ts
@@ -55,11 +55,11 @@ export class Polyline<
 
   private declare initialized: true | undefined;
 
-  static ownDefaults: Record<string, any> = polylineDefaultValues;
+  static ownDefaults = polylineDefaultValues;
 
   static type = 'Polyline';
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return {
       ...super.getDefaults(),
       ...Polyline.ownDefaults,

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -52,7 +52,7 @@ export class Rect<
 
   static cacheProperties = [...cacheProperties, ...RECT_PROPS];
 
-  static ownDefaults: Record<string, any> = rectDefaultValues;
+  static ownDefaults = rectDefaultValues;
 
   static getDefaults(): Record<string, any> {
     return {

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -410,11 +410,11 @@ export class FabricText<
 
   static cacheProperties = [...cacheProperties, ...additionalProps];
 
-  static ownDefaults: Record<string, any> = textDefaultValues;
+  static ownDefaults = textDefaultValues;
 
   static type = 'Text';
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return { ...super.getDefaults(), ...FabricText.ownDefaults };
   }
 

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -92,9 +92,9 @@ export class Textbox<
 
   static textLayoutProperties = [...IText.textLayoutProperties, 'width'];
 
-  static ownDefaults: Record<string, any> = textboxDefaultValues;
+  static ownDefaults = textboxDefaultValues;
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return {
       ...super.getDefaults(),
       controls: createTextboxDefaultControls(),

--- a/src/shapes/Triangle.ts
+++ b/src/shapes/Triangle.ts
@@ -1,10 +1,10 @@
 import { classRegistry } from '../ClassRegistry';
 import { FabricObject } from './Object/FabricObject';
 import type { FabricObjectProps, SerializedObjectProps } from './Object/types';
-import type { TOptions } from '../typedefs';
+import type { TClassProperties, TOptions } from '../typedefs';
 import type { ObjectEvents } from '../EventTypeDefs';
 
-export const triangleDefaultValues = {
+export const triangleDefaultValues: Partial<TClassProperties<Triangle>> = {
   width: 100,
   height: 100,
 };
@@ -19,9 +19,9 @@ export class Triangle<
 {
   static type = 'Triangle';
 
-  static ownDefaults: Record<string, any> = triangleDefaultValues;
+  static ownDefaults = triangleDefaultValues;
 
-  static getDefaults() {
+  static getDefaults(): Record<string, any> {
     return { ...super.getDefaults(), ...Triangle.ownDefaults };
   }
 


### PR DESCRIPTION
`Textbox.getDefaults` type is inferred, resulting in error if trying to extend the class and override the static method:

```ts
// Will error
class Test extends Textbox {
  static ownDefaults = {
    textAlign: "center"
  } satisfies Partial<Textbox>;

  static getDefaults(): Record<string, any> {
    return {
      ...super.getDefaults(),
      ...Test.ownDefaults
    }
  }
}
```

<img width="500" alt="Screenshot 2024-02-29 at 13 28 00" src="https://github.com/fabricjs/fabric.js/assets/10067273/434cf397-8ec0-490f-b97a-076f5b81b3fe">

I took the chance to ensure all `getDefaults` explicitly return the type `: Record<string, any>`, whereas the default values are strictly typed instead of being `Record<string, any>`.