### PR TITLE
fix(Group, LayoutManager) Correctly dispose LayoutManager when disposing the Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Group): Correctly dispose layoutManager [#9787](https://github.com/fabricjs/fabric.js/pull/9787)
 - test(): Rename svg tests [#9775](https://github.com/fabricjs/fabric.js/pull/9775)
 - refactor(): `_findTargetCorner` is now called `findControl` and returns the key and the control and the coordinates [#9668](https://github.com/fabricjs/fabric.js/pull/9668)
 - feat(LayoutManager): Handle the case of activeSelection with objects inside different groups [#9651](https://github.com/fabricjs/fabric.js/pull/9651)

--- a/src/shapes/Group.spec.ts
+++ b/src/shapes/Group.spec.ts
@@ -58,6 +58,34 @@ describe('Group', () => {
     expect(group.height).toBe(100);
   });
 
+  test('disposes the LayoutManager subscriptions', () => {
+    class CustomLayoutManager extends LayoutManager {
+      private disposers: VoidFunction[] = [];
+
+      attachListener(subscription: VoidFunction) {
+        this.disposers.push(subscription);
+      }
+
+      dispose(): void {
+        this.disposers.forEach((d) => d());
+        this.disposers = [];
+
+        super.dispose();
+      }
+    }
+
+    const objs = [new FabricObject(), new FabricObject()];
+    const layoutManager = new CustomLayoutManager(new FitContentLayout());
+    const group = new Group(objs, { layoutManager });
+
+    const subscription = jest.fn();
+    layoutManager.attachListener(subscription);
+
+    group.dispose();
+
+    expect(subscription).toHaveBeenCalled();
+  });
+
   describe('With fit-content layout manager', () => {
     test('will serialize correctly without default values', async () => {
       const { group } = makeGenericGroup({

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -578,10 +578,7 @@ export class Group
   }
 
   dispose() {
-    this.layoutManager.unsubscribeTargets({
-      targets: this.getObjects(),
-      target: this,
-    });
+    this.layoutManager.dispose();
     this._activeObjects = [];
     this.forEachObject((object) => {
       this._watchObject(false, object);

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -582,6 +582,8 @@ export class Group
       targets: this.getObjects(),
       target: this,
     });
+    // dispose additional listeners that may have been
+    // added by the developer on the layoutManager #9787
     this.layoutManager.dispose();
     this._activeObjects = [];
     this.forEachObject((object) => {

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -578,6 +578,10 @@ export class Group
   }
 
   dispose() {
+    this.layoutManager.unsubscribeTargets({
+      targets: this.getObjects(),
+      target: this,
+    });
     this.layoutManager.dispose();
     this._activeObjects = [];
     this.forEachObject((object) => {


### PR DESCRIPTION
If I'm not wrong, it seems that `LayoutManager.dispose` is never called actually. Disposing of the layout manager completely is safer than unsubscribing the Group objects:
1. There may be other target subscriptions left behind due to other bugs
2. `dispose` in an extended `LayoutManager` class takes care of disposing other things