### PR TITLE
perf(composeMatrix): 25% improv by restoring v5 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(util): restore old composeMatrix code for performances improvement [#9851](https://github.com/fabricjs/fabric.js/pull/9851)
 - feat(IText): Adjust cursor blinking for better feedback [#9823](https://github.com/fabricjs/fabric.js/pull/9823)
 - feat(FabricObject): pass `e` to `shouldStartDragging` [#9843](https://github.com/fabricjs/fabric.js/pull/9843)
 - fix(Canvas): mouse move before event data [#9849](https://github.com/fabricjs/fabric.js/pull/9849)

--- a/src/benchmarks/calcTransformMatrix.mjs
+++ b/src/benchmarks/calcTransformMatrix.mjs
@@ -1,0 +1,98 @@
+import { util } from '../../dist/index.mjs';
+
+// perf(composeMatrix): 25% improv by restoring v5 implementation #9851
+
+// OLD CODE FOR REFERENCE AND IMPLEMENTATION TEST
+
+const util2 = { ...util };
+
+util2.calcDimensionsMatrix = ({
+  scaleX = 1,
+  scaleY = 1,
+  flipX = false,
+  flipY = false,
+  skewX = 0,
+  skewY = 0,
+}) => {
+  return util2.multiplyTransformMatrixArray(
+    [
+      util2.createScaleMatrix(
+        flipX ? -scaleX : scaleX,
+        flipY ? -scaleY : scaleY
+      ),
+      skewX && util2.createSkewXMatrix(skewX),
+      skewY && util2.createSkewYMatrix(skewY),
+    ],
+    true
+  );
+};
+
+util2.composeMatrix = ({
+  translateX = 0,
+  translateY = 0,
+  angle = 0,
+  ...otherOptions
+}) => {
+  return util2.multiplyTransformMatrixArray([
+    util2.createTranslateMatrix(translateX, translateY),
+    angle && util2.createRotateMatrix({ angle }),
+    util2.calcDimensionsMatrix(otherOptions),
+  ]);
+};
+
+// END OF OLD CODE
+
+const benchmark = (callback) => {
+  const start = Date.now();
+  callback();
+  return Date.now() - start;
+};
+
+const optionsComplex = {
+  skewY: 10,
+  skewX: 4,
+  scaleX: 5,
+  scaleY: 4,
+  angle: 20,
+  flipY: true,
+};
+
+const simpleCase = {
+  scaleX: 5,
+  scaleY: 4,
+  angle: 20,
+};
+
+const complexOld = benchmark(() => {
+  for (let i = 0; i < 1_000_000; i++) {
+    util2.composeMatrix(optionsComplex);
+  }
+});
+
+const complexNew = benchmark(() => {
+  for (let i = 0; i < 1_000_000; i++) {
+    util.composeMatrix(optionsComplex);
+  }
+});
+
+console.log({ complexOld, complexNew });
+
+const simpleOld = benchmark(() => {
+  for (let i = 0; i < 1_000_000; i++) {
+    util2.composeMatrix(simpleCase);
+  }
+});
+
+const simpleNew = benchmark(() => {
+  for (let i = 0; i < 1_000_000; i++) {
+    util.composeMatrix(simpleCase);
+  }
+});
+
+console.log({ simpleOld, simpleNew });
+
+/**
+ * On Node 18.17
+ * { complexOld: 749, complexNew: 627 }
+ * { simpleOld: 537, simpleNew: 374 }
+ */

--- a/src/benchmarks/calcTransformMatrix.mjs
+++ b/src/benchmarks/calcTransformMatrix.mjs
@@ -96,3 +96,9 @@ console.log({ simpleOld, simpleNew });
  * { complexOld: 749, complexNew: 627 }
  * { simpleOld: 537, simpleNew: 374 }
  */
+
+/**
+ * After removing the spread operator
+ * { complexOld: 761, complexNew: 446 }
+ * { simpleOld: 526, simpleNew: 271 }
+ */

--- a/src/util/misc/matrix.ts
+++ b/src/util/misc/matrix.ts
@@ -277,25 +277,17 @@ export const calcDimensionsMatrix = ({
   skewX = 0 as TDegree,
   skewY = 0 as TDegree,
 }: TScaleMatrixArgs) => {
-  let scaleMat = createScaleMatrix(
+  let matrix = createScaleMatrix(
     flipX ? -scaleX : scaleX,
     flipY ? -scaleY : scaleY
   );
   if (skewX) {
-    scaleMat = multiplyTransformMatrices(
-      scaleMat,
-      createSkewXMatrix(skewX),
-      true
-    );
+    matrix = multiplyTransformMatrices(matrix, createSkewXMatrix(skewX), true);
   }
   if (skewY) {
-    scaleMat = multiplyTransformMatrices(
-      scaleMat,
-      createSkewXMatrix(skewY),
-      true
-    );
+    matrix = multiplyTransformMatrices(matrix, createSkewXMatrix(skewY), true);
   }
-  return scaleMat;
+  return matrix;
 };
 
 /**

--- a/src/util/misc/matrix.ts
+++ b/src/util/misc/matrix.ts
@@ -277,14 +277,25 @@ export const calcDimensionsMatrix = ({
   skewX = 0 as TDegree,
   skewY = 0 as TDegree,
 }: TScaleMatrixArgs) => {
-  return multiplyTransformMatrixArray(
-    [
-      createScaleMatrix(flipX ? -scaleX : scaleX, flipY ? -scaleY : scaleY),
-      skewX && createSkewXMatrix(skewX),
-      skewY && createSkewYMatrix(skewY),
-    ],
-    true
+  let scaleMat = createScaleMatrix(
+    flipX ? -scaleX : scaleX,
+    flipY ? -scaleY : scaleY
   );
+  if (skewX) {
+    scaleMat = multiplyTransformMatrices(
+      scaleMat,
+      createSkewXMatrix(skewX),
+      true
+    );
+  }
+  if (skewY) {
+    scaleMat = multiplyTransformMatrices(
+      scaleMat,
+      createSkewXMatrix(skewY),
+      true
+    );
+  }
+  return scaleMat;
 };
 
 /**
@@ -309,9 +320,13 @@ export const composeMatrix = ({
   angle = 0 as TDegree,
   ...otherOptions
 }: TComposeMatrixArgs): TMat2D => {
-  return multiplyTransformMatrixArray([
-    createTranslateMatrix(translateX, translateY),
-    angle && createRotateMatrix({ angle }),
-    calcDimensionsMatrix(otherOptions),
-  ]);
+  let matrix = createTranslateMatrix(translateX, translateY);
+  if (angle) {
+    matrix = multiplyTransformMatrices(matrix, createRotateMatrix({ angle }));
+  }
+  const scaleMatrix = calcDimensionsMatrix(otherOptions);
+  if (!isIdentityMatrix(scaleMatrix)) {
+    matrix = multiplyTransformMatrices(matrix, scaleMatrix);
+  }
+  return matrix;
 };

--- a/src/util/misc/matrix.ts
+++ b/src/util/misc/matrix.ts
@@ -294,6 +294,7 @@ export const calcDimensionsMatrix = ({
  * Returns a transform matrix starting from an object of the same kind of
  * the one returned from qrDecompose, useful also if you want to calculate some
  * transformations from an object that is not enlived yet
+ * Before changing this function look at: src/benchmarks/calcTransformMatrix.mjs
  * @param  {Object} options
  * @param  {Number} [options.angle]
  * @param  {Number} [options.scaleX]
@@ -306,17 +307,13 @@ export const calcDimensionsMatrix = ({
  * @param  {Number} [options.translateY]
  * @return {Number[]} transform matrix
  */
-export const composeMatrix = ({
-  translateX = 0,
-  translateY = 0,
-  angle = 0 as TDegree,
-  ...otherOptions
-}: TComposeMatrixArgs): TMat2D => {
+export const composeMatrix = (options: TComposeMatrixArgs): TMat2D => {
+  const { translateX = 0, translateY = 0, angle = 0 as TDegree } = options;
   let matrix = createTranslateMatrix(translateX, translateY);
   if (angle) {
     matrix = multiplyTransformMatrices(matrix, createRotateMatrix({ angle }));
   }
-  const scaleMatrix = calcDimensionsMatrix(otherOptions);
+  const scaleMatrix = calcDimensionsMatrix(options);
   if (!isIdentityMatrix(scaleMatrix)) {
     matrix = multiplyTransformMatrices(matrix, scaleMatrix);
   }

--- a/src/util/misc/matrix.ts
+++ b/src/util/misc/matrix.ts
@@ -285,7 +285,7 @@ export const calcDimensionsMatrix = ({
     matrix = multiplyTransformMatrices(matrix, createSkewXMatrix(skewX), true);
   }
   if (skewY) {
-    matrix = multiplyTransformMatrices(matrix, createSkewXMatrix(skewY), true);
+    matrix = multiplyTransformMatrices(matrix, createSkewYMatrix(skewY), true);
   }
   return matrix;
 };


### PR DESCRIPTION
Based on the findings of https://github.com/fabricjs/canvas-engines-comparison/pull/1 and my own experiments because I'm writing an article about analysing performance (soon to be published 😏), I saw that `composeMatrix` performance can be significantly improved for non-rotated/scaled objects by just returning `createTranslateMatrix(translateX, translateY)`.

Then I remembered that @ShaMan123 mentioned to me that he changed the functions to be more declarative in v6, so I looked back at how it was and noticed indeed that it was more performant before: https://github.com/fabricjs/fabric.js/commit/d0d0cfb157ddc650e17eca2a8f70006f81594906#diff-c771d7d885099c09929056e6d495faa0cd32bd1269dda11623cd1dddf4122b59

Previously we would avoid uselessly multiplying matrixes if not needed. In my tests this simple change can result in ~25% improved performance, without any API change.

You can test it yourself @asturur, I've prepare a benchmark clone to try out changes  https://codesandbox.io/p/sandbox/fabric-bench-forked-4xfvnd. Just change this line in `OptimisedRect#calcOwnMatrix`:

```js
const value = composeMatrix(options);
```

To

```js
const value = fabric.util.composeMatrix(options);
```

The top-right FPS meter is by no means accurate but it's decent indicator of % of improvement. The Chrome Devtools flame chart showed me that `renderCanvas` time changed from 45ms to 35ms for 16k objects, around 28% improvement. Alternatively you can use the Chrome FPS meter. Whatever you use to measure, there's no doubt about the performance change.

You can also try out the other changes yourself, such as removing the cache key completely in `calcOwnMatrix` improves the FPS meter by 50% for 16k objects, 80% for 8k objects. But changing cache key is less trivial so we can discuss that on a separate PR/issue.