### PR TITLE
feat(Group): make `interactive` > `subTargetCheck` 

### DIFF
--- a/.codesandbox/templates/vanilla/src/testcases/nestedSelections.ts
+++ b/.codesandbox/templates/vanilla/src/testcases/nestedSelections.ts
@@ -22,7 +22,6 @@ export function testCase(canvas: fabric.Canvas, objectCaching = true) {
     ],
     {
       backgroundColor: 'blue',
-      subTargetCheck: true,
       interactive: true,
       objectCaching,
     }

--- a/e2e/tests/controls/hit-regions/index.ts
+++ b/e2e/tests/controls/hit-regions/index.ts
@@ -29,7 +29,6 @@ beforeAll((canvas) => {
     angle: 30,
     scaleX: 2,
     interactive: true,
-    subTargetCheck: true,
   });
   canvas.add(group);
   canvas.centerObject(group);

--- a/e2e/tests/selection/multi-selection-in-groups/index.ts
+++ b/e2e/tests/selection/multi-selection-in-groups/index.ts
@@ -24,7 +24,6 @@ beforeAll(async (canvas) => {
     ],
     {
       backgroundColor: 'blue',
-      subTargetCheck: true,
       interactive: true,
     }
   );

--- a/src/LayoutManager/ActiveSelectionLayoutManager.spec.ts
+++ b/src/LayoutManager/ActiveSelectionLayoutManager.spec.ts
@@ -23,7 +23,6 @@ describe('ActiveSelectionLayoutManager', () => {
         const object = new FabricObject();
         const group = new Group([object], {
           interactive: true,
-          subTargetCheck: true,
         });
         const as = new ActiveSelection([object], { layoutManager: manager });
         const objectOn = jest.spyOn(object, 'on');
@@ -46,11 +45,9 @@ describe('ActiveSelectionLayoutManager', () => {
         const object4 = new FabricObject();
         const group = new Group([object, object2], {
           interactive: true,
-          subTargetCheck: true,
         });
         const group2 = new Group([object3, object4], {
           interactive: true,
-          subTargetCheck: true,
         });
         const as = new ActiveSelection([object, object2, object3, object4]);
         const asPerformLayout = jest.spyOn(as.layoutManager, 'performLayout');

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -1343,7 +1343,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     if (!corner) {
       // hoverCursor should come from top-most subTarget
       const subTargetHoverCursor =
-        (target as Group).subTargetCheck &&
+        ((target as Group).subTargetCheck || (target as Group).interactive) &&
         this.targets.find((target) => target.hoverCursor)?.hoverCursor;
       this.setCursor(
         subTargetHoverCursor || target.hoverCursor || this.hoverCursor

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -836,7 +836,10 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
     while (i--) {
       const target = objects[i];
       if (this._checkTarget(target, pointer)) {
-        if (isCollection(target) && target.subTargetCheck) {
+        if (
+          isCollection(target) &&
+          (target.subTargetCheck || target.interactive)
+        ) {
           const subTarget = this._searchPossibleTargets(
             target._objects as FabricObject[],
             pointer

--- a/src/canvas/__tests__/eventData.test.ts
+++ b/src/canvas/__tests__/eventData.test.ts
@@ -144,7 +144,6 @@ describe('Event targets', () => {
   it('A selected subtarget should not fire an event twice', () => {
     const target = new FabricObject();
     const group = new Group([target], {
-      subTargetCheck: true,
       interactive: true,
     });
     const canvas = new Canvas();
@@ -296,7 +295,6 @@ describe('Event targets', () => {
       (searchAll) => {
         const subTarget1 = new FabricObject();
         const target1 = new Group([subTarget1], {
-          subTargetCheck: true,
           interactive: true,
         });
         const subTarget2 = new FabricObject();
@@ -304,7 +302,6 @@ describe('Event targets', () => {
           subTargetCheck: true,
         });
         const parent = new Group([target1, target2], {
-          subTargetCheck: true,
           interactive: true,
         });
         registerTestObjects({
@@ -336,7 +333,6 @@ describe('Event targets', () => {
         subTargetCheck: true,
       });
       const parent = new Group([target], {
-        subTargetCheck: true,
         interactive: true,
       });
       registerTestObjects({ subTarget, target, parent });

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -91,7 +91,6 @@ export class Group
   /**
    * Used to allow targeting of object inside groups.
    * set to true if you want to select an object inside a group.\
-   * **REQUIRES** `subTargetCheck` set to true
    * This will be not removed but slowly replaced with a method setInteractive
    * that will take care of enabling subTargetCheck and necessary object events.
    * There is too much attached to group interactivity to just be evaluated by a

--- a/src/shapes/Object/InteractiveObject.spec.ts
+++ b/src/shapes/Object/InteractiveObject.spec.ts
@@ -32,7 +32,6 @@ describe('InteractiveObject', () => {
         angle: 30,
         scaleX: 2,
         interactive: true,
-        subTargetCheck: true,
       });
       canvas.add(group);
       const objectAngle = Math.round(object.getTotalAngle());


### PR DESCRIPTION
completes #9550

This PR makes 
```
new Group(object, { interactive: true })
// eq to
new Group(object, { interactive: true, subTargetCheck: true })
```

To be able to select sub targets both need to be flagged as true.
`subTargetCheck` flags `searchPossibleTargets` to traverse the children of a group.
`interactive` flags to return the top most sub target found within `searchPossibleTargets`.
So essentially `interactive = true` contains `subTargetCheck = true`. 
It is more straight forward and better DX.
I would like this to be part of v6.
