### PR TITLE
fix(ActiveSelection): block ancestors/descendants of selected objects from being selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(ActiveSelection): block ancestors/descendants of selected objects from being selected [#9732](https://github.com/fabricjs/fabric.js/pull/9732)
 - fix(Image): typo in style property for svg export [#9717](https://github.com/fabricjs/fabric.js/pull/9717)
 - ci(): Update the changelog and stats action to work from forks
 - fix(Shadow): Cloning a shape with shadow throws an error[#9711](https://github.com/fabricjs/fabric.js/issues/9711)

--- a/src/shapes/ActiveSelection.spec.ts
+++ b/src/shapes/ActiveSelection.spec.ts
@@ -139,4 +139,26 @@ describe('ActiveSelection', () => {
     });
     expect(eventsSpy).toBeCalledTimes(3);
   });
+
+  it('should block descendants from entering selection', () => {
+    const object = new FabricObject();
+    const group = new Group([object]);
+    const activeSelection = new ActiveSelection([group]);
+    const spy = jest.spyOn(activeSelection, 'canEnterGroup');
+    activeSelection.add(object);
+    expect(activeSelection.getObjects()).toEqual([group]);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveNthReturnedWith(1, false);
+  });
+
+  it('should block ancestors from entering selection', () => {
+    const object = new FabricObject();
+    const group = new Group([object]);
+    const activeSelection = new ActiveSelection([object]);
+    const spy = jest.spyOn(activeSelection, 'canEnterGroup');
+    activeSelection.add(group);
+    expect(activeSelection.getObjects()).toEqual([object]);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveNthReturnedWith(1, false);
+  });
 });

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -87,6 +87,18 @@ export class ActiveSelection extends Group {
   }
 
   /**
+   * @override block ancestors/descendants of selected objects from being selected
+   */
+  canEnterGroup(object: FabricObject) {
+    return (
+      super.canEnterGroup(object) &&
+      !this.getObjects().some(
+        (o) => o.isDescendantOf(object) || object.isDescendantOf(o)
+      )
+    );
+  }
+
+  /**
    * Change an object so that it can be part of an active selection.
    * this method is called by multiselectAdd from canvas code.
    * @private

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -8,6 +8,7 @@ import {
   LAYOUT_TYPE_REMOVED,
 } from '../LayoutManager/constants';
 import type { TClassProperties } from '../typedefs';
+import { log } from '../util/internals/console';
 
 export type MultiSelectionStacking = 'canvas-stacking' | 'selection-order';
 
@@ -87,15 +88,23 @@ export class ActiveSelection extends Group {
   }
 
   /**
-   * @override block ancestors/descendants of selected objects from being selected
+   * @override block ancestors/descendants of selected objects from being selected to prevent a circular object tree
    */
   canEnterGroup(object: FabricObject) {
-    return (
-      super.canEnterGroup(object) &&
-      !this.getObjects().some(
+    if (
+      this.getObjects().some(
         (o) => o.isDescendantOf(object) || object.isDescendantOf(o)
       )
-    );
+    ) {
+      //  prevent circular object tree
+      log(
+        'error',
+        'ActiveSelection: circular object trees are not supported, this call has no effect'
+      );
+      return false;
+    }
+
+    return super.canEnterGroup(object);
   }
 
   /**


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

Since ActiveSelection is a special Group and doesn't call `parent.remove` when an object is added there is a case where it is possible to have ancestors and descendants live together in the selection. This is a bug because it breaks the object tree by making it cyclic.
<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
