### PR TITLE
Fix jumping issue when scaling and not centered on the control

### DIFF
--- a/src/controls/scale.ts
+++ b/src/controls/scale.ts
@@ -18,10 +18,16 @@ import {
 import { wrapWithFireEvent } from './wrapWithFireEvent';
 import { wrapWithFixedAnchor } from './wrapWithFixedAnchor';
 
+type controlOffset = {
+  x: number;
+  y: number;	
+}
+
 type ScaleTransform = Transform & {
   gestureScale?: number;
   signX?: number;
   signY?: number;
+  controlOffset?: controlOffset;  
 };
 
 type ScaleBy = TAxis | 'equally' | '' | undefined;
@@ -171,6 +177,16 @@ function scaleObject(
     }
 
     dim = target._getTransformedDimensions();
+
+    // Adjust control offsets. Fixes jumping problem in scaling when hitting a control while not being centered on it.
+    if (!transform.controlOffset) {
+      // need to determine if this is a ALT Action, multiply newPoints by 2 if it is.
+      let multi = isTransformCentered(transform) ? 2 : 1
+      transform.controlOffset = { x: dim.x - Math.abs(newPoint.x * multi), y: dim.y - Math.abs(newPoint.y * multi) }
+    }
+    dim.x -= transform.controlOffset.x
+    dim.y -= transform.controlOffset.y
+
     // missing detection of flip and logic to switch the origin
     if (scaleProportionally && !by) {
       // uniform scaling

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -161,6 +161,20 @@ export class IText<
    * @default
    */
   declare editingBorderColor: string;
+  
+  /**
+   * Type of mouse action, char (single click), word (double click), line (triple click)
+   * @type String
+   * @default
+   */  
+  declare selector: string;
+  
+  /**
+   * Store start and end points of selection
+   * @type Array
+   * @default
+   */
+  declare selectBounds: number[];
 
   /**
    * Width of cursor (in px)

--- a/src/shapes/IText/ITextBehavior.ts
+++ b/src/shapes/IText/ITextBehavior.ts
@@ -151,7 +151,7 @@ export abstract class ITextBehavior<
 
   private _tick(delay?: number) {
     this._currentTickState = this._animateCursor({
-      toValue: 1,
+      toValue: 0,
       duration: this.cursorDuration,
       delay,
       onComplete: this._onTickComplete,
@@ -161,7 +161,7 @@ export abstract class ITextBehavior<
   private _onTickComplete() {
     this._currentTickCompleteState?.abort();
     this._currentTickCompleteState = this._animateCursor({
-      toValue: 0,
+      toValue: 1,
       duration: this.cursorDuration / 2,
       delay: 100,
       onComplete: this._tick,


### PR DESCRIPTION
When scaling from any one of tl, tr, br, bl, ml, mt, mr or mb controls and you are not 100% centered on it you will get a jump effect. This commit helps to fix that by adjusting the starting position by the offset amount when dragging a scale control.

This is most noticeable when using larger controls. Works in both ALT and non ALT modes. On Desktop and Mobile.

Rotate and Move are not affected.
