### PR TITLE
fix(Canvas): mouse move before event data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Canvas): mouse move before event data [#9849](https://github.com/fabricjs/fabric.js/pull/9849)
 - chore(FabricObject): pass `e` to `shouldStartDragging` [#9843](https://github.com/fabricjs/fabric.js/pull/9843)
 - ci(): Add Jest coverage to the report [#9836](https://github.com/fabricjs/fabric.js/pull/9836)
 - test(): Add cursor animation testing and migrate some easy one to jest [#9829](https://github.com/fabricjs/fabric.js/pull/9829)

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -1117,8 +1117,8 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
    */
   __onMouseMove(e: TPointerEvent) {
     this._isClick = false;
-    this._handleEvent(e, 'move:before');
     this._cacheTransformEventData(e);
+    this._handleEvent(e, 'move:before');
 
     if (this.isDrawingMode) {
       this._onMouseMoveInDrawingMode(e);

--- a/src/canvas/__tests__/__snapshots__/eventData.test.ts.snap
+++ b/src/canvas/__tests__/__snapshots__/eventData.test.ts.snap
@@ -703,6 +703,33 @@ exports[`Canvas event data HTML event "wheel" should fire a corresponding canvas
 exports[`Event targets should fire mouse over/out events on target 1`] = `
 [
   [
+    "mousemove:before",
+    {
+      "absolutePointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "e": MouseEvent {
+        "isTrusted": false,
+      },
+      "pointer": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "scenePoint": Point {
+        "x": 5,
+        "y": 5,
+      },
+      "subTargets": [],
+      "target": "target",
+      "transform": null,
+      "viewportPoint": Point {
+        "x": 5,
+        "y": 5,
+      },
+    },
+  ],
+  [
     "mouseover",
     {
       "absolutePointer": Point {
@@ -805,7 +832,7 @@ exports[`Event targets should fire mouse over/out events on target 2`] = `
         "y": 5,
       },
       "subTargets": [],
-      "target": undefined,
+      "target": "target",
       "transform": null,
       "viewportPoint": Point {
         "x": 5,


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

Mouse move before is fired before the event data is cached, meaning before findTarget is called. This makes the event data wrong because it is always empty.
Mouse down/up do not do that so it is clearly a bug

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
