### PR TITLE
fix(): Replace 'hasOwn' with 'in' operator in typeAssertions check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [next]
+
+- fix(): Replace 'hasOwn' with 'in' operator in typeAssertions check [#9812](https://github.com/fabricjs/fabric.js/pull/9812)
+
 ## [6.0.0-rc1]
 
 - fix(Canvas): Fix searchPossibleTargets for non-interactive nested targets [#9762](https://github.com/fabricjs/fabric.js/pull/9762)

--- a/src/util/typeAssertions.ts
+++ b/src/util/typeAssertions.ts
@@ -19,9 +19,7 @@ export const isSerializableFiller = (
 
 export const isPattern = (filler: TFiller): filler is Pattern => {
   return (
-    !!filler &&
-    (filler as Pattern).offsetX !== undefined &&
-    Object.hasOwn(filler, 'source')
+    !!filler && (filler as Pattern).offsetX !== undefined && 'source' in filler
   );
 };
 
@@ -46,4 +44,4 @@ export const isPath = (fabricObject?: FabricObject): fabricObject is Path => {
 export const isActiveSelection = (
   fabricObject?: FabricObject
 ): fabricObject is ActiveSelection =>
-  !!fabricObject && Object.hasOwn(fabricObject, 'multiSelectionStacking');
+  !!fabricObject && 'multiSelectionStacking' in fabricObject;


### PR DESCRIPTION
`Object.hasOwn` is a relatively-recent API so it should not be used. Indeed I noticed this by looking at our production exceptions. I've replaced the usage with just `in` operator, which for some reason makes TS happier than `obj.hasOwnProperty()`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn