### PR TITLE
chore(TS): control generic object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(TS): control generic object type [#9770](https://github.com/fabricjs/fabric.js/pull/9770)
 - feat(LayoutManager): Handle the case of activeSelection with objects inside different groups [#9651](https://github.com/fabricjs/fabric.js/pull/9651)
 
 ## [6.0.0-beta20]

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -21,7 +21,7 @@ export type TOptionalModifierKey = ModifierKey | null | undefined;
 
 export type TPointerEvent = MouseEvent | TouchEvent | PointerEvent;
 
-export type TransformAction<T extends Transform = Transform, R = void> = (
+export type TransformAction<T extends Transform<any> = Transform, R = void> = (
   eventData: TPointerEvent,
   transform: T,
   x: number,
@@ -32,14 +32,17 @@ export type TransformAction<T extends Transform = Transform, R = void> = (
  * Control handlers that define a transformation
  * Those handlers run when the user starts a transform and during a transform
  */
-export type TransformActionHandler<T extends Transform = Transform> =
+export type TransformActionHandler<T extends Transform<any> = Transform> =
   TransformAction<T, boolean>;
 
 /**
  * Control handlers that run on control click/down/up
  * Those handlers run with or without a transform defined
  */
-export type ControlActionHandler = TransformAction<Transform, any>;
+export type ControlActionHandler<T extends Transform<any>> = TransformAction<
+  T,
+  any
+>;
 
 export type ControlCallback<R = void> = (
   eventData: TPointerEvent,
@@ -53,10 +56,15 @@ export type ControlCursorCallback = ControlCallback<string>;
  * relative to target's containing coordinate plane
  * both agree on every point
  */
-export type Transform = {
-  target: FabricObject;
+export type Transform<T extends FabricObject = FabricObject> = {
+  target: T;
   action?: string;
-  actionHandler?: TransformActionHandler;
+  actionHandler?: (
+    eventData: TPointerEvent,
+    transform: Transform<T>,
+    x: number,
+    y: number
+  ) => boolean;
   corner: string;
   scaleX: number;
   scaleY: number;

--- a/src/controls/Control.ts
+++ b/src/controls/Control.ts
@@ -2,11 +2,12 @@
 import type {
   ControlActionHandler,
   TPointerEvent,
+  Transform,
   TransformActionHandler,
 } from '../EventTypeDefs';
 import { Intersection } from '../Intersection';
 import { Point } from '../Point';
-import type { InteractiveFabricObject as FabricObject } from '../shapes/Object/InteractiveObject';
+import type { FabricObject } from '../shapes/Object/FabricObject';
 import type { TCornerPoint, TDegree, TMat2D } from '../typedefs';
 import {
   createRotateMatrix,
@@ -150,7 +151,7 @@ export class Control<T extends FabricObject = FabricObject> {
    * @param {Number} y y position of the cursor
    * @return {Boolean} true if the action/event modified the object
    */
-  declare actionHandler: TransformActionHandler;
+  declare actionHandler: TransformActionHandler<Transform<T>>;
 
   /**
    * The control handler for mouse down, provide one to handle mouse down on control
@@ -160,7 +161,7 @@ export class Control<T extends FabricObject = FabricObject> {
    * @param {Number} y y position of the cursor
    * @return {Boolean} true if the action/event modified the object
    */
-  declare mouseDownHandler?: ControlActionHandler;
+  declare mouseDownHandler?: ControlActionHandler<Transform<T>>;
 
   /**
    * The control mouseUpHandler, provide one to handle an effect on mouse up.
@@ -170,7 +171,7 @@ export class Control<T extends FabricObject = FabricObject> {
    * @param {Number} y y position of the cursor
    * @return {Boolean} true if the action/event modified the object
    */
-  declare mouseUpHandler?: ControlActionHandler;
+  declare mouseUpHandler?: ControlActionHandler<Transform<T>>;
 
   shouldActivate(
     controlKey: string,
@@ -198,7 +199,7 @@ export class Control<T extends FabricObject = FabricObject> {
     eventData: TPointerEvent,
     fabricObject: T,
     control: Control<T>
-  ): TransformActionHandler | undefined {
+  ): TransformActionHandler<Transform<T>> | undefined {
     return this.actionHandler;
   }
 
@@ -213,7 +214,7 @@ export class Control<T extends FabricObject = FabricObject> {
     eventData: TPointerEvent,
     fabricObject: T,
     control: Control<T>
-  ): ControlActionHandler | undefined {
+  ): ControlActionHandler<Transform<T>> | undefined {
     return this.mouseDownHandler;
   }
 
@@ -229,7 +230,7 @@ export class Control<T extends FabricObject = FabricObject> {
     eventData: TPointerEvent,
     fabricObject: T,
     control: Control<T>
-  ): ControlActionHandler | undefined {
+  ): ControlActionHandler<Transform<T>> | undefined {
     return this.mouseUpHandler;
   }
 

--- a/src/controls/Control.ts
+++ b/src/controls/Control.ts
@@ -6,7 +6,7 @@ import type {
 } from '../EventTypeDefs';
 import { Intersection } from '../Intersection';
 import { Point } from '../Point';
-import type { InteractiveFabricObject } from '../shapes/Object/InteractiveObject';
+import type { InteractiveFabricObject as FabricObject } from '../shapes/Object/InteractiveObject';
 import type { TCornerPoint, TDegree, TMat2D } from '../typedefs';
 import {
   createRotateMatrix,
@@ -17,7 +17,7 @@ import {
 import type { ControlRenderingStyleOverride } from './controlRendering';
 import { renderCircleControl, renderSquareControl } from './controlRendering';
 
-export class Control {
+export class Control<T extends FabricObject = FabricObject> {
   /**
    * keep track of control visibility.
    * mainly for backward compatibility.
@@ -138,7 +138,7 @@ export class Control {
    */
   withConnection = false;
 
-  constructor(options?: Partial<Control>) {
+  constructor(options?: Partial<Control<T>>) {
     Object.assign(this, options);
   }
 
@@ -174,13 +174,14 @@ export class Control {
 
   shouldActivate(
     controlKey: string,
-    fabricObject: InteractiveFabricObject,
+    fabricObject: T,
     pointer: Point,
     { tl, tr, br, bl }: TCornerPoint
   ) {
     // TODO: locking logic can be handled here instead of in the control handler logic
     return (
-      fabricObject.canvas?.getActiveObject() === fabricObject &&
+      (fabricObject.canvas?.getActiveObject() as unknown as T) ===
+        fabricObject &&
       fabricObject.isControlVisible(controlKey) &&
       Intersection.isPointInPolygon(pointer, [tl, tr, br, bl])
     );
@@ -195,8 +196,8 @@ export class Control {
    */
   getActionHandler(
     eventData: TPointerEvent,
-    fabricObject: InteractiveFabricObject,
-    control: Control
+    fabricObject: T,
+    control: Control<T>
   ): TransformActionHandler | undefined {
     return this.actionHandler;
   }
@@ -210,8 +211,8 @@ export class Control {
    */
   getMouseDownHandler(
     eventData: TPointerEvent,
-    fabricObject: InteractiveFabricObject,
-    control: Control
+    fabricObject: T,
+    control: Control<T>
   ): ControlActionHandler | undefined {
     return this.mouseDownHandler;
   }
@@ -226,8 +227,8 @@ export class Control {
    */
   getMouseUpHandler(
     eventData: TPointerEvent,
-    fabricObject: InteractiveFabricObject,
-    control: Control
+    fabricObject: T,
+    control: Control<T>
   ): ControlActionHandler | undefined {
     return this.mouseUpHandler;
   }
@@ -243,8 +244,8 @@ export class Control {
    */
   cursorStyleHandler(
     eventData: TPointerEvent,
-    control: Control,
-    fabricObject: InteractiveFabricObject
+    control: Control<T>,
+    fabricObject: T
   ) {
     return control.cursorStyle;
   }
@@ -258,8 +259,8 @@ export class Control {
    */
   getActionName(
     eventData: TPointerEvent,
-    control: Control,
-    fabricObject: InteractiveFabricObject
+    control: Control<T>,
+    fabricObject: T
   ) {
     return control.actionName;
   }
@@ -270,7 +271,7 @@ export class Control {
    * @param {String} controlKey key where the control is memorized on the
    * @return {Boolean}
    */
-  getVisibility(fabricObject: InteractiveFabricObject, controlKey: string) {
+  getVisibility(fabricObject: T, controlKey: string) {
     return fabricObject._controlsVisibility?.[controlKey] ?? this.visible;
   }
 
@@ -279,19 +280,15 @@ export class Control {
    * @param {Boolean} visibility for the object
    * @return {Void}
    */
-  setVisibility(
-    visibility: boolean,
-    name: string,
-    fabricObject: InteractiveFabricObject
-  ) {
+  setVisibility(visibility: boolean, name: string, fabricObject: T) {
     this.visible = visibility;
   }
 
   positionHandler(
     dim: Point,
     finalMatrix: TMat2D,
-    fabricObject: InteractiveFabricObject,
-    currentControl: Control
+    fabricObject: T,
+    currentControl: Control<T>
   ) {
     return new Point(
       this.x * dim.x + this.offsetX,
@@ -314,7 +311,7 @@ export class Control {
     centerX: number,
     centerY: number,
     isTouch: boolean,
-    fabricObject: InteractiveFabricObject
+    fabricObject: T
   ) {
     const t = multiplyTransformMatrixArray([
       createTranslateMatrix(centerX, centerY),
@@ -349,7 +346,7 @@ export class Control {
     left: number,
     top: number,
     styleOverride: ControlRenderingStyleOverride | undefined,
-    fabricObject: InteractiveFabricObject
+    fabricObject: T
   ) {
     styleOverride = styleOverride || {};
     switch (styleOverride.cornerStyle || fabricObject.cornerStyle) {

--- a/src/controls/controlRendering.ts
+++ b/src/controls/controlRendering.ts
@@ -1,11 +1,11 @@
 import { twoMathPi } from '../constants';
-import type { InteractiveFabricObject } from '../shapes/Object/InteractiveObject';
+import type { InteractiveFabricObject as FabricObject } from '../shapes/Object/InteractiveObject';
 import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import type { Control } from './Control';
 
 export type ControlRenderingStyleOverride = Partial<
   Pick<
-    InteractiveFabricObject,
+    FabricObject,
     | 'cornerStyle'
     | 'cornerSize'
     | 'cornerColor'
@@ -20,7 +20,7 @@ export type ControlRenderer = (
   left: number,
   top: number,
   styleOverride: ControlRenderingStyleOverride,
-  fabricObject: InteractiveFabricObject
+  fabricObject: FabricObject
 ) => void;
 
 /**
@@ -40,7 +40,7 @@ export function renderCircleControl(
   left: number,
   top: number,
   styleOverride: ControlRenderingStyleOverride,
-  fabricObject: InteractiveFabricObject
+  fabricObject: FabricObject
 ) {
   styleOverride = styleOverride || {};
   const xSize =
@@ -101,7 +101,7 @@ export function renderSquareControl(
   left: number,
   top: number,
   styleOverride: ControlRenderingStyleOverride,
-  fabricObject: InteractiveFabricObject
+  fabricObject: FabricObject
 ) {
   styleOverride = styleOverride || {};
   const xSize =

--- a/src/controls/controlRendering.ts
+++ b/src/controls/controlRendering.ts
@@ -1,5 +1,5 @@
 import { twoMathPi } from '../constants';
-import type { InteractiveFabricObject as FabricObject } from '../shapes/Object/InteractiveObject';
+import type { FabricObject } from '../shapes/Object/FabricObject';
 import { degreesToRadians } from '../util/misc/radiansDegreesConversion';
 import type { Control } from './Control';
 
@@ -15,14 +15,6 @@ export type ControlRenderingStyleOverride = Partial<
   >
 >;
 
-export type ControlRenderer = (
-  ctx: CanvasRenderingContext2D,
-  left: number,
-  top: number,
-  styleOverride: ControlRenderingStyleOverride,
-  fabricObject: FabricObject
-) => void;
-
 /**
  * Render a round control, as per fabric features.
  * This function is written to respect object properties like transparentCorners, cornerSize
@@ -35,7 +27,7 @@ export type ControlRenderer = (
  * @param {FabricObject} fabricObject the fabric object for which we are rendering controls
  */
 export function renderCircleControl(
-  this: Control,
+  this: Control<any>,
   ctx: CanvasRenderingContext2D,
   left: number,
   top: number,
@@ -96,7 +88,7 @@ export function renderCircleControl(
  * @param {FabricObject} fabricObject the fabric object for which we are rendering controls
  */
 export function renderSquareControl(
-  this: Control,
+  this: Control<any>,
   ctx: CanvasRenderingContext2D,
   left: number,
   top: number,

--- a/src/controls/polyControl.ts
+++ b/src/controls/polyControl.ts
@@ -101,25 +101,25 @@ export const createPolyActionHandler = (pointIndex: number) =>
     factoryPolyActionHandler(pointIndex, polyActionHandler)
   );
 
-export function createPolyControls(
-  poly: Polyline,
-  options?: Partial<Control>
-): Record<string, Control>;
-export function createPolyControls(
+export function createPolyControls<T extends Polyline>(
+  poly: T,
+  options?: Partial<Control<T>>
+): Record<string, Control<T>>;
+export function createPolyControls<T extends Polyline>(
   numOfControls: number,
-  options?: Partial<Control>
-): Record<string, Control>;
-export function createPolyControls(
+  options?: Partial<Control<T>>
+): Record<string, Control<T>>;
+export function createPolyControls<T extends Polyline>(
   arg0: number | Polyline,
-  options: Partial<Control> = {}
+  options: Partial<Control<T>> = {}
 ) {
-  const controls = {} as Record<string, Control>;
+  const controls = {} as Record<string, Control<T>>;
   for (
     let idx = 0;
     idx < (typeof arg0 === 'number' ? arg0 : arg0.points.length);
     idx++
   ) {
-    controls[`p${idx}`] = new Control({
+    controls[`p${idx}`] = new Control<T>({
       actionName: ACTION_NAME,
       positionHandler: createPolyPositionHandler(idx),
       actionHandler: createPolyActionHandler(idx),

--- a/src/controls/wrapWithFireEvent.ts
+++ b/src/controls/wrapWithFireEvent.ts
@@ -11,7 +11,7 @@ import { commonEventInfo } from './util';
  * @param {Function} actionHandler the function to wrap
  * @return {Function} a function with an action handler signature
  */
-export const wrapWithFireEvent = <T extends Transform>(
+export const wrapWithFireEvent = <T extends Transform<any>>(
   eventName: TModificationEvents,
   actionHandler: TransformActionHandler<T>
 ) => {

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -25,8 +25,6 @@ export type TOCoord = Point & {
   touchCorner: TCornerPoint;
 };
 
-export type TControlSet = Record<string, Control>;
-
 export type TBorderRenderingStyleOverride = Partial<
   Pick<InteractiveFabricObject, 'borderColor' | 'borderDashArray'>
 >;
@@ -114,7 +112,7 @@ export class InteractiveFabricObject<
    * holds the controls for the object.
    * controls are added by default_controls.js
    */
-  declare controls: TControlSet;
+  declare controls: Record<string, Control>;
 
   /**
    * internal boolean to signal the code that the object is
@@ -315,11 +313,7 @@ export class InteractiveFabricObject<
    * @param {Function} fn function to iterate over the controls over
    */
   forEachControl(
-    fn: (
-      control: Control,
-      key: string,
-      fabricObject: InteractiveFabricObject
-    ) => any
+    fn: (control: Control, key: string, fabricObject: this) => any
   ) {
     for (const i in this.controls) {
       fn(this.controls[i], i, this);

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -1,6 +1,7 @@
 import { Point, ZERO } from '../../Point';
 import type { TCornerPoint, TDegree } from '../../typedefs';
-import { FabricObject } from './Object';
+import { FabricObject as BaseFabricObject } from './Object';
+import type { FabricObject } from './FabricObject';
 import { degreesToRadians } from '../../util/misc/radiansDegreesConversion';
 import type { TQrDecomposeOut } from '../../util/misc/matrix';
 import {
@@ -42,7 +43,7 @@ export class InteractiveFabricObject<
     SProps extends SerializedObjectProps = SerializedObjectProps,
     EventSpec extends ObjectEvents = ObjectEvents
   >
-  extends FabricObject<Props, SProps, EventSpec>
+  extends BaseFabricObject<Props, SProps, EventSpec>
   implements FabricObjectProps
 {
   declare noScaleCache: boolean;
@@ -199,7 +200,7 @@ export class InteractiveFabricObject<
       if (
         this.controls[key].shouldActivate(
           key,
-          this,
+          this as unknown as FabricObject,
           pointer,
           forTouch ? corner.touchCorner : corner.corner
         )
@@ -243,7 +244,12 @@ export class InteractiveFabricObject<
       coords: Record<string, TOCoord> = {};
 
     this.forEachControl((control, key) => {
-      const position = control.positionHandler(dim, finalMatrix, this, control);
+      const position = control.positionHandler(
+        dim,
+        finalMatrix,
+        this as unknown as FabricObject,
+        control
+      );
       // coords[key] are sometimes used as points. Those are points to which we add
       // the property corner and touchCorner from `_calcCornerCoords`.
       // don't remove this assign for an object spread.
@@ -284,7 +290,7 @@ export class InteractiveFabricObject<
       position.x,
       position.y,
       false,
-      this
+      this as unknown as FabricObject
     );
     const touchCorner = control.calcCornerCoords(
       angle,
@@ -292,7 +298,7 @@ export class InteractiveFabricObject<
       position.x,
       position.y,
       true,
-      this
+      this as unknown as FabricObject
     );
     return { corner, touchCorner };
   }
@@ -482,7 +488,10 @@ export class InteractiveFabricObject<
     this.forEachControl((control, key) => {
       // in this moment, the ctx is centered on the object.
       // width and height of the above function are the size of the bbox.
-      if (control.withConnection && control.getVisibility(this, key)) {
+      if (
+        control.withConnection &&
+        control.getVisibility(this as unknown as FabricObject, key)
+      ) {
         // reset movement for each control
         shouldStroke = true;
         ctx.moveTo(control.x * size.x, control.y * size.y);
@@ -523,9 +532,9 @@ export class InteractiveFabricObject<
     this._setLineDash(ctx, options.cornerDashArray);
     this.setCoords();
     this.forEachControl((control, key) => {
-      if (control.getVisibility(this, key)) {
+      if (control.getVisibility(this as unknown as FabricObject, key)) {
         const p = this.oCoords[key];
-        control.render(ctx, p.x, p.y, options, this);
+        control.render(ctx, p.x, p.y, options, this as unknown as FabricObject);
       }
     });
     ctx.restore();
@@ -540,7 +549,10 @@ export class InteractiveFabricObject<
   isControlVisible(controlKey: string): boolean {
     return (
       this.controls[controlKey] &&
-      this.controls[controlKey].getVisibility(this, controlKey)
+      this.controls[controlKey].getVisibility(
+        this as unknown as FabricObject,
+        controlKey
+      )
     );
   }
 


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

This PR makes it easier to use a control for a specific object class.
Instead of using type casting everywhere the object ref is accessed we pass a generic.


<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

### Desired Behavior

```typescript
export class MyPathControl extends fabric.Control<fabric.Path> {
  actionHandler = (
    e: fabric.TPointerEvent,
    transform: fabric.Transform<fabric.Path>
  ) => {
    transform.target.path;
    return false;
  };

  mouseDownHandler = (
    e: fabric.TPointerEvent,
    transform: fabric.Transform<fabric.Path>
  ) => {
    transform.target.pathOffset;
  };
}

export class MyPolyControl extends fabric.Control<fabric.Polyline> {
  actionHandler = (
    e: fabric.TPointerEvent,
    transform: fabric.Transform<fabric.Polyline>
  ) => {
    transform.target.points;
    return false;
  };

  mouseDownHandler = (
    e: fabric.TPointerEvent,
    transform: fabric.Transform<fabric.Polyline>
  ) => {
    transform.target;
  };
}
```


https://github.com/fabricjs/fabric.js/assets/34343793/0c2298bb-bef9-4344-836b-1c829fce4c96


### Current Behavior


```typescript
export class MyPathControl extends fabric.Control {
  actionHandler = (
    e: fabric.TPointerEvent,
    transform: fabric.Transform
  ) => {
    (transform.target as fabric.Path).path;
    return false;
  };

  mouseDownHandler = (
    e: fabric.TPointerEvent,
    transform: fabric.Transform<fabric.Path>
  ) => {
    (transform.target as fabric.Path).pathOffset;
  };
}
```