### PR TITLE
perf(): reduce setCoords calls #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - refactor(): Separate defaults for base fabric object vs interactive object. Also some moving around of variables [#9474](https://github.com/fabricjs/fabric.js/pull/9474)
 - refactor(): Change how LayoutManager handles restoring groups [#9522](https://github.com/fabricjs/fabric.js/pull/9522)
 - fix(BaseConfiguration): set `devicePixelRatio` from window [#9470](https://github.com/fabricjs/fabric.js/pull/9470)
+- perf(): reduce setCoords calls [#9793](https://github.com/fabricjs/fabric.js/pull/9793)
 - fix(): bubble dirty flag for group only when true [#9540](https://github.com/fabricjs/fabric.js/pull/9540)
 - test() Backport a test to capture a failing text style situation [#9531](https://github.com/fabricjs/fabric.js/pull/9531)
 

--- a/e2e/tests/controls/hit-regions/index.ts
+++ b/e2e/tests/controls/hit-regions/index.ts
@@ -33,7 +33,6 @@ beforeAll((canvas) => {
   });
   canvas.add(group);
   canvas.centerObject(group);
-  group.setCoords();
   canvas.setActiveObject(rect);
   canvas.renderAll();
   return { rect, group };

--- a/e2e/utils/ObjectUtil.ts
+++ b/e2e/utils/ObjectUtil.ts
@@ -39,7 +39,7 @@ export class ObjectUtil<T extends FabricObject = FabricObject> {
 
   getObjectControlPoint(controlName: string) {
     return this.executeInBrowser(
-      (object, { controlName }) => object.oCoords[controlName],
+      (object, { controlName }) => object.getControlCoords()[controlName],
       { controlName }
     );
   }

--- a/src/CommonMethods.ts
+++ b/src/CommonMethods.ts
@@ -22,7 +22,7 @@ export class CommonMethods<EventSpec> extends Observable<EventSpec> {
   }
 
   /**
-   * Sets property to a given value. When changing position/dimension -related properties (left, top, scale, angle, etc.) `set` does not update position of object's borders/controls. If you need to update those, call `setCoords()`.
+   * Sets property to a given value.
    * @param {String|Object} key Property name or object (if object, iterate over the object properties)
    * @param {Object|Function} value Property value (if function, the value is passed into it and its return value is used as a new one)
    */

--- a/src/LayoutManager/LayoutManager.spec.ts
+++ b/src/LayoutManager/LayoutManager.spec.ts
@@ -345,10 +345,10 @@ describe('Layout Manager', () => {
       const targetSet = jest.spyOn(target, 'set').mockImplementation(() => {
         lifecycle.push(targetSet);
       });
-      const targetSetCoords = jest
-        .spyOn(target, 'setCoords')
+      const targetInvalidateCoords = jest
+        .spyOn(target, 'invalidateCoords')
         .mockImplementation(() => {
-          lifecycle.push(targetSetCoords);
+          lifecycle.push(targetInvalidateCoords);
         });
       const targetSetPositionByOrigin = jest
         .spyOn(target, 'setPositionByOrigin')
@@ -386,7 +386,7 @@ describe('Layout Manager', () => {
         },
         targetMocks: {
           set: targetSet,
-          setCoords: targetSetCoords,
+          invalidateCoords: targetInvalidateCoords,
           setPositionByOrigin: targetSetPositionByOrigin,
         },
         mocks: {
@@ -450,7 +450,7 @@ describe('Layout Manager', () => {
         targetMocks.set,
         layoutObjects,
         targetMocks.setPositionByOrigin,
-        targetMocks.setCoords,
+        targetMocks.invalidateCoords,
         targetMocks.set,
       ]);
       expect(targetMocks.set).nthCalledWith(1, { width, height });

--- a/src/LayoutManager/LayoutManager.ts
+++ b/src/LayoutManager/LayoutManager.ts
@@ -251,6 +251,7 @@ export class LayoutManager {
       target.setPositionByOrigin(nextCenter, CENTER, CENTER);
       // invalidate
       target.setCoords();
+      target['setDescendantCoords']();
       target.set('dirty', true);
     }
   }

--- a/src/LayoutManager/LayoutManager.ts
+++ b/src/LayoutManager/LayoutManager.ts
@@ -250,8 +250,7 @@ export class LayoutManager {
     } else {
       target.setPositionByOrigin(nextCenter, CENTER, CENTER);
       // invalidate
-      target.setCoords();
-      target['setDescendantCoords']();
+      target.invalidateCoords();
       target.set('dirty', true);
     }
   }

--- a/src/brushes/PencilBrush.ts
+++ b/src/brushes/PencilBrush.ts
@@ -288,13 +288,12 @@ export class PencilBrush extends BaseBrush {
 
     const path = this.createPath(pathData);
     this.canvas.clearContext(this.canvas.contextTop);
-    this.canvas.fire('before:path:created', { path: path });
+    this.canvas.fire('before:path:created', { path });
     this.canvas.add(path);
     this.canvas.requestRenderAll();
-    path.setCoords();
     this._resetShadow();
 
     // fire event 'path' created
-    this.canvas.fire('path:created', { path: path });
+    this.canvas.fire('path:created', { path });
   }
 }

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -10,7 +10,7 @@ import type {
 } from '../EventTypeDefs';
 import { Point } from '../Point';
 import type { ActiveSelection } from '../shapes/ActiveSelection';
-import { Group } from '../shapes/Group';
+import type { Group } from '../shapes/Group';
 import type { IText } from '../shapes/IText/IText';
 import type { FabricObject } from '../shapes/Object/FabricObject';
 import { isTouchEvent, stopEvent } from '../util/dom_event';
@@ -1309,10 +1309,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     const actionPerformed =
       !!actionHandler && actionHandler(e, transform, pointer.x, pointer.y);
 
-    if (actionPerformed) {
-      target.setCoords();
-      target instanceof Group && target['setDescendantCoords']();
-    }
+    actionPerformed && target.invalidateCoords();
 
     if (action === 'drag' && actionPerformed) {
       target.isMoving = true;

--- a/src/canvas/SelectableCanvas.spec.ts
+++ b/src/canvas/SelectableCanvas.spec.ts
@@ -465,7 +465,7 @@ describe('Selectable Canvas', () => {
 
       const {
         corner: { tl, tr, bl },
-      } = object.oCoords[controlKey];
+      } = object.getControlCoords()[controlKey];
       canvas.getSelectionElement().dispatchEvent(
         new MouseEvent('mousedown', {
           clientX: canvasOffset.left + (tl.x + tr.x) / 2,

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -1148,8 +1148,9 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
 
     if (isActiveSelection(object) && prevActiveObject !== object) {
       object.set('canvas', this);
-      object.setCoords();
     }
+
+    object.setCoords();
 
     return true;
   }

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -1150,7 +1150,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
       object.set('canvas', this);
     }
 
-    object.setCoords();
+    object.invalidateCoords();
 
     return true;
   }
@@ -1238,7 +1238,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
       target._scaling = false;
     }
 
-    target.setCoords();
+    target.invalidateCoords();
 
     if (transform.actionPerformed) {
       this.fire('object:modified', options);
@@ -1254,7 +1254,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
     super.setViewportTransform(vpt);
     const activeObject = this._activeObject;
     if (activeObject) {
-      activeObject.setCoords();
+      activeObject.invalidateCoords();
     }
   }
 

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -224,7 +224,7 @@ export class StaticCanvas<
       obj.canvas.remove(obj);
     }
     obj._set('canvas', this);
-    obj.setCoords();
+    obj.invalidateCoords();
     this.fire('object:added', { target: obj });
     obj.fire('added', { target: this });
   }
@@ -793,7 +793,7 @@ export class StaticCanvas<
    */
   _centerObject(object: FabricObject, center: Point) {
     object.setXY(center, CENTER, CENTER);
-    object.setCoords();
+    object.invalidateCoords();
     this.renderOnAddRemove && this.requestRenderAll();
   }
 

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -379,21 +379,7 @@ export class StaticCanvas<
    * @param {Array} vpt a Canvas 2D API transform matrix
    */
   setViewportTransform(vpt: TMat2D) {
-    const backgroundObject = this.backgroundImage,
-      overlayObject = this.overlayImage,
-      len = this._objects.length;
-
-    this.viewportTransform = vpt;
-    for (let i = 0; i < len; i++) {
-      const object = this._objects[i];
-      object.group || object.setCoords();
-    }
-    if (backgroundObject) {
-      backgroundObject.setCoords();
-    }
-    if (overlayObject) {
-      overlayObject.setCoords();
-    }
+    this.viewportTransform = [...vpt];
     this.calcViewportBoundaries();
     this.renderOnAddRemove && this.requestRenderAll();
   }

--- a/src/canvas/__tests__/eventData.test.ts
+++ b/src/canvas/__tests__/eventData.test.ts
@@ -476,7 +476,7 @@ describe('Event targets', () => {
       });
 
       group.subTargetCheck = true;
-      group.setCoords();
+      group.invalidateCoords();
 
       expect(findTarget(canvas, { clientX: 5, clientY: 5 })).toEqual({
         target: group,

--- a/src/controls/Control.spec.ts
+++ b/src/controls/Control.spec.ts
@@ -1,3 +1,4 @@
+import { Point } from '../Point';
 import { Canvas } from '../canvas/Canvas';
 import { FabricObject } from '../shapes/Object/FabricObject';
 import { Control } from './Control';
@@ -19,14 +20,31 @@ describe('Controls', () => {
       canvas: new Canvas(),
     });
 
-    target.setCoords();
+    target.invalidateCoords();
 
     jest
       .spyOn(target, 'findControl')
       .mockImplementation(function (this: FabricObject) {
         this.__corner = 'test';
 
-        return { key: 'test', control };
+        return {
+          key: 'test',
+          control,
+          coord: Object.assign(new Point(), {
+            corner: {
+              tl: new Point(),
+              tr: new Point(),
+              br: new Point(),
+              bl: new Point(),
+            },
+            touchCorner: {
+              tl: new Point(),
+              tr: new Point(),
+              br: new Point(),
+              bl: new Point(),
+            },
+          }),
+        };
       });
 
     const canvas = new Canvas();

--- a/src/controls/scale.test.ts
+++ b/src/controls/scale.test.ts
@@ -38,14 +38,16 @@ const createZeroThickRectangleScalingItems = (
   // create mouse event near center of rect, as the 0 size will put it on the middle scaler
   const canvasOffset = canvas.calcOffset();
 
+  const coord = target.getControlCoords()[usedCorner];
+
   const mouseDown = new MouseEvent('mousedown', {
-    clientX: canvasOffset.left + target.oCoords[usedCorner].x,
-    clientY: canvasOffset.top + target.oCoords[usedCorner].y,
+    clientX: canvasOffset.left + coord.x,
+    clientY: canvasOffset.top + coord.y,
   });
 
   const moveEvent = new MouseEvent('mousemove', {
-    clientX: canvasOffset.left + target.oCoords[usedCorner].x + pointDiff.x,
-    clientY: canvasOffset.top + target.oCoords[usedCorner].y + pointDiff.y,
+    clientX: canvasOffset.left + coord.x + pointDiff.x,
+    clientY: canvasOffset.top + coord.y + pointDiff.y,
   });
 
   canvas.setActiveObject(target);

--- a/src/controls/scale.test.ts
+++ b/src/controls/scale.test.ts
@@ -9,7 +9,7 @@ import { scalingX, scalingY } from './scale';
 //
 const createZeroThickRectangleScalingItems = (
   rectOptions: { width: number; height: number } & Partial<RectProps>,
-  usedCorner: keyof Rect['oCoords'],
+  usedCorner: string,
   pointDiff: Point
 ) => {
   const extraMargin = 100;

--- a/src/parkinglot/canvas_animation.mixin.ts
+++ b/src/parkinglot/canvas_animation.mixin.ts
@@ -38,7 +38,7 @@ Object.assign(StaticCanvas.prototype, {
         onChange();
       },
       onComplete: function () {
-        object.setCoords();
+        object.invalidateCoords();
         onComplete();
       },
     });
@@ -71,7 +71,7 @@ Object.assign(StaticCanvas.prototype, {
         onChange();
       },
       onComplete: function () {
-        object.setCoords();
+        object.invalidateCoords();
         onComplete();
       },
     });

--- a/src/parkinglot/straighten.ts
+++ b/src/parkinglot/straighten.ts
@@ -57,7 +57,7 @@ Object.assign(FabricObject.prototype, {
         onChange(value);
       },
       onComplete: () => {
-        this.setCoords();
+        this.invalidateCoords();
         onComplete();
       },
     });

--- a/src/shapes/ActiveSelection.spec.ts
+++ b/src/shapes/ActiveSelection.spec.ts
@@ -58,7 +58,7 @@ describe('ActiveSelection', () => {
     const obj2 = new FabricObject();
     canvas.add(obj1, obj2);
     const activeSelection = new ActiveSelection([obj1, obj2]);
-    const spy = jest.spyOn(activeSelection, 'setCoords');
+    const spy = jest.spyOn(activeSelection, 'invalidateCoords');
     canvas.setActiveObject(activeSelection);
     expect(canvas.getActiveObject()).toBe(activeSelection);
     expect(canvas.getActiveObjects()).toEqual([obj1, obj2]);

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -70,13 +70,6 @@ export class ActiveSelection extends Group {
 
   /**
    * @private
-   */
-  _shouldSetNestedCoords() {
-    return true;
-  }
-
-  /**
-   * @private
    * @override we don't want the selection monitor to be active
    */
   __objectSelectionMonitor() {
@@ -161,6 +154,9 @@ export class ActiveSelection extends Group {
     this._exitGroup(object, removeParentTransform);
     // return to parent
     object.parent && object.parent._enterGroup(object, true);
+    // invalidate coords in case active selection was transformed
+    delete object['aCoords'];
+    delete object['oCoords'];
   }
 
   /**

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -154,9 +154,6 @@ export class ActiveSelection extends Group {
     this._exitGroup(object, removeParentTransform);
     // return to parent
     object.parent && object.parent._enterGroup(object, true);
-    // invalidate coords in case active selection was transformed
-    delete object['aCoords'];
-    delete object['oCoords'];
   }
 
   /**

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -31,6 +31,16 @@ import type { SerializedLayoutManager } from '../LayoutManager/LayoutManager';
 import type { FitContentLayout } from '../LayoutManager';
 
 /**
+ * @deprecated setting descendant coords is might become redundant in the near future once coords are refactored for it
+ * This is being discussed and is here as an intermediate step until coords support what is needed.
+ */
+export const setDescendantCoords = (group: Group) => {
+  group.forEachObject((object) => {
+    object instanceof Group ? setDescendantCoords(object) : object.setCoords();
+  });
+};
+
+/**
  * This class handles the specific case of creating a group using {@link Group#fromObject} and is not meant to be used in any other case.
  * We could have used a boolean in the constructor, as we did previously, but we think the boolean
  * would stay in the group's constructor interface and create confusion, therefore it was removed.
@@ -285,13 +295,6 @@ export class Group
   }
 
   /**
-   * @private
-   */
-  _shouldSetNestedCoords() {
-    return this.subTargetCheck;
-  }
-
-  /**
    * Remove all objects
    * @returns {FabricObject[]} removed objects
    */
@@ -365,7 +368,7 @@ export class Group
         )
       );
     }
-    this._shouldSetNestedCoords() && object.setCoords();
+
     object._set('group', this);
     object._set('canvas', this.canvas);
     this._watchObject(true, object);
@@ -412,7 +415,6 @@ export class Group
           object.calcTransformMatrix()
         )
       );
-      object.setCoords();
     }
     this._watchObject(false, object);
     const index =
@@ -490,13 +492,10 @@ export class Group
   }
 
   /**
-   * @override
-   * @return {Boolean}
+   * @deprecated intermediate internal method here for the dev to noop, see {@link setDescendantCoords}
    */
-  setCoords() {
-    super.setCoords();
-    this._shouldSetNestedCoords() &&
-      this.forEachObject((object) => object.setCoords());
+  protected setDescendantCoords() {
+    setDescendantCoords(this);
   }
 
   triggerLayout(options: ImperativeLayoutOptions = {}) {
@@ -689,7 +688,6 @@ export class Group
         target: group,
         targets: group.getObjects(),
       });
-      group.setCoords();
       return group;
     });
   }

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -133,7 +133,7 @@ export class Group
    */
   constructor(objects: FabricObject[] = [], options: Partial<GroupProps> = {}) {
     // @ts-expect-error options error
-    super(options);
+    super({ _objects: [], ...options });
     this._objects = [...objects]; // Avoid unwanted mutations of Collection to affect the caller
 
     this.__objectSelectionTracker = this.__objectSelectionMonitor.bind(

--- a/src/shapes/IText/IText.test.ts
+++ b/src/shapes/IText/IText.test.ts
@@ -24,7 +24,6 @@ describe('IText', () => {
         });
         const group = new Group([text]);
         group.set({ scaleX: scale, scaleY: scale, angle });
-        group.setCoords();
         const fillRect = jest.fn();
         const getZoom = jest.fn().mockReturnValue(zoom);
         const mockContext = { fillRect };

--- a/src/shapes/IText/ITextBehavior.ts
+++ b/src/shapes/IText/ITextBehavior.ts
@@ -528,7 +528,6 @@ export abstract class ITextBehavior<
     this.text = textarea.value;
     this.set('dirty', true);
     this.initDimensions();
-    this.setCoords();
     const newSelection = this.fromStringToGraphemeSelection(
       textarea.selectionStart,
       textarea.selectionEnd,
@@ -685,7 +684,6 @@ export abstract class ITextBehavior<
     this._restoreEditingProps();
     if (this._forceClearCache) {
       this.initDimensions();
-      this.setCoords();
     }
     this.fire('editing:exited');
     isTextChanged && this.fire('modified');
@@ -1002,7 +1000,6 @@ export abstract class ITextBehavior<
     this.text = this._text.join('');
     this.set('dirty', true);
     this.initDimensions();
-    this.setCoords();
     this._removeExtraneousStyles();
   }
 
@@ -1037,7 +1034,6 @@ export abstract class ITextBehavior<
     this.text = this._text.join('');
     this.set('dirty', true);
     this.initDimensions();
-    this.setCoords();
     this._removeExtraneousStyles();
   }
 

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -220,7 +220,7 @@ export class FabricImage<
   /**
    * Sets image element for this instance to a specified one.
    * If filters defined they are applied to new image.
-   * You might need to call `canvas.renderAll` and `object.setCoords` after replacing, to render new image and update controls area.
+   * You might need to call `canvas.renderAll` after replacing, to render new image and update controls area.
    * @param {HTMLImageElement} element
    * @param {Partial<TSize>} [size] Options object
    */
@@ -677,8 +677,11 @@ export class FabricImage<
    */
   _setWidthHeight({ width, height }: Partial<TSize> = {}) {
     const size = this.getOriginalSize();
+    const { width: prevWidth, height: prevHeight } = this;
     this.width = width || size.width;
     this.height = height || size.height;
+    (prevWidth !== this.width || prevHeight !== this.height) &&
+      this.invalidateCoords();
   }
 
   /**

--- a/src/shapes/Object/AnimatableObject.ts
+++ b/src/shapes/Object/AnimatableObject.ts
@@ -87,7 +87,7 @@ export abstract class AnimatableObject<
         valueProgress: number,
         durationProgress: number
       ) => {
-        this.setCoords();
+        this.invalidateCoords();
         onComplete &&
           // @ts-expect-error generic callback arg0 is wrong
           onComplete(value, valueProgress, durationProgress);

--- a/src/shapes/Object/FabricObject.spec.ts
+++ b/src/shapes/Object/FabricObject.spec.ts
@@ -3,14 +3,14 @@ import { FabricObject } from './FabricObject';
 describe('FabricObject', () => {
   it('setCoords should calculate control coords only if canvas ref is set', () => {
     const object = new FabricObject();
-    expect(object.aCoords).toBeUndefined();
-    expect(object.oCoords).toBeUndefined();
+    expect(object['aCoords']).toBeUndefined();
+    expect(object['oCoords']).toBeUndefined();
     object.setCoords();
-    expect(object.aCoords).toBeDefined();
-    expect(object.oCoords).toBeUndefined();
+    expect(object['aCoords']).toBeDefined();
+    expect(object['oCoords']).toBeUndefined();
     object.canvas = jest.fn();
     object.setCoords();
-    expect(object.aCoords).toBeDefined();
-    expect(object.oCoords).toBeDefined();
+    expect(object['aCoords']).toBeDefined();
+    expect(object['oCoords']).toBeDefined();
   });
 });

--- a/src/shapes/Object/InteractiveObject.spec.ts
+++ b/src/shapes/Object/InteractiveObject.spec.ts
@@ -37,7 +37,7 @@ describe('InteractiveObject', () => {
       canvas.add(group);
       const objectAngle = Math.round(object.getTotalAngle());
       expect(objectAngle).toEqual(35);
-      Object.values(object.oCoords).forEach((cornerPoint: TOCoord) => {
+      Object.values(object['oCoords']!).forEach((cornerPoint: TOCoord) => {
         const controlAngle = Math.round(
           radiansToDegrees(
             Math.atan2(
@@ -61,7 +61,7 @@ describe('InteractiveObject', () => {
     expect(object.getActiveControl()).toEqual({
       key: 'control',
       control,
-      coord: object.oCoords.control,
+      coord: object['oCoords']!.control,
     });
   });
 });

--- a/src/shapes/Object/InteractiveObject.spec.ts
+++ b/src/shapes/Object/InteractiveObject.spec.ts
@@ -37,17 +37,19 @@ describe('InteractiveObject', () => {
       canvas.add(group);
       const objectAngle = Math.round(object.getTotalAngle());
       expect(objectAngle).toEqual(35);
-      Object.values(object['oCoords']!).forEach((cornerPoint: TOCoord) => {
-        const controlAngle = Math.round(
-          radiansToDegrees(
-            Math.atan2(
-              cornerPoint.corner.tr.y - cornerPoint.corner.tl.y,
-              cornerPoint.corner.tr.x - cornerPoint.corner.tl.x
+      Object.values(object.getControlCoords()).forEach(
+        (cornerPoint: TOCoord) => {
+          const controlAngle = Math.round(
+            radiansToDegrees(
+              Math.atan2(
+                cornerPoint.corner.tr.y - cornerPoint.corner.tl.y,
+                cornerPoint.corner.tr.x - cornerPoint.corner.tl.x
+              )
             )
-          )
-        );
-        expect(controlAngle).toEqual(objectAngle);
-      });
+          );
+          expect(controlAngle).toEqual(objectAngle);
+        }
+      );
     });
   });
 

--- a/src/shapes/Object/InteractiveObject.spec.ts
+++ b/src/shapes/Object/InteractiveObject.spec.ts
@@ -35,7 +35,6 @@ describe('InteractiveObject', () => {
         subTargetCheck: true,
       });
       canvas.add(group);
-      group.setCoords();
       const objectAngle = Math.round(object.getTotalAngle());
       expect(objectAngle).toEqual(35);
       Object.values(object.oCoords).forEach((cornerPoint: TOCoord) => {

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -312,8 +312,8 @@ export class InteractiveFabricObject<
   }
 
   /**
+   * Calling this method is probably redundant, consider calling {@link invalidateCoords} instead.
    * @override set controls' coordinates as well
-   * See {@link https://github.com/fabricjs/fabric.js/wiki/When-to-call-setCoords} and {@link http://fabricjs.com/fabric-gotchas}
    * @return {void}
    */
   setCoords(): void {

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -312,7 +312,6 @@ export class InteractiveFabricObject<
   }
 
   /**
-   * Calling this method is probably redundant, consider calling {@link invalidateCoords} instead.
    * @override set controls' coordinates as well
    * @return {void}
    */

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -534,7 +534,6 @@ export class InteractiveFabricObject<
       ctx.strokeStyle = options.cornerStrokeColor;
     }
     this._setLineDash(ctx, options.cornerDashArray);
-    this.setCoords();
     this.forEachControl((control, key) => {
       if (control.getVisibility(this, key)) {
         const p = this.oCoords[key];

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -46,6 +46,7 @@ import type { FabricImage } from '../Image';
 import {
   cacheProperties,
   fabricObjectDefaultValues,
+  geometryProperties,
   stateProperties,
 } from './defaultValues';
 import type { Gradient } from '../../gradient/Gradient';
@@ -183,6 +184,8 @@ export class FabricObject<
    * @type Array
    */
   static cacheProperties: string[] = cacheProperties;
+
+  static geometryProperties: string[] = geometryProperties;
 
   /**
    * When set to `true`, object's cache will be rerendered next render call.
@@ -756,6 +759,13 @@ export class FabricObject<
             key
           ))) &&
       this.parent._set('dirty', true);
+
+    if (
+      isChanged &&
+      (this.constructor as typeof FabricObject).geometryProperties.includes(key)
+    ) {
+      this.invalidateCoords();
+    }
 
     return this;
   }
@@ -1414,7 +1424,7 @@ export class FabricObject<
       sendObjectToPlane(this, this.getViewportTransform());
     }
 
-    this.setCoords();
+    this.invalidateCoords();
     const el = createCanvasElement(),
       boundingRect = this.getBoundingRect(),
       shadow = this.shadow,
@@ -1451,7 +1461,7 @@ export class FabricObject<
     // @ts-expect-error this needs to be fixed somehow, or ignored globally
     canvas._objects = [this];
     this.set('canvas', canvas);
-    this.setCoords();
+    this.invalidateCoords();
     const canvasEl = canvas.toCanvasElement(multiplier || 1, options);
     this.set('canvas', originalCanvas);
     this.shadow = originalShadow;
@@ -1459,7 +1469,7 @@ export class FabricObject<
       this.group = originalGroup;
     }
     this.set(origParams);
-    this.setCoords();
+    this.invalidateCoords();
     // canvas.dispose will call image.dispose that will nullify the elements
     // since this canvas is a simple element for the process, we remove references
     // to objects in this way in order to avoid object trashing.

--- a/src/shapes/Object/ObjectGeometry.ts
+++ b/src/shapes/Object/ObjectGeometry.ts
@@ -357,7 +357,7 @@ export class ObjectGeometry<EventSpec extends ObjectEvents = ObjectEvents>
   scale(value: number): void {
     this._set('scaleX', value);
     this._set('scaleY', value);
-    this.setCoords();
+    this.invalidateCoords();
   }
 
   /**

--- a/src/shapes/Object/ObjectGeometry.ts
+++ b/src/shapes/Object/ObjectGeometry.ts
@@ -47,7 +47,7 @@ export class ObjectGeometry<EventSpec extends ObjectEvents = ObjectEvents>
    * The coordinates get updated with {@link setCoords}.
    * You can calculate them without updating with {@link calcACoords()}
    */
-  declare aCoords: TACoords;
+  protected declare aCoords?: TACoords;
 
   /**
    * storage cache for object transform matrix
@@ -435,6 +435,10 @@ export class ObjectGeometry<EventSpec extends ObjectEvents = ObjectEvents>
    */
   setCoords(): void {
     this.aCoords = this.calcACoords();
+  }
+
+  invalidateCoords() {
+    delete this.aCoords;
   }
 
   transformMatrixKey(skipGroup = false): string {

--- a/src/shapes/Object/ObjectGeometry.ts
+++ b/src/shapes/Object/ObjectGeometry.ts
@@ -430,8 +430,9 @@ export class ObjectGeometry<EventSpec extends ObjectEvents = ObjectEvents>
 
   /**
    * Sets corner and controls position coordinates based on current angle, width and height, left and top.
-   * aCoords are used to quickly find an object on the canvas.
-   * See {@link https://github.com/fabricjs/fabric.js/wiki/When-to-call-setCoords} and {@link http://fabricjs.com/fabric-gotchas}
+   * {@link aCoords} are used to quickly find an object on the canvas.
+   *
+   * Calling this method is probably redundant, consider calling {@link invalidateCoords} instead.
    */
   setCoords(): void {
     this.aCoords = this.calcACoords();

--- a/src/shapes/Object/defaultValues.ts
+++ b/src/shapes/Object/defaultValues.ts
@@ -38,6 +38,30 @@ export const cacheProperties = [
   'clipPath',
 ];
 
+export const geometryProperties = [
+  TOP,
+  LEFT,
+  'angle',
+  'scaleX',
+  'scaleY',
+  'flipX',
+  'flipY',
+  'skewX',
+  'skewY',
+  'width',
+  'height',
+  'originX',
+  'originY',
+  'strokeWidth',
+  'strokeUniform',
+  // this don't affect coords currently but should
+  'strokeLineCap',
+  'strokeLineJoin',
+  'strokeMiterLimit',
+  // this doesn't affect aCoords but due to laziness it will invalidate all coords
+  'padding',
+];
+
 export const fabricObjectDefaultValues: Partial<
   TClassProperties<FabricObject>
 > = {

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -474,6 +474,8 @@ export class FabricText<
       // once text is measured we need to make space fatter to make justified text.
       this.enlargeSpaces();
     }
+
+    this.invalidateCoords();
   }
 
   /**
@@ -1693,7 +1695,6 @@ export class FabricText<
     }
     if (this._forceClearCache) {
       this.initDimensions();
-      this.setCoords();
     }
     super.render(ctx);
   }
@@ -1771,7 +1772,6 @@ export class FabricText<
     }
     if (needsDims && this.initialized) {
       this.initDimensions();
-      this.setCoords();
     }
     return this;
   }

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -427,7 +427,6 @@ export class FabricText<
       this.setPathInfo();
     }
     this.initDimensions();
-    this.setCoords();
   }
 
   /**
@@ -1694,6 +1693,7 @@ export class FabricText<
     }
     if (this._forceClearCache) {
       this.initDimensions();
+      this.setCoords();
     }
     super.render(ctx);
   }

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -128,6 +128,8 @@ export class Textbox<
     }
     // clear cache and re-calculate height
     this.height = this.calcTextHeight();
+
+    this.invalidateCoords();
   }
 
   /**

--- a/test/unit/canvas_events.js
+++ b/test/unit/canvas_events.js
@@ -840,7 +840,6 @@
     var target = new fabric.Rect({ width: 100, height: 100 });
     canvas.add(target);
     canvas.setActiveObject(target);
-    target.setCoords();
     const expected = {
       mt: 'n-resize',
       mb: 's-resize',
@@ -852,7 +851,7 @@
       br: 'se-resize',
       mtr: 'crosshair',
     };
-    Object.entries(target.oCoords).forEach(([corner, coords]) => {
+    Object.entries(target.getControlCoords()).forEach(([corner, coords]) => {
       const e = { clientX: coords.x, clientY: coords.y, [key]: false, target: canvas.upperCanvasEl };
       canvas._setCursorFromEvent(e, target);
       assert.equal(canvas.upperCanvasEl.style.cursor, expected[corner], `${expected[corner]} action is not disabled`);

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1714,27 +1714,6 @@
     canvas.viewportTransform = fabric.StaticCanvas.getDefaults().viewportTransform;
   });
 
-  QUnit.test('setViewportTransform calls objects setCoords', function(assert) {
-    var vpt = [2, 0, 0, 2, 50, 50];
-    assert.deepEqual(canvas.viewportTransform, [1, 0, 0, 1, 0, 0], 'initial viewport is identity matrix');
-    var rect = new fabric.Rect({ width: 10, heigth: 10 });
-    var rectBg = new fabric.Rect({ width: 10, heigth: 10 });
-    var rectOverlay = new fabric.Rect({ width: 10, heigth: 10 });
-    canvas.add(rect);
-    canvas.cancelRequestedRender();
-    rectBg.canvas = canvas;
-    canvas.backgroundImage = rectBg;
-    rectOverlay.canvas = canvas;
-    canvas.overlayImage = rectOverlay;
-    assert.deepEqual(new fabric.Point(rect.oCoords.tl), new fabric.Point(0,0), 'rect oCoords are set for normal viewport');
-    assert.equal(rectBg.oCoords, undefined, 'rectBg oCoords are not set');
-    assert.equal(rectOverlay.oCoords, undefined, 'rectOverlay oCoords are not set');
-    canvas.setViewportTransform(vpt);
-    assert.deepEqual(new fabric.Point(rect.oCoords.tl), new fabric.Point(50,50), 'rect oCoords are set');
-    assert.deepEqual(new fabric.Point(rectBg.oCoords.tl),  new fabric.Point(50,50), 'rectBg oCoords are set');
-    assert.deepEqual(new fabric.Point(rectOverlay.oCoords.tl),  new fabric.Point(50,50), 'rectOverlay oCoords are set');
-  });
-
   QUnit.test('getZoom', function(assert) {
     assert.ok(typeof canvas.getZoom === 'function');
     var vpt = [2, 0, 0, 2, 50, 50];

--- a/test/unit/canvas_static.js
+++ b/test/unit/canvas_static.js
@@ -1425,7 +1425,6 @@
     assert.equal(canvas.item(2), rect3);
 
     rect1.set({ top: 100 });
-    rect1.setCoords();
     canvas.sendObjectBackwards(rect1, true);
 
     assert.equal(canvas.item(1), rect1);
@@ -1482,7 +1481,6 @@
     assert.equal(canvas.item(2), rect3);
 
     rect2.set({ left: 200 });
-    rect2.setCoords();
     canvas.bringObjectForward(rect2, true);
 
     // rect2, rect3 do not overlap

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -719,17 +719,6 @@
     assert.equal(isTransparent(ctx, 7, 7, 0), true, '7,7 is transparent');
   });
 
-  QUnit.test('group add', function(assert) {
-    var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false}),
-        rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false}),
-        group = new fabric.Group([rect1], { layoutManager: new fabric.LayoutManager() });
-
-    var coords = group.aCoords;
-    group.add(rect2);
-    var newCoords = group.aCoords;
-    assert.notEqual(coords, newCoords, 'object coords have been recalculated - add');
-  });
-
   QUnit.test('group add edge cases', function (assert) {
     var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false }),
       rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false }),
@@ -757,17 +746,6 @@
     assert.notOk(group.canEnterGroup(circularGroup), 'circular group should be denied entry');
     group.add(circularGroup);
     assert.deepEqual(group.getObjects(), [rect2, nestedGroup], 'objects should not have changed');
-  });
-
-  QUnit.test('group remove', function(assert) {
-    var rect1 = new fabric.Rect({ top: 1, left: 1, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false}),
-        rect2 = new fabric.Rect({ top: 5, left: 5, width: 2, height: 2, strokeWidth: 0, fill: 'red', opacity: 1, objectCaching: false}),
-        group = new fabric.Group([rect1, rect2], { layoutManager: new fabric.LayoutManager() });
-
-    var coords = group.aCoords;
-    group.remove(rect2);
-    var newCoords = group.aCoords;
-    assert.notEqual(coords, newCoords, 'object coords have been recalculated - remove');
   });
 
   QUnit.test('group willDrawShadow', function(assert) {

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -424,20 +424,6 @@
     });
   });
 
-  QUnit.test('fromObject restores aCoords', function(assert) {
-    var done = assert.async();
-    var group = makeGroupWith2ObjectsWithOpacity();
-
-    var groupObject = group.toObject();
-    groupObject.subTargetCheck = true;
-
-    fabric.Group.fromObject(groupObject).then(function(newGroupFromObject) {
-      assert.ok(newGroupFromObject._objects[0].aCoords.tl, 'acoords 0 are restored');
-      assert.ok(newGroupFromObject._objects[1].aCoords.tl, 'acoords 1 are restored');
-      done();
-    });
-  });
-
   QUnit.test('fromObject does not delete objects from source', function(assert) {
     var done = assert.async();
     var group = makeGroupWith2ObjectsWithOpacity();

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -329,7 +329,7 @@
   QUnit.test('containsPoint', function(assert) {
 
     var group = makeGroupWith2Objects();
-    group.set({ originX: 'center', originY: 'center' }).setCoords();
+    group.set({ originX: 'center', originY: 'center' });
 
     //  Rect #1     top: 100, left: 100, width: 30, height: 10
     //  Rect #2     top: 120, left: 50, width: 10, height: 40
@@ -345,7 +345,7 @@
 
     group.scale(1);
     group.padding = 30;
-    group.setCoords();
+    group.invalidateCoords();
     assert.ok(group.containsPoint(new fabric.Point( 50, 120 )));
     assert.ok(!group.containsPoint(new fabric.Point( 100, 170 )));
     assert.ok(!group.containsPoint(new fabric.Point( 0, 0 )));

--- a/test/unit/object_geometry.js
+++ b/test/unit/object_geometry.js
@@ -231,17 +231,8 @@
 
     cObj.set('left', 250).set('top', 250);
 
-    // coords should still correspond to initial one, even after invoking `set`
-    assert.equal(cObj.oCoords.tl.x, 150);
-    assert.equal(cObj.oCoords.tl.y, 150);
-    assert.equal(cObj.oCoords.tr.x, 250);
-    assert.equal(cObj.oCoords.tr.y, 150);
-    assert.equal(cObj.oCoords.bl.x, 150);
-    assert.equal(cObj.oCoords.bl.y, 250);
-    assert.equal(cObj.oCoords.br.x, 250);
-    assert.equal(cObj.oCoords.br.y, 250);
-    assert.equal(cObj.oCoords.mtr.x, 200);
-    assert.equal(cObj.oCoords.mtr.y, 110);
+    assert.equal(cObj.aCoords, undefined);
+    assert.equal(cObj.oCoords, undefined);
 
     // recalculate coords
     cObj.setCoords();
@@ -259,6 +250,7 @@
     assert.equal(cObj.oCoords.mtr.y, 210);
 
     cObj.set('padding', 25);
+    assert.equal(cObj.oCoords, undefined);
     cObj.setCoords();
     // coords should still correspond to initial one, even after invoking `set`
     assert.equal(cObj.oCoords.tl.x, 225, 'setCoords tl.x padding');

--- a/test/unit/object_geometry.js
+++ b/test/unit/object_geometry.js
@@ -4,7 +4,6 @@
 
   QUnit.test('intersectsWithRectangle without zoom', function(assert) {
     var cObj = new fabric.Object({ left: 50, top: 50, width: 100, height: 100 });
-    cObj.setCoords();
     assert.ok(typeof cObj.intersectsWithRect === 'function');
 
     var point1 = new fabric.Point(110, 100),
@@ -20,7 +19,6 @@
     var cObj = new fabric.Rect({ left: 10, top: 10, width: 20, height: 20 });
     canvas.add(cObj);
     canvas.viewportTransform = [2, 0, 0, 2, 0, 0];
-    cObj.setCoords();
     canvas.calcViewportBoundaries();
 
     var point1 = new fabric.Point(5, 5),
@@ -34,28 +32,23 @@
 
   QUnit.test('intersectsWithObject', function(assert) {
     var cObj = new fabric.Object({ left: 50, top: 50, width: 100, height: 100 });
-    cObj.setCoords();
     assert.ok(typeof cObj.intersectsWithObject === 'function', 'has intersectsWithObject method');
 
     var cObj2 = new fabric.Object({ left: -150, top: -150, width: 200, height: 200 });
-    cObj2.setCoords();
     assert.ok(cObj.intersectsWithObject(cObj2), 'cobj2 does intersect with cobj');
     assert.ok(cObj2.intersectsWithObject(cObj), 'cobj2 does intersect with cobj');
 
     var cObj3 = new fabric.Object({ left: 392.5, top: 339.5, width: 13, height: 33 });
-    cObj3.setCoords();
     assert.ok(!cObj.intersectsWithObject(cObj3), 'cobj3 does not intersect with cobj (external)');
     assert.ok(!cObj3.intersectsWithObject(cObj), 'cobj3 does not intersect with cobj (external)');
 
     var cObj4 = new fabric.Object({ left: 0, top: 0, width: 200, height: 200 });
-    cObj4.setCoords();
     assert.ok(cObj4.intersectsWithObject(cObj), 'overlapping objects are considered intersecting');
     assert.ok(cObj.intersectsWithObject(cObj4), 'overlapping objects are considered intersecting');
   });
 
   QUnit.test('isContainedWithinRect', function(assert) {
     var cObj = new fabric.Object({ left: 20, top: 20, width: 10, height: 10 });
-    cObj.setCoords();
     assert.ok(typeof cObj.isContainedWithinRect === 'function');
 
     // fully contained
@@ -70,7 +63,6 @@
     var cObj = new fabric.Rect({ left: 20, top: 20, width: 10, height: 10 });
     canvas.add(cObj);
     canvas.viewportTransform = [2, 0, 0, 2, 0, 0];
-    cObj.setCoords();
     canvas.calcViewportBoundaries();
     assert.ok(typeof cObj.isContainedWithinRect === 'function');
 
@@ -91,8 +83,6 @@
         point5 = new fabric.Point(50, 60),
         point6 = new fabric.Point(70, 80);
 
-    object.setCoords();
-
     // object and area intersects
     assert.equal(object.intersectsWithRect(point1, point2), true);
     // area is contained in object (no intersection)
@@ -107,10 +97,10 @@
         object2 = new fabric.Object({ left: 25, top: 35, width: 20, height: 20, angle: 50, strokeWidth: 0 }),
         object3 = new fabric.Object({ left: 50, top: 50, width: 20, height: 20, angle: 0, strokeWidth: 0 });
 
-    object.set({ originX: 'center', originY: 'center' }).setCoords();
-    object1.set({ originX: 'center', originY: 'center' }).setCoords();
-    object2.set({ originX: 'center', originY: 'center' }).setCoords();
-    object3.set({ originX: 'center', originY: 'center' }).setCoords();
+    object.set({ originX: 'center', originY: 'center' });
+    object1.set({ originX: 'center', originY: 'center' });
+    object2.set({ originX: 'center', originY: 'center' });
+    object3.set({ originX: 'center', originY: 'center' });
 
     assert.equal(object.intersectsWithObject(object1), true, 'object and object1 intersects');
     assert.equal(object.intersectsWithObject(object2), true, 'object2 is contained in object');
@@ -123,16 +113,11 @@
         object2 = new fabric.Object({ left: 20, top: 20, width: 40, height: 40, angle: 0 }),
         object3 = new fabric.Object({ left: 50, top: 50, width: 40, height: 40, angle: 0 });
 
-    object.setCoords();
-    object1.setCoords();
-    object2.setCoords();
-    object3.setCoords();
-
     assert.equal(object1.isContainedWithinObject(object), true, 'object1 is fully contained within object');
     assert.equal(object2.isContainedWithinObject(object), false, 'object2 intersects object (not fully contained)');
     assert.equal(object3.isContainedWithinObject(object), false, 'object3 is outside of object (not fully contained)');
     object1.angle = 45;
-    object1.setCoords();
+    object1.invalidateCoords();
     assert.equal(object1.isContainedWithinObject(object), false, 'object1 rotated is not contained within object');
 
     var rect1 = new fabric.Rect({
@@ -149,8 +134,6 @@
       top: 0,
       angle: 45,
     });
-    rect1.setCoords();
-    rect2.setCoords();
     assert.equal(rect1.isContainedWithinObject(rect2), false, 'rect1 rotated is not contained within rect2');
   });
 
@@ -163,7 +146,7 @@
         point5 = new fabric.Point(80, 80),
         point6 = new fabric.Point(90, 90);
 
-    object.set({ originX: 'center', originY: 'center' }).setCoords();
+    object.set({ originX: 'center', originY: 'center' })
 
     // area is contained in object (no intersection)
     assert.equal(object.isContainedWithinRect(point1, point2), true);
@@ -182,7 +165,7 @@
         point5 = new fabric.Point(80, 80),
         point6 = new fabric.Point(90, 90);
 
-    object.set({ originX: 'center', originY: 'center' }).setCoords();
+    object.set({ originX: 'center', originY: 'center' })
 
     // area is contained in object (no intersection)
     assert.equal(object.isContainedWithinRect(point1, point2), true);
@@ -200,7 +183,7 @@
         point4 = new fabric.Point(15, 40),
         point5 = new fabric.Point(30, 15);
 
-    object.set({ originX: 'center', originY: 'center' }).setCoords();
+    object.set({ originX: 'center', originY: 'center' })
 
     // point1 is contained in object
     assert.equal(object.containsPoint(point1), true);
@@ -298,14 +281,13 @@
     canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
     canvas.calcViewportBoundaries();
     cObj.canvas = canvas;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.ok(cObj.isOnScreen(), 'object is onScreen');
     cObj.top = 1000;
-    assert.ok(cObj.isOnScreen(), 'object is still wrongly on screen since setCoords is not called and calculate is not set, even when top is already at 1000');
-    cObj.setCoords();
+    assert.ok(cObj.isOnScreen(), 'object is still wrongly on screen since invalidateCoords is not called and calculate is not set, even when top is already at 1000');
+    cObj.invalidateCoords();
     assert.ok(!cObj.isOnScreen(), 'object is not onScreen with top 1000');
     canvas.setZoom(0.1);
-    cObj.setCoords();
     assert.ok(cObj.isOnScreen(), 'zooming out the object is again on screen');
   });
 
@@ -314,14 +296,13 @@
     canvas.viewportTransform = [-1, 0, 0, -1, 0, 0];
     canvas.calcViewportBoundaries();
     cObj.canvas = canvas;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.ok(cObj.isOnScreen(), 'object is onScreen');
     cObj.top = 1000;
-    assert.ok(cObj.isOnScreen(), 'object is still wrongly on screen since setCoords is not called and calculate is not set, even when top is already at 1000');
-    cObj.setCoords();
+    assert.ok(cObj.isOnScreen(), 'object is still wrongly on screen since invalidateCoords is not called and calculate is not set, even when top is already at 1000');
+    cObj.invalidateCoords();
     assert.ok(!cObj.isOnScreen(), 'object is not onScreen with top 1000');
     canvas.setZoom(0.1);
-    cObj.setCoords();
     assert.ok(cObj.isOnScreen(), 'zooming out the object is again on screen');
   });
 
@@ -361,11 +342,11 @@
     canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
     canvas.calcViewportBoundaries();
     cObj.canvas = canvas;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.equal(cObj.isOnScreen(), true, 'object is onScreen because it include the canvas');
     cObj.top = -1000;
     cObj.left = -1000;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.equal(cObj.isOnScreen(), false, 'object is completely out of viewport');
   });
 
@@ -374,11 +355,11 @@
     canvas.viewportTransform = [1, 0, 0, 1, 0, 0];
     canvas.calcViewportBoundaries();
     cObj.canvas = canvas;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.ok(cObj.isOnScreen(), 'object is onScreen because it intersect a canvas line');
     cObj.top -= 20;
     cObj.left -= 20;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.ok(!cObj.isOnScreen(), 'object is completely out of viewport');
   });
 
@@ -486,7 +467,6 @@
     var cObj = new fabric.Object({ strokeWidth: 0, width: 10, height: 10, top: 6, left: 5 }),
         boundingRect;
 
-    cObj.setCoords();
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left, 5, 'gives the bounding rect left with absolute coords');
     assert.equal(boundingRect.width, 10, 'gives the bounding rect width with absolute coords');
@@ -494,7 +474,7 @@
     cObj.canvas = {
        viewportTransform: [2, 0, 0, 2, 0, 0]
     };
-    cObj.setCoords();
+    cObj.invalidateCoords();
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left, 5, 'gives the bounding rect left with absolute coords, regardless of vpt');
     assert.equal(boundingRect.width, 10, 'gives the bounding rect width with absolute coords, regardless of vpt');
@@ -506,13 +486,12 @@
         boundingRect;
     assert.ok(typeof cObj.getBoundingRect === 'function');
 
-    cObj.setCoords();
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left, 0);
     assert.equal(boundingRect.top, 0);
     assert.equal(boundingRect.width, 0);
     assert.equal(boundingRect.height, 0);
-    cObj.set('width', 123).setCoords();
+    cObj.set('width', 123);
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left, 0);
     assert.equal(boundingRect.top, 0);
@@ -520,7 +499,6 @@
     assert.equal(boundingRect.height, 0);
 
     cObj.set('height', 167);
-    cObj.setCoords();
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left, 0);
     assert.equal(Math.abs(boundingRect.top).toFixed(13), 0);
@@ -528,7 +506,6 @@
     assert.equal(boundingRect.height, 167);
 
     cObj.scale(2)
-    cObj.setCoords();
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left, 0);
     assert.equal(Math.abs(boundingRect.top).toFixed(13), 0);
@@ -541,31 +518,27 @@
         boundingRect;
     assert.ok(typeof cObj.getBoundingRect === 'function');
 
-    cObj.setCoords();
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left.toFixed(2), 0);
     assert.equal(boundingRect.top.toFixed(2), 0);
     assert.equal(boundingRect.width.toFixed(2), 1);
     assert.equal(boundingRect.height.toFixed(2), 1);
 
-    cObj.set('width', 123)
-    cObj.setCoords();
+    cObj.set('width', 123);
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left.toFixed(2), 0);
     assert.equal(boundingRect.top.toFixed(2), 0);
     assert.equal(boundingRect.width.toFixed(2), 124);
     assert.equal(boundingRect.height.toFixed(2), 1);
 
-    cObj.set('height', 167)
-    cObj.setCoords();
+    cObj.set('height', 167);
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left.toFixed(2), 0);
     assert.equal(boundingRect.top.toFixed(2), 0);
     assert.equal(boundingRect.width.toFixed(2), 124);
     assert.equal(boundingRect.height.toFixed(2), 168);
 
-    cObj.scale(2)
-    cObj.setCoords();
+    cObj.scale(2);
     boundingRect = cObj.getBoundingRect();
     assert.equal(boundingRect.left.toFixed(2), 0);
     assert.equal(boundingRect.top.toFixed(2), 0);
@@ -625,7 +598,7 @@
     assert.deepEqual(coords[2], new fabric.Point(52, 47), 'return bottom right corner cached aCoords');
     assert.deepEqual(coords[3], new fabric.Point(40, 47), 'return bottom left corner cached aCoords');
 
-    cObj.setCoords();
+    cObj.invalidateCoords();
     coords = cObj.getCoords();
     assert.deepEqual(coords[0], new fabric.Point(45, 30), 'return top left corner recalculated');
     assert.deepEqual(coords[1], new fabric.Point(57, 30), 'return top right corner recalculated');
@@ -720,15 +693,15 @@
     cObj.canvas = canvas;
     cObj.left = -60;
     cObj.top = -60;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.equal(cObj.isPartiallyOnScreen(true), true,'object is partially onScreen');
     cObj.left = -110;
     cObj.top = -110;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.equal(cObj.isPartiallyOnScreen(true), false,'object is completely offScreen and not partial');
     cObj.left = 45;
     cObj.top = 45;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.equal(cObj.isPartiallyOnScreen(true), false, 'object is completely on screen and not partial');
     canvas.setZoom(2);
     assert.equal(cObj.isPartiallyOnScreen(true), true, 'after zooming object is partially onScreen and offScreen');
@@ -743,7 +716,7 @@
     cObj.top = -20;
     cObj.scaleX = 2;
     cObj.scaleY = 2;
-    cObj.setCoords();
+    cObj.invalidateCoords();
     assert.equal(cObj.isPartiallyOnScreen(true), true, 'object has all corners outside screen but contains canvas');
   });
 })();

--- a/test/unit/textbox.js
+++ b/test/unit/textbox.js
@@ -313,10 +313,9 @@
     var text = new fabric.Textbox('xa xb xc xd xe ya yb id', { strokeWidth: 0 });
     canvas.add(text);
     canvas.setActiveObject(text);
-    var canvasEl = canvas.getElement();
     var eventStub = {
       clientX: text.width,
-      clientY: text.oCoords.mr.corner.tl.y + 1,
+      clientY: text.getControlCoords().mr.corner.tl.y + 1,
       type: 'mousedown',
       target: canvas.upperCanvasEl
     };
@@ -343,7 +342,7 @@
     var canvasEl = canvas.getElement();
     var eventStub = {
       clientX: text.left,
-      clientY: text.oCoords.ml.corner.tl.y + 2,
+      clientY: text.getControlCoords().ml.corner.tl.y + 2,
       type: 'mousedown',
       target: canvas.upperCanvasEl
     };
@@ -489,7 +488,7 @@
     var text = 'aaa aaq ggg gg oee eee';
     var styles = {};
     for (var index = 0; index < text.length; index++) {
-      styles[index] = { fontSize: 4 };      
+      styles[index] = { fontSize: 4 };
     }
     var textbox = new fabric.Textbox(text, {
       styles: { 0: styles },

--- a/test/visual/group_layout.js
+++ b/test/visual/group_layout.js
@@ -172,7 +172,6 @@
             [rect3, rect4],
             { scaleX: 0.5, scaleY: 0.5, top: 100, left: 0 });
         group3.subTargetCheck = true;
-        group3.setCoords();
         var rect1 = new fabric.Rect({
             width: 100,
             height: 100,


### PR DESCRIPTION
## Description

A partial of #9550

After removing lineCoords we have 2 sets of coords
Corner coords (`aCoords`) used for object geometry (`isOnScreen`, intersection etc.) that belong to the parent plane, `getCoords` returning them in the scene plane.
Control coords (`oCoords`) used for control rendering/hit detection that belong to the viewport plane.

This distinction is very important and useful.
It means that viewport changes do not affect corner coords. 
Also since they belong to the parent plane they need to be recalculated only if the object itself changes its own transform/size. This means that if an ancestor changes transform we do not need to recalculate the corner coords.
Since control coords exist only on the active object it seems important to separate use cases of `setCoords` to reduce computation.

I have found that fabric used to call `setCoords` before drawing the controls (at the end of the rendering cycle) instead of after a transform action. This led to a stale coords state between the 2 calls affecting apps using corner controls in the rendering cycle. It was always a frame behind. This is fixed now.

Looking into `setCoords` in general it seems we should decide when they are first set. It is ambiguous.
Does it happen when an object mounts the canvas? What about an object added to a group? We can check if the group has a canvas set, therefore it is mounted , therefore `setCoords` should be called.
It also means that object geometry should not be used until an object is mounted.

With this in mind and with the existing nested setCoords logic needing a refactor/solution I've introduced an `invalidateCoords` concept that effectively replaces the need to call `setCoords`.
I had to solve the nested set coords calls somehow and this seemed the right and simple solution.
I used the existing logic from `calcACoords` that calculates `aCoords` if they are `undefined` so
`invalidateCoords` deletes `aCoords`/`oCoords` and they will be recalculated when requested by `getCoords`/`getControlCoords`.

I think this is great DX and is good for perf because the coords will not be calculated until they are actually needed (consider a case where geometry is not used at all, including `skipOffscreen` - there is no need for aCoords and there are other cases that are solved with this approach) and most importantly nothing is breaking.





## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
