### PR TITLE
fix(): bubble dirty flag to parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - chore(TS): minor changes to typescript notation to be compatible with a 5.3.3 [#9725](https://github.com/fabricjs/fabric.js/pull/9725)
 - fix(InteractiveObject): "borderOpacityWhenMoving" does not take effect on the child shapes within the group [#9374](https://github.com/fabricjs/fabric.js/issues/9734)
 - fix(SVGParser): Consider the transformMatrix of the clipPath owner as part of the clipPath trasnformation [#9750](https://github.com/fabricjs/fabric.js/pull/9750)
+- fix(): bubble dirty flag to parent [#9741](https://github.com/fabricjs/fabric.js/pull/9741)
 - fix(StaticCanvas): setDimensions not requesting a render if options are not passed [#9710](https://github.com/fabricjs/fabric.js/pull/9710)
 - fix(LayoutManager): wrong bounding box position when activeSelection has originX/originY that are not default left/top [#9649](https://github.com/fabricjs/fabric.js/pull/9649)
 - fix(ActiveSelection): block ancestors/descendants of selected objects from being selected [#9732](https://github.com/fabricjs/fabric.js/pull/9732)

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -454,7 +454,7 @@ export class Group
    * @return {Boolean}
    */
   isOnACache(): boolean {
-    return this.ownCaching || (!!this.group && this.group.isOnACache());
+    return this.ownCaching || (!!this.parent && this.parent.isOnACache());
   }
 
   /**

--- a/src/shapes/Object/Object.spec.ts
+++ b/src/shapes/Object/Object.spec.ts
@@ -131,5 +131,16 @@ describe('Object', () => {
       rect.set('dirty', false);
       expect(group.dirty).toBe(true);
     });
+    it('when dirty is true it bubbles to the parent', () => {
+      const rect = new Rect({ width: 100, height: 100 });
+      rect.group = new Group();
+      rect.parent = new Group();
+      rect.group.dirty = false;
+      rect.parent.dirty = false;
+      rect.dirty = false;
+      rect.set('dirty', true);
+      expect(rect.group.dirty).toBe(false);
+      expect(rect.parent.dirty).toBe(true);
+    });
   });
 });

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -677,18 +677,6 @@
     assert.equal(g1.dirty, true, 'Group has dirty flag set');
   });
 
-  QUnit.test('dirty flag propagation from children up is stopped if group is not caching', function(assert) {
-    var g1 = makeGroupWith4Objects();
-    var obj = g1.item(0);
-    g1.dirty = false;
-    obj.dirty = false;
-    g1.ownCaching = false;
-    assert.equal(g1.dirty, false, 'Group has no dirty flag set');
-    obj.set('fill', 'red');
-    assert.equal(obj.dirty, true, 'Obj has dirty flag set');
-    assert.equal(g1.dirty, false, 'Group has no dirty flag set');
-  });
-
   QUnit.test('dirty flag propagation from children up does not happen if value does not change really', function(assert) {
     var g1 = makeGroupWith4Objects();
     var obj = g1.item(0);

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -1235,29 +1235,29 @@
     object.needsItsOwnCache = function () { return false; };
 
     object.objectCaching = true;
-    object.group = { isOnACache: function() { return true; }};
+    object.parent = { isOnACache: function() { return true; }};
     assert.equal(object.shouldCache(), false, 'if objectCaching is true, but we are in a group, shouldCache returns false');
 
     object.objectCaching = true;
-    object.group = { isOnACache: function() { return false; }};
+    object.parent = { isOnACache: function() { return false; }};
     assert.equal(object.shouldCache(), true, 'if objectCaching is true, but we are in a not cached group, shouldCache returns true');
 
     object.objectCaching = false;
-    object.group = { isOnACache: function() { return false; }};
+    object.parent = { isOnACache: function() { return false; }};
     assert.equal(object.shouldCache(), false, 'if objectCaching is false, but we are in a not cached group, shouldCache returns false');
 
     object.objectCaching = false;
-    object.group = { isOnACache: function() { return true; }};
+    object.parent = { isOnACache: function() { return true; }};
     assert.equal(object.shouldCache(), false, 'if objectCaching is false, but we are in a cached group, shouldCache returns false');
 
     object.needsItsOwnCache = function () { return true; };
 
     object.objectCaching = false;
-    object.group = { isOnACache: function() { return true; }};
+    object.parent = { isOnACache: function() { return true; }};
     assert.equal(object.shouldCache(), true, 'if objectCaching is false, but we have a clipPath, group cached, we cache anyway');
 
     object.objectCaching = false;
-    object.group = { isOnACache: function() { return false; }};
+    object.parent = { isOnACache: function() { return false; }};
     assert.equal(object.shouldCache(), true, 'if objectCaching is false, but we have a clipPath, group not cached, we cache anyway');
 
   });


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

As part of the group rewrite we exposed a `parent` ref on the object #8951 .
As part of the layout manager fixes an invalidation bug surfaced #9651 .
Fabric relays on `Object#_set` to bubble cache invalidation to the **parent**.
I forgot to fix the invalidation logic when I exposed the parent ref so it still invalidated the group ref.
The bug occurs when a nested object is part of an `ActiveSelection`.
In that case the group ref is the active selection and the parent ref is the group.
 `ActiveSelection` does not render anything, therefore it doesn't cache meaning that it is pointless to flag it as dirty as opposed to the parent.
This PR will fix the mentioned bug.
I also changed the bubbling logic to always bubble a dirty flag regardless of caching state.

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
