### PR TITLE
BREAKING BETA refactor(DOMManager): abstract to avoid DOM mutation

### DIFF
--- a/.codesandbox/templates/next/components/hooks.ts
+++ b/.codesandbox/templates/next/components/hooks.ts
@@ -1,0 +1,62 @@
+import React, { useEffect, useCallback, useMemo } from 'react';
+import * as fabric from 'fabric';
+
+export function useResize<T extends fabric.Canvas>(
+  ref: React.RefObject<T>,
+  {
+    zoomToFit,
+    onResize,
+  }: {
+    zoomToFit?: boolean;
+    onResize?: () => void;
+  } = {}
+) {
+  const resize = useCallback(() => {
+    const canvas = ref.current;
+    if (!canvas) {
+      return;
+    }
+    canvas.setDimensions({ width: '100%', height: '100%' }, { cssOnly: true });
+    if (!zoomToFit) {
+      const { width, height } = window.getComputedStyle(
+        canvas.elements.items.main.el
+      );
+      canvas.setDimensions({
+        width: parseInt(width),
+        height: parseInt(height),
+      });
+    }
+  }, [ref, zoomToFit]);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) {
+      return;
+    }
+    resize();
+    const observer = new ResizeObserver(() => {
+      resize();
+      onResize?.();
+    });
+    observer.observe(canvas.elements.items.main.el.parentElement!);
+    return () => observer.disconnect();
+  }, [ref, resize, onResize]);
+}
+
+export function useListener<T, K extends keyof T, E extends T[K]>(
+  ref: React.RefObject<fabric.Observable<T>>,
+  key: K,
+  callback: (options: E) => any
+) {
+  useEffect(() => ref.current?.on(key, callback), [ref, key, callback]);
+}
+
+export function useAnimation(
+  options: Parameters<typeof fabric.util.animate>[0]
+) {
+  const animation = useMemo(() => fabric.util.animate(options), [options]);
+  useEffect(() => {
+    animation.start();
+    return () => animation.abort();
+  }, [animation]);
+}

--- a/.codesandbox/templates/next/components/index.tsx
+++ b/.codesandbox/templates/next/components/index.tsx
@@ -15,7 +15,9 @@ const canvasStyle: React.CSSProperties = {
   userSelect: 'none',
 };
 
-export const CanvasSlot = ({ name }: { name: string }) => <div name={name} />;
+export const CanvasSlot = ({ name }: { name: 'main' | 'top' | string }) => (
+  <div name={name} />
+);
 
 /**
  * @example Standard
@@ -87,15 +89,20 @@ export const CanvasComponent = ({
     };
   }, [canvasRefs, create]);
 
-  return React.Children.map(children, (child) =>
-    typeof child === 'object' &&
-    (child as React.ReactElement).type === CanvasSlot ? (
-      <canvas
-        style={canvasStyle}
-        ref={canvasRefs[(child as React.ReactElement).props.name]}
-      />
-    ) : (
-      child
-    )
-  );
+  return React.Children.map(children, (child) => {
+    if (
+      typeof child === 'object' &&
+      (child as React.ReactElement).type === CanvasSlot
+    ) {
+      const { name } = (child as React.ReactElement).props;
+      return (
+        <canvas
+          style={name === 'main' ? undefined : canvasStyle}
+          ref={canvasRefs[name]}
+        />
+      );
+    } else {
+      return child;
+    }
+  });
 };

--- a/.codesandbox/templates/next/components/index.tsx
+++ b/.codesandbox/templates/next/components/index.tsx
@@ -1,0 +1,101 @@
+import React, { createRef, useEffect, useMemo } from 'react';
+import {
+  DOMManager,
+  DOMManagerType,
+  StaticCanvas,
+  StaticDOMManagerType,
+} from 'fabric';
+
+const canvasStyle: React.CSSProperties = {
+  position: 'absolute',
+  left: 0,
+  top: 0,
+  touchAction: 'none',
+  msTouchAction: 'none',
+  userSelect: 'none',
+};
+
+export const CanvasSlot = ({ name }: { name: string }) => <div name={name} />;
+
+/**
+ * @example Standard
+ *   const create = useCallback((arg0: DOMManagerType) => {
+ *     const canvas = new Canvas(arg0);
+ *     ...
+ *     return canvas; // return for cleanup
+ *   });
+ *
+ *   <CanvasComponent create={create}>
+ *     <CanvasSlot name="main" />
+ *     <CanvasSlot name="top" />
+ *   </CanvasComponent>
+ *
+ * @example DOM elements in between
+ *   <CanvasComponent create={create}>
+ *     <CanvasSlot name="main" />
+ *     <CanvasSlot name="pointers" />
+ *     Hello World
+ *     <CanvasSlot name="top" />
+ *   </CanvasComponent>
+ *
+ * @example Static
+ *   const createStatic = useCallback((arg0: StaticDOMManagerType) => {
+ *     const canvas = new StaticCanvas(arg0);
+ *     ...
+ *     return canvas; // return for cleanup
+ *   });
+ *   <CanvasComponent create={createStatic}>
+ *     <CanvasSlot name="main" />
+ *   </CanvasComponent>
+ */
+export const CanvasComponent = ({
+  create,
+  children,
+}: React.PropsWithChildren<{
+  create: (arg0: StaticDOMManagerType | DOMManagerType) => StaticCanvas;
+}>) => {
+  const canvasRefs = useMemo(
+    () =>
+      React.Children.toArray(children).reduce((refs, child) => {
+        typeof child === 'object' &&
+          (child as React.ReactElement).type === CanvasSlot &&
+          (refs[(child as React.ReactElement).props.name] =
+            createRef<HTMLCanvasElement>());
+
+        return refs;
+      }, {} as Record<string, React.RefObject<HTMLCanvasElement>>),
+    [children]
+  );
+
+  useEffect(() => {
+    // it is crucial `create` is a dependency of this effect
+    // to ensure the canvas is disposed and re-created if it changes
+    const canvas = create(
+      new DOMManager(
+        Object.fromEntries(
+          Object.entries(canvasRefs).map(([key, ref]) => [key, ref.current])
+        )
+      )
+    );
+
+    return () => {
+      // `dispose` is async
+      // however it runs a sync DOM cleanup
+      // its async part ensures rendering has completed
+      // and should not affect react
+      canvas.dispose();
+    };
+  }, [canvasRefs, create]);
+
+  return React.Children.map(children, (child) =>
+    typeof child === 'object' &&
+    (child as React.ReactElement).type === CanvasSlot ? (
+      <canvas
+        style={canvasStyle}
+        ref={canvasRefs[(child as React.ReactElement).props.name]}
+      />
+    ) : (
+      child
+    )
+  );
+};

--- a/.codesandbox/templates/next/components/index.tsx
+++ b/.codesandbox/templates/next/components/index.tsx
@@ -18,9 +18,10 @@ const canvasStyle: React.CSSProperties = {
   userSelect: 'none',
 };
 
-export const CanvasSlot = ({ name }: { name: 'main' | 'top' | string }) => (
-  <div name={name} />
-);
+export const CanvasSlot = forwardRef<
+  HTMLCanvasElement,
+  { name: 'main' | 'top' | string }
+>((props, ref) => <canvas {...props} ref={ref} />);
 
 /**
  * @example Standard
@@ -80,6 +81,7 @@ export const CanvasComponent = forwardRef<
         )
       )
     );
+
     if (typeof ref === 'function') {
       ref(canvas);
     } else if (typeof ref === 'object' && ref) {
@@ -107,12 +109,10 @@ export const CanvasComponent = forwardRef<
       (child as React.ReactElement).type === CanvasSlot
     ) {
       const { name } = (child as React.ReactElement).props;
-      return (
-        <canvas
-          style={name === 'main' ? undefined : canvasStyle}
-          ref={canvasRefs[name]}
-        />
-      );
+      return React.cloneElement(child as React.ReactElement, {
+        style: name === 'main' ? undefined : canvasStyle,
+        ref: canvasRefs[name],
+      });
     } else {
       return child;
     }

--- a/.codesandbox/templates/next/components/index.tsx
+++ b/.codesandbox/templates/next/components/index.tsx
@@ -1,8 +1,11 @@
-import React, { createRef, useEffect, useMemo } from 'react';
+import React, { createRef, useEffect, useMemo, forwardRef } from 'react';
 import {
+  Canvas,
+  CanvasOptions,
   DOMManager,
   DOMManagerType,
   StaticCanvas,
+  StaticCanvasOptions,
   StaticDOMManagerType,
 } from 'fabric';
 
@@ -21,19 +24,14 @@ export const CanvasSlot = ({ name }: { name: 'main' | 'top' | string }) => (
 
 /**
  * @example Standard
- *   const create = useCallback((arg0: DOMManagerType) => {
- *     const canvas = new Canvas(arg0);
- *     ...
- *     return canvas; // return for cleanup
- *   });
  *
- *   <CanvasComponent create={create}>
+ *   <CanvasComponent ref={ref}>
  *     <CanvasSlot name="main" />
  *     <CanvasSlot name="top" />
  *   </CanvasComponent>
  *
  * @example DOM elements in between
- *   <CanvasComponent create={create}>
+ *   <CanvasComponent ref={ref}>
  *     <CanvasSlot name="main" />
  *     <CanvasSlot name="pointers" />
  *     Hello World
@@ -42,20 +40,23 @@ export const CanvasSlot = ({ name }: { name: 'main' | 'top' | string }) => (
  *
  * @example Static
  *   const createStatic = useCallback((arg0: StaticDOMManagerType) => {
- *     const canvas = new StaticCanvas(arg0);
- *     ...
- *     return canvas; // return for cleanup
+ *     return new StaticCanvas(arg0);
  *   });
- *   <CanvasComponent create={createStatic}>
+ *   <CanvasComponent builder={createStatic} ref={ref}>
  *     <CanvasSlot name="main" />
  *   </CanvasComponent>
  */
-export const CanvasComponent = ({
-  create,
-  children,
-}: React.PropsWithChildren<{
-  create: (arg0: StaticDOMManagerType | DOMManagerType) => StaticCanvas;
-}>) => {
+export const CanvasComponent = forwardRef<
+  Canvas | StaticCanvas,
+  React.PropsWithChildren<{
+    builder?:
+      | ((
+          arg0: StaticDOMManagerType,
+          options?: StaticCanvasOptions
+        ) => StaticCanvas)
+      | ((arg0: DOMManagerType, options?: CanvasOptions) => Canvas);
+  }>
+>(({ children, builder = (arg0: DOMManagerType) => new Canvas(arg0) }, ref) => {
   const canvasRefs = useMemo(
     () =>
       React.Children.toArray(children).reduce((refs, child) => {
@@ -72,13 +73,18 @@ export const CanvasComponent = ({
   useEffect(() => {
     // it is crucial `create` is a dependency of this effect
     // to ensure the canvas is disposed and re-created if it changes
-    const canvas = create(
+    const canvas = builder(
       new DOMManager(
         Object.fromEntries(
           Object.entries(canvasRefs).map(([key, ref]) => [key, ref.current])
         )
       )
     );
+    if (typeof ref === 'function') {
+      ref(canvas);
+    } else if (typeof ref === 'object' && ref) {
+      ref.current = canvas;
+    }
 
     return () => {
       // `dispose` is async
@@ -86,8 +92,14 @@ export const CanvasComponent = ({
       // its async part ensures rendering has completed
       // and should not affect react
       canvas.dispose();
+
+      if (typeof ref === 'function') {
+        ref(null);
+      } else if (typeof ref === 'object' && ref) {
+        ref.current = null;
+      }
     };
-  }, [canvasRefs, create]);
+  }, [canvasRefs, builder, ref]);
 
   return React.Children.map(children, (child) => {
     if (
@@ -105,4 +117,4 @@ export const CanvasComponent = ({
       return child;
     }
   });
-};
+});

--- a/.codesandbox/templates/next/pages/index.tsx
+++ b/.codesandbox/templates/next/pages/index.tsx
@@ -51,13 +51,19 @@ const IndexPage: NextPage = () => {
   }, []);
 
   return (
-    <div className="position-relative">
+    <div style={{ position: 'relative' }}>
       <CanvasComponent create={create}>
         <CanvasSlot name="main" />
         <CanvasSlot name="pointers" />
+        <iframe
+          src="https://fabricjs.github.io/"
+          width="100%"
+          height="500px"
+          style={{ position: 'absolute', left: 0, top: 0, opacity: 0.8 }}
+        />
         Hello World
         {/* keep on top */}
-        {/* <CanvasSlot name="top" /> */}
+        <CanvasSlot name="top" />
       </CanvasComponent>
     </div>
   );

--- a/.codesandbox/templates/next/pages/index.tsx
+++ b/.codesandbox/templates/next/pages/index.tsx
@@ -58,7 +58,7 @@ const IndexPage: NextPage = () => {
         <iframe
           src="https://fabricjs.github.io/"
           width="100%"
-          height="500px"
+          height="100%"
           style={{ position: 'absolute', left: 0, top: 0, opacity: 0.8 }}
         />
         Hello World

--- a/.codesandbox/templates/next/pages/index.tsx
+++ b/.codesandbox/templates/next/pages/index.tsx
@@ -1,15 +1,16 @@
 import * as fabric from 'fabric';
 import { NextPage } from 'next';
-import { useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import { CanvasComponent, CanvasSlot } from '../components';
 
 const IndexPage: NextPage = () => {
-  const create = useCallback((arg0: fabric.DOMManagerType) => {
-    const canvas = (window.canvas = new fabric.Canvas(arg0));
-    canvas.setDimensions({
-      width: window.innerWidth,
-      height: 500,
-    });
+  const ref = useRef<fabric.Canvas>(null);
+  // const [canvas, setCanvas] = useState<fabric.Canvas | null>(null);
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) {
+      return;
+    }
     const textValue = 'fabric.js sandbox';
     const text = new fabric.Textbox(textValue, {
       originX: 'center',
@@ -46,13 +47,15 @@ const IndexPage: NextPage = () => {
       );
     };
     animate(1);
-
-    return canvas;
   }, []);
 
+  // useResize(ref, { fillParent: true });
+
   return (
-    <div style={{ position: 'relative' }}>
-      <CanvasComponent create={create}>
+    <div
+      style={{ position: 'relative', margin: 0, padding: 0, borderWidth: 0 }}
+    >
+      <CanvasComponent ref={ref}>
         <CanvasSlot name="main" />
         <CanvasSlot name="pointers" />
         <iframe

--- a/.codesandbox/templates/next/pages/index.tsx
+++ b/.codesandbox/templates/next/pages/index.tsx
@@ -1,60 +1,64 @@
 import * as fabric from 'fabric';
 import { NextPage } from 'next';
-import { useRef, useCallback } from 'react';
-import { Canvas } from '../components/Canvas';
+import { useCallback } from 'react';
+import { CanvasComponent, CanvasSlot } from '../components';
 
 const IndexPage: NextPage = () => {
-  const ref = useRef<fabric.Canvas>(null);
-
-  const onLoad = useCallback(
-    (canvas: fabric.Canvas) => {
-      canvas.setDimensions({
-        width: window.innerWidth,
-        height: 500,
-      });
-      const textValue = 'fabric.js sandbox';
-      const text = new fabric.Textbox(textValue, {
-        originX: 'center',
-        top: 20,
-        textAlign: 'center',
-        styles: fabric.util.stylesFromArray(
-          [
-            {
-              style: {
-                fontWeight: 'bold',
-                fontSize: 64,
-              },
-              start: 0,
-              end: 9,
-            },
-          ],
-          textValue
-        ),
-      });
-      canvas.add(text);
-      canvas.centerObjectH(text);
-
-      const animate = (toState: number) => {
-        text.animate(
-          { scaleX: Math.max(toState, 0.1) * 2 },
+  const create = useCallback((arg0: fabric.DOMManagerType) => {
+    const canvas = (window.canvas = new fabric.Canvas(arg0));
+    canvas.setDimensions({
+      width: window.innerWidth,
+      height: 500,
+    });
+    const textValue = 'fabric.js sandbox';
+    const text = new fabric.Textbox(textValue, {
+      originX: 'center',
+      top: 20,
+      textAlign: 'center',
+      styles: fabric.util.stylesFromArray(
+        [
           {
-            onChange: () => canvas.renderAll(),
-            onComplete: () => animate(Number(!toState)),
-            duration: 1000,
-            easing: toState
-              ? fabric.util.ease.easeInOutQuad
-              : fabric.util.ease.easeInOutSine,
-          }
-        );
-      };
-      animate(1);
-    },
-    [ref]
-  );
+            style: {
+              fontWeight: 'bold',
+              fontSize: 64,
+            },
+            start: 0,
+            end: 9,
+          },
+        ],
+        textValue
+      ),
+    });
+    canvas.add(text);
+    canvas.centerObjectH(text);
+
+    const animate = (toState: number) => {
+      text.animate(
+        { scaleX: Math.max(toState, 0.1) * 2 },
+        {
+          onChange: () => canvas.renderAll(),
+          onComplete: () => animate(Number(!toState)),
+          duration: 1000,
+          easing: toState
+            ? fabric.util.ease.easeInOutQuad
+            : fabric.util.ease.easeInOutSine,
+        }
+      );
+    };
+    animate(1);
+
+    return canvas;
+  }, []);
 
   return (
     <div className="position-relative">
-      <Canvas ref={ref} onLoad={onLoad} />
+      <CanvasComponent create={create}>
+        <CanvasSlot name="main" />
+        <CanvasSlot name="pointers" />
+        Hello World
+        {/* keep on top */}
+        {/* <CanvasSlot name="top" /> */}
+      </CanvasComponent>
     </div>
   );
 };

--- a/.codesandbox/templates/next/pages/index.tsx
+++ b/.codesandbox/templates/next/pages/index.tsx
@@ -1,16 +1,22 @@
 import * as fabric from 'fabric';
 import { NextPage } from 'next';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { CanvasComponent, CanvasSlot } from '../components';
+import { useResize } from '../components/hooks';
 
 const IndexPage: NextPage = () => {
   const ref = useRef<fabric.Canvas>(null);
-  // const [canvas, setCanvas] = useState<fabric.Canvas | null>(null);
+  const [canvas, setCanvas] = useState<fabric.Canvas | null>(null);
+
+  useResize(ref);
+
   useEffect(() => {
     const canvas = ref.current;
+    // setCanvas(canvas);
     if (!canvas) {
       return;
     }
+
     const textValue = 'fabric.js sandbox';
     const text = new fabric.Textbox(textValue, {
       originX: 'center',
@@ -48,8 +54,6 @@ const IndexPage: NextPage = () => {
     };
     animate(1);
   }, []);
-
-  // useResize(ref, { fillParent: true });
 
   return (
     <div

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
 
 - perf(): measuring canvas size [#9697](https://github.com/fabricjs/fabric.js/pull/9697)
+- **BREAKING BETA** refactor(DOMManager): abstract to avoid DOM mutation
 - chore(TS): Add type for options in toCanvasElement and toDataUrl [#9673](https://github.com/fabricjs/fabric.js/pull/9673)
 - ci(): add source map support to node sandbox [#9686](https://github.com/fabricjs/fabric.js/pull/9686)
 - fix(Canvas): Correct type mainTouchId initialization [#9684](https://github.com/fabricjs/fabric.js/pull/9684)

--- a/e2e/site/index.html
+++ b/e2e/site/index.html
@@ -14,6 +14,8 @@
     </style>
   </head>
   <body>
-    <canvas id="canvas" width="800" height="600"></canvas>
+    <div style="display: flex">
+      <canvas id="canvas" width="800" height="600"></canvas>
+    </div>
   </body>
 </html>

--- a/e2e/tests/template/index.html
+++ b/e2e/tests/template/index.html
@@ -1,6 +1,9 @@
-<!-- 
+<!--
     This file overrides the `body` of the test app as defined in `e2e/site/index.html`.
     Add it only if there is a need to change `body`
  -->
 
-<canvas id="canvas" width="800" height="600"></canvas>
+<div style="display: flex">
+  <canvas id="canvas" width="800" height="600"></canvas>
+</div>
+`

--- a/e2e/tests/text/drag&drop/index.html
+++ b/e2e/tests/text/drag&drop/index.html
@@ -1,2 +1,4 @@
-<canvas id="canvas" width="800" height="600"></canvas>
+<div style="display: flex">
+  <canvas id="canvas" width="800" height="600"></canvas>
+</div>
 <textarea id="textarea" rows="5"></textarea>

--- a/fabric.ts
+++ b/fabric.ts
@@ -18,8 +18,11 @@ export type { StaticCanvasOptions } from './src/canvas/StaticCanvasOptions';
 export { StaticCanvas } from './src/canvas/StaticCanvas';
 export { Canvas } from './src/canvas/Canvas';
 export type { CanvasOptions } from './src/canvas/CanvasOptions';
-export { CanvasDOMManager } from './src/canvas/DOMManagers/CanvasDOMManager';
-export { StaticCanvasDOMManager } from './src/canvas/DOMManagers/StaticCanvasDOMManager';
+export {
+  DOMManager,
+  type DOMManagerType,
+  type StaticDOMManagerType,
+} from './src/canvas/DOMManagers/DOMManager';
 
 export type { XY } from './src/Point';
 export { Point } from './src/Point';

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -18,7 +18,7 @@ import { getDocumentFromElement, getWindowFromElement } from '../util/dom_misc';
 import { sendPointToPlane } from '../util/misc/planeChange';
 import { isActiveSelection } from '../util/typeAssertions';
 import type { CanvasOptions, TCanvasOptions } from './CanvasOptions';
-import { DOMManagerType } from './DOMManagers/DOMManager';
+import type { DOMManagerType } from './DOMManagers/DOMManager';
 import { SelectableCanvas } from './SelectableCanvas';
 import { TextEditingManager } from './TextEditingManager';
 

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -18,6 +18,7 @@ import { getDocumentFromElement, getWindowFromElement } from '../util/dom_misc';
 import { sendPointToPlane } from '../util/misc/planeChange';
 import { isActiveSelection } from '../util/typeAssertions';
 import type { CanvasOptions, TCanvasOptions } from './CanvasOptions';
+import { DOMManagerType } from './DOMManagers/DOMManager';
 import { SelectableCanvas } from './SelectableCanvas';
 import { TextEditingManager } from './TextEditingManager';
 
@@ -114,8 +115,13 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
 
   textEditingManager = new TextEditingManager(this);
 
-  constructor(el?: string | HTMLCanvasElement, options: TCanvasOptions = {}) {
-    super(el, options);
+  constructor(
+    arg0?: string | HTMLCanvasElement | DOMManagerType,
+    options: TCanvasOptions = {}
+  ) {
+    super(arg0, options);
+    // enable drag and drop
+    this.elements.items.top.el.setAttribute('draggable', 'true');
     // bind event handlers
     (
       [

--- a/src/canvas/DOMManagers/CanvasDOMManager.ts
+++ b/src/canvas/DOMManagers/CanvasDOMManager.ts
@@ -1,21 +1,23 @@
-import { getEnv, getFabricDocument } from '../../env';
+import { getFabricDocument } from '../../env';
 import type { TSize } from '../../typedefs';
 import { createCanvasElement, setStyle } from '../../util';
-import type { CSSDimensions } from './util';
-import {
-  allowTouchScrolling,
-  makeElementUnselectable,
-  setCSSDimensions,
-} from './util';
-import type { CanvasItem } from './StaticCanvasDOMManager';
+import { allowTouchScrolling, makeElementUnselectable } from './util';
 import { StaticCanvasDOMManager } from './StaticCanvasDOMManager';
-import { setCanvasDimensions } from './util';
 
-export class CanvasDOMManager extends StaticCanvasDOMManager {
-  upper: CanvasItem;
-  container: HTMLDivElement;
+export class CanvasDOMManager extends StaticCanvasDOMManager<{
+  main: HTMLCanvasElement;
+  top: HTMLCanvasElement;
+}> {
+  declare readonly container: HTMLDivElement;
 
-  constructor(
+  /**
+   * Keeps a copy of the canvas style before setting retina scaling and other potions
+   * in order to return it to original state on dispose
+   * @type string
+   */
+  private _originalCanvasStyle?: string;
+
+  static build(
     arg0?: string | HTMLCanvasElement,
     {
       allowTouchScrolling = false,
@@ -28,27 +30,33 @@ export class CanvasDOMManager extends StaticCanvasDOMManager {
       containerClass?: string;
     } = {}
   ) {
-    super(arg0);
-    const { el: lowerCanvasEl } = this.lower;
-    const upperCanvasEl = this.createUpperCanvas();
-    this.upper = { el: upperCanvasEl, ctx: upperCanvasEl.getContext('2d')! };
+    const lowerCanvasEl = this.createLowerCanvas(arg0);
+    const style = lowerCanvasEl.style.cssText;
+    const upperCanvasEl = this.createUpperCanvas(lowerCanvasEl);
+
     this.applyCanvasStyle(lowerCanvasEl, {
       allowTouchScrolling,
     });
     this.applyCanvasStyle(upperCanvasEl, {
       allowTouchScrolling,
     });
+
     const container = this.createContainerElement();
     container.classList.add(containerClass);
     if (lowerCanvasEl.parentNode) {
       lowerCanvasEl.parentNode.replaceChild(container, lowerCanvasEl);
     }
     container.append(lowerCanvasEl, upperCanvasEl);
-    this.container = container;
+
+    const manager = new this(
+      { main: lowerCanvasEl, top: upperCanvasEl },
+      container
+    );
+    manager._originalCanvasStyle = style;
+    return manager;
   }
 
-  protected createUpperCanvas() {
-    const { el: lowerCanvasEl } = this.lower;
+  static createUpperCanvas(lowerCanvasEl: HTMLCanvasElement) {
     const el = createCanvasElement();
     // we assign the same classname of the lowerCanvas
     el.className = lowerCanvasEl.className;
@@ -58,11 +66,10 @@ export class CanvasDOMManager extends StaticCanvasDOMManager {
     el.classList.add('upper-canvas');
     el.setAttribute('data-fabric', 'top');
     el.style.cssText = lowerCanvasEl.style.cssText;
-    el.setAttribute('draggable', 'true');
     return el;
   }
 
-  protected createContainerElement() {
+  static createContainerElement() {
     const container = getFabricDocument().createElement('div');
     container.setAttribute('data-fabric', 'wrapper');
     setStyle(container, {
@@ -76,7 +83,7 @@ export class CanvasDOMManager extends StaticCanvasDOMManager {
    * @private
    * @param {HTMLCanvasElement} element canvas element to apply styles on
    */
-  protected applyCanvasStyle(
+  static applyCanvasStyle(
     element: HTMLCanvasElement,
     { allowTouchScrolling: allow }: { allowTouchScrolling: boolean }
   ) {
@@ -89,36 +96,20 @@ export class CanvasDOMManager extends StaticCanvasDOMManager {
     makeElementUnselectable(element);
   }
 
-  setDimensions(size: TSize, retinaScaling: number) {
-    super.setDimensions(size, retinaScaling);
-    const { el, ctx } = this.upper;
-    setCanvasDimensions(el, ctx, size, retinaScaling);
-  }
-
-  setCSSDimensions(size: Partial<CSSDimensions>): void {
-    super.setCSSDimensions(size);
-    setCSSDimensions(this.upper.el, size);
-    setCSSDimensions(this.container, size);
-  }
-
   cleanupDOM(size: TSize) {
     const container = this.container,
-      { el: lowerCanvasEl } = this.lower,
-      { el: upperCanvasEl } = this.upper;
+      {
+        main: { el: lowerCanvasEl },
+        top: { el: upperCanvasEl },
+      } = this.items;
+
     super.cleanupDOM(size);
     container.removeChild(upperCanvasEl);
     container.removeChild(lowerCanvasEl);
     if (container.parentNode) {
       container.parentNode.replaceChild(lowerCanvasEl, container);
     }
-  }
-
-  dispose() {
-    super.dispose();
-    getEnv().dispose(this.upper.el);
-    // @ts-expect-error disposing
-    delete this.upper;
-    // @ts-expect-error disposing
-    delete this.container;
+    lowerCanvasEl.style.cssText = this._originalCanvasStyle || '';
+    delete this._originalCanvasStyle;
   }
 }

--- a/src/canvas/DOMManagers/DOMManager.ts
+++ b/src/canvas/DOMManagers/DOMManager.ts
@@ -1,0 +1,79 @@
+import { getEnv } from '../../env';
+import { TSize } from '../../typedefs';
+import {
+  CSSDimensions,
+  getElementOffset,
+  setCSSDimensions,
+  setCanvasDimensions,
+} from './util';
+
+export type CanvasItem = {
+  el: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+};
+
+export type ItemMap<T = HTMLCanvasElement> =
+  | {
+      main: T;
+      [x: string]: T;
+    }
+  | {
+      main: T;
+      top: T;
+      [x: string]: T;
+    };
+
+export type StaticDOMManagerType = DOMManager<{
+  main: HTMLCanvasElement;
+  [x: string]: HTMLCanvasElement;
+}>;
+export type DOMManagerType = DOMManager<{
+  main: HTMLCanvasElement;
+  top: HTMLCanvasElement;
+  [x: string]: HTMLCanvasElement;
+}>;
+
+export class DOMManager<T extends ItemMap> {
+  readonly items: Record<keyof T, CanvasItem>;
+  readonly container?: HTMLDivElement;
+
+  constructor(items: T, container?: HTMLDivElement) {
+    this.items = Object.fromEntries(
+      Object.entries(items).map(([key, canvas]) => [
+        key,
+        { el: canvas, ctx: canvas.getContext('2d')! },
+      ])
+    ) as Record<keyof T, CanvasItem>;
+    this.container = container;
+  }
+
+  setDimensions(size: TSize, retinaScaling: number) {
+    Object.values(this.items).forEach(({ el, ctx }) =>
+      setCanvasDimensions(el, ctx, size, retinaScaling)
+    );
+  }
+
+  setCSSDimensions(size: Partial<CSSDimensions>) {
+    Object.values(this.items).forEach(({ el }) => setCSSDimensions(el, size));
+    this.container && setCSSDimensions(this.container, size);
+  }
+
+  /**
+   * Calculates canvas element offset relative to the document
+   */
+  calcOffset() {
+    return getElementOffset(this.items.main.el);
+  }
+
+  cleanupDOM(size: TSize) {}
+
+  dispose() {
+    Object.values(this.items).forEach(({ el }) => {
+      getEnv().dispose(el);
+    });
+    // @ts-expect-error disposing
+    this.items = {};
+    // @ts-expect-error disposing
+    delete this.container;
+  }
+}

--- a/src/canvas/DOMManagers/DOMManager.ts
+++ b/src/canvas/DOMManagers/DOMManager.ts
@@ -1,7 +1,7 @@
 import { getEnv } from '../../env';
-import { TSize } from '../../typedefs';
+import type { TSize } from '../../typedefs';
+import type { CSSDimensions } from './util';
 import {
-  CSSDimensions,
   getElementOffset,
   setCSSDimensions,
   setCanvasDimensions,
@@ -62,7 +62,9 @@ export class DOMManager<T extends ItemMap> {
     return getElementOffset(this.items.main.el);
   }
 
-  cleanupDOM(size: TSize) {}
+  cleanupDOM(size: TSize) {
+    // exposed for subclasses
+  }
 
   dispose() {
     Object.values(this.items).forEach(({ el }) => {

--- a/src/canvas/DOMManagers/DOMManager.ts
+++ b/src/canvas/DOMManagers/DOMManager.ts
@@ -35,16 +35,14 @@ export type DOMManagerType = DOMManager<{
 
 export class DOMManager<T extends ItemMap> {
   readonly items: Record<keyof T, CanvasItem>;
-  readonly container?: HTMLDivElement;
 
-  constructor(items: T, container?: HTMLDivElement) {
+  constructor(items: T) {
     this.items = Object.fromEntries(
       Object.entries(items).map(([key, canvas]) => [
         key,
         { el: canvas, ctx: canvas.getContext('2d')! },
       ])
     ) as Record<keyof T, CanvasItem>;
-    this.container = container;
   }
 
   setDimensions(size: TSize, retinaScaling: number) {
@@ -55,7 +53,6 @@ export class DOMManager<T extends ItemMap> {
 
   setCSSDimensions(size: Partial<CSSDimensions>) {
     Object.values(this.items).forEach(({ el }) => setCSSDimensions(el, size));
-    this.container && setCSSDimensions(this.container, size);
   }
 
   /**
@@ -73,7 +70,5 @@ export class DOMManager<T extends ItemMap> {
     });
     // @ts-expect-error disposing
     this.items = {};
-    // @ts-expect-error disposing
-    delete this.container;
   }
 }

--- a/src/canvas/DOMManagers/StaticCanvasDOMManager.ts
+++ b/src/canvas/DOMManagers/StaticCanvasDOMManager.ts
@@ -2,7 +2,8 @@ import { getFabricDocument } from '../../env';
 import type { TSize } from '../../typedefs';
 import { FabricError } from '../../util/internals/console';
 import { createCanvasElement, isHTMLCanvas } from '../../util/misc/dom';
-import { ItemMap, DOMManager } from './DOMManager';
+import type { ItemMap } from './DOMManager';
+import { DOMManager } from './DOMManager';
 
 export class StaticCanvasDOMManager<
   T extends ItemMap = {

--- a/src/canvas/DOMManagers/StaticCanvasDOMManager.ts
+++ b/src/canvas/DOMManagers/StaticCanvasDOMManager.ts
@@ -1,32 +1,19 @@
-import { getEnv, getFabricDocument } from '../../env';
+import { getFabricDocument } from '../../env';
 import type { TSize } from '../../typedefs';
-import type { CSSDimensions } from './util';
-import { setCSSDimensions, getElementOffset } from './util';
-import { createCanvasElement, isHTMLCanvas } from '../../util/misc/dom';
-import { setCanvasDimensions } from './util';
 import { FabricError } from '../../util/internals/console';
+import { createCanvasElement, isHTMLCanvas } from '../../util/misc/dom';
+import { ItemMap, DOMManager } from './DOMManager';
 
-export type CanvasItem = {
-  el: HTMLCanvasElement;
-  ctx: CanvasRenderingContext2D;
-};
-
-export class StaticCanvasDOMManager {
-  /**
-   * Keeps a copy of the canvas style before setting retina scaling and other potions
-   * in order to return it to original state on dispose
-   * @type string
-   */
-  private _originalCanvasStyle?: string;
-
-  lower: CanvasItem;
-
-  constructor(arg0?: string | HTMLCanvasElement) {
-    const el = this.createLowerCanvas(arg0);
-    this.lower = { el, ctx: el.getContext('2d')! };
+export class StaticCanvasDOMManager<
+  T extends ItemMap = {
+    main: HTMLCanvasElement;
+  }
+> extends DOMManager<T> {
+  static build(arg0?: string | HTMLCanvasElement) {
+    return new this({ main: this.createLowerCanvas(arg0) });
   }
 
-  protected createLowerCanvas(arg0?: HTMLCanvasElement | string) {
+  static createLowerCanvas(arg0?: HTMLCanvasElement | string) {
     // canvasEl === 'HTMLCanvasElement' does not work on jsdom/node
     const el = isHTMLCanvas(arg0)
       ? arg0
@@ -38,43 +25,19 @@ export class StaticCanvasDOMManager {
         'Trying to initialize a canvas that has already been initialized. Did you forget to dispose the canvas?'
       );
     }
-    this._originalCanvasStyle = el.style.cssText;
     el.setAttribute('data-fabric', 'main');
     el.classList.add('lower-canvas');
     return el;
   }
 
-  cleanupDOM({ width, height }: TSize) {
-    const { el } = this.lower;
+  cleanupDOM(size: TSize) {
+    const { el } = this.items.main;
+    super.cleanupDOM(size);
     // restore canvas style and attributes
     el.classList.remove('lower-canvas');
     el.removeAttribute('data-fabric');
     // restore canvas size to original size in case retina scaling was applied
-    el.setAttribute('width', `${width}`);
-    el.setAttribute('height', `${height}`);
-    el.style.cssText = this._originalCanvasStyle || '';
-    this._originalCanvasStyle = undefined;
-  }
-
-  setDimensions(size: TSize, retinaScaling: number) {
-    const { el, ctx } = this.lower;
-    setCanvasDimensions(el, ctx, size, retinaScaling);
-  }
-
-  setCSSDimensions(size: Partial<CSSDimensions>) {
-    setCSSDimensions(this.lower.el, size);
-  }
-
-  /**
-   * Calculates canvas element offset relative to the document
-   */
-  calcOffset() {
-    return getElementOffset(this.lower.el);
-  }
-
-  dispose() {
-    getEnv().dispose(this.lower.el);
-    // @ts-expect-error disposing
-    delete this.lower;
+    el.setAttribute('width', `${size.width}`);
+    el.setAttribute('height', `${size.height}`);
   }
 }

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -286,9 +286,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
   get contextTop() {
     return this.elements.items.top?.ctx;
   }
-  get wrapperEl() {
-    return this.elements.container;
-  }
+
   private declare pixelFindCanvasEl: HTMLCanvasElement;
   private declare pixelFindContext: CanvasRenderingContext2D;
 

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -37,7 +37,8 @@ import type { CanvasOptions } from './CanvasOptions';
 import { canvasDefaults } from './CanvasOptions';
 import { Intersection } from '../Intersection';
 import { isActiveSelection } from '../util/typeAssertions';
-import { DOMManager, DOMManagerType } from './DOMManagers/DOMManager';
+import type { DOMManagerType } from './DOMManagers/DOMManager';
+import { DOMManager } from './DOMManagers/DOMManager';
 import { FabricError } from '../util/internals/console';
 
 /**

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -44,7 +44,8 @@ import type { StaticCanvasOptions } from './StaticCanvasOptions';
 import { staticCanvasDefaults } from './StaticCanvasOptions';
 import { log, FabricError } from '../util/internals/console';
 import { getDevicePixelRatio } from '../env';
-import { DOMManager, StaticDOMManagerType } from './DOMManagers/DOMManager';
+import type { StaticDOMManagerType } from './DOMManagers/DOMManager';
+import { DOMManager } from './DOMManagers/DOMManager';
 
 /**
  * Having both options in TCanvasSizeOptions set to true transform the call in a calcOffset

--- a/src/canvas/__tests__/__snapshots__/eventData.test.ts.snap
+++ b/src/canvas/__tests__/__snapshots__/eventData.test.ts.snap
@@ -175,7 +175,7 @@ exports[`Canvas event data HTML event "dragend" should fire a corresponding canv
           data-fabric="top"
           draggable="true"
           height="150"
-          style="position: absolute; left: 0px; top: 0px; user-select: none; width: 300px; height: 150px; cursor: move;"
+          style="user-select: none; position: absolute; left: 0px; top: 0px; width: 300px; height: 150px; cursor: move;"
           width="300"
         />,
         "createPattern": [Function],

--- a/src/filters/typedefs.ts
+++ b/src/filters/typedefs.ts
@@ -56,5 +56,3 @@ export type TWebGLProgramCacheItem = {
   attributeLocations: TWebGLAttributeLocationMap;
   uniformLocations: TWebGLUniformLocationMap;
 };
-
-export type TApplyFilterArgs = {};

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -119,8 +119,8 @@
     doc.body.appendChild(wrapper);
     const canvas = new fabric.Canvas(canvasEl);
     assert.equal(wrapper.firstChild, canvas.elements.container, 'replaced canvas el in dom');
-    assert.equal(canvas.elements.container.firstChild, canvas.elements.lower.el, 'appended canvas el to container');
-    assert.equal(canvas.elements.container.lastChild, canvas.elements.upper.el, 'appended upper canvas el to container');
+    assert.equal(canvas.elements.container.firstChild, canvas.elements.main.el, 'appended canvas el to container');
+    assert.equal(canvas.elements.container.lastChild, canvas.elements.top.el, 'appended upper canvas el to container');
   });
 
 

--- a/test/unit/canvas.js
+++ b/test/unit/canvas.js
@@ -118,9 +118,9 @@
     wrapper.appendChild(canvasEl);
     doc.body.appendChild(wrapper);
     const canvas = new fabric.Canvas(canvasEl);
-    assert.equal(wrapper.firstChild, canvas.elements.container, 'replaced canvas el in dom');
-    assert.equal(canvas.elements.container.firstChild, canvas.elements.main.el, 'appended canvas el to container');
-    assert.equal(canvas.elements.container.lastChild, canvas.elements.top.el, 'appended upper canvas el to container');
+    assert.equal(wrapper.firstChild.tagName, 'DIV', 'replaced canvas el in dom');
+    assert.equal(wrapper.firstChild.firstChild, canvas.elements.items.main.el, 'appended canvas el to container');
+    assert.equal(wrapper.firstChild.lastChild, canvas.elements.items.top.el, 'appended upper canvas el to container');
   });
 
 
@@ -191,7 +191,7 @@
   QUnit.test('init', function(assert) {
     assert.equal(canvas.lowerCanvasEl.getAttribute('data-fabric'), 'main', 'el should be marked by canvas init');
     assert.equal(canvas.upperCanvasEl.getAttribute('data-fabric'), 'top', 'el should be marked by canvas init');
-    assert.equal(canvas.wrapperEl.getAttribute('data-fabric'), 'wrapper', 'el should be marked by canvas init');
+    assert.equal(canvas.lowerCanvasEl.parentElement.getAttribute('data-fabric'), 'wrapper', 'el should be marked by canvas init');
   });
 
   QUnit.test('renderTop', function(assert) {
@@ -1595,7 +1595,6 @@
 
     assert.equal(canvas.lowerCanvasEl.style.width, '100%', 'Should be as the css only value');
     assert.equal(canvas.upperCanvasEl.style.width, '100%', 'Should be as the css only value');
-    assert.equal(canvas.wrapperEl.style.width, '100%', 'Should be as the css only value');
     assert.equal(canvas.getWidth(), 123, 'Should be as the none css only value');
   });
 
@@ -1605,7 +1604,6 @@
 
     assert.equal(canvas.lowerCanvasEl.style.height, '100%', 'Should be as the css only value');
     assert.equal(canvas.upperCanvasEl.style.height, '100%', 'Should be as the css only value');
-    assert.equal(canvas.wrapperEl.style.height, '100%', 'Should be as the css only value');
     assert.equal(canvas.getHeight(), 123, 'Should be as the none css only value');
   });
 
@@ -1615,7 +1613,6 @@
 
     assert.equal(canvas.lowerCanvasEl.style.width, 123 + 'px', 'Should be as none backstore only value + "px"');
     assert.equal(canvas.upperCanvasEl.style.width, 123 + 'px', 'Should be as none backstore only value + "px"');
-    assert.equal(canvas.wrapperEl.style.width, 123 + 'px', 'Should be as none backstore only value + "px"');
     assert.equal(canvas.getWidth(), 500, 'Should be as the backstore only value');
   });
 
@@ -1625,7 +1622,6 @@
 
     assert.equal(canvas.lowerCanvasEl.style.height, 123 + 'px', 'Should be as none backstore only value + "px"');
     assert.equal(canvas.upperCanvasEl.style.height, 123 + 'px', 'Should be as none backstore only value + "px"');
-    assert.equal(canvas.wrapperEl.style.height, 123 + 'px', 'Should be as none backstore only value + "px"');
     assert.equal(canvas.getHeight(), 500, 'Should be as the backstore only value');
   });
 

--- a/test/unit/canvas_dispose.js
+++ b/test/unit/canvas_dispose.js
@@ -245,9 +245,9 @@ function testCanvasDisposing() {
         assert.equal(elStyle, 'position: relative;', 'el style should not be empty');
 
         var canvas = new fabric.Canvas(el, { enableRetinaScaling: true, renderOnAddRemove: false });
-        wrapperEl = canvas.wrapperEl;
         lowerCanvasEl = canvas.lowerCanvasEl;
         upperCanvasEl = canvas.upperCanvasEl;
+        wrapperEl = lowerCanvasEl.parentElement;
         const activeSel = new fabric.ActiveSelection();
         assert.equal(parentEl.childNodes.length, 1, 'parentEl has still 1 child only');
         assert.equal(wrapperEl.childNodes.length, 2, 'wrapper should have 2 children');
@@ -303,9 +303,9 @@ function testCanvasDisposing() {
         assert.equal(elStyle, 'position: relative;', 'el style should not be empty');
 
         var canvas = new fabric.Canvas(el, { enableRetinaScaling: true, renderOnAddRemove: false });
-        wrapperEl = canvas.wrapperEl;
         lowerCanvasEl = canvas.lowerCanvasEl;
         upperCanvasEl = canvas.upperCanvasEl;
+        wrapperEl = lowerCanvasEl.parentElement;
         const activeSel = new fabric.ActiveSelection();
         canvas.setActiveObject(activeSel)
         assert.equal(parentEl.childNodes.length, 1, 'parentEl has still 1 child only');


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->
#6208 

This PR refactors the DOMManager concept enabling a canvas class to accept a DOMManager instance as the first arg, thus allowing the dev to handle the DOM as they wish with whatever framework they use.
This is a long standing request and it aligns fabric with the big boys. 
The DOM mutation that fabric does is dirty and weird and counter intuitive. However it can remain.

This PR also addresses another pain in the DOMManager API.
It was hard and annoying trying to add another canvas and have it resize etc. with the rest.
Now it is seamless.
In addition it allows the dev to handle the DOM between the 2 canvases as well which is great.

I have removed the absolute positioning of the main canvas. This made resizing the container redundant so I removed that logic and is a lot easier to deal with because the container fits the content and therefore elements inside it can use percent based sizing.


### Gist 
`DOMManager` is the class that holds all the DOM elements the canvas needs but does not mutate the DOM.
`StaticCanvasDOMManager` subclasses it and behaves as before.

Check out the next app changes. I believe the hook should be the official react binding.

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
