### PR TITLE
WIP: Move default values to prototype to resolve v6 performance regression

### DIFF
--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -205,7 +205,7 @@ export class IText<
   static ownDefaults = iTextDefaultValues;
 
   static getDefaults(): Record<string, any> {
-    return { ...super.getDefaults(), ...IText.ownDefaults };
+    return {};
   }
 
   static type = 'IText';
@@ -698,6 +698,8 @@ export class IText<
     super.dispose();
   }
 }
+
+Object.assign(IText.prototype, IText.ownDefaults);
 
 classRegistry.setClass(IText);
 // legacy

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -137,11 +137,7 @@ export class InteractiveFabricObject<
   static ownDefaults = interactiveObjectDefaultValues;
 
   static getDefaults(): Record<string, any> {
-    return {
-      ...super.getDefaults(),
-      controls: createObjectDefaultControls(),
-      ...InteractiveFabricObject.ownDefaults,
-    };
+    return {};
   }
 
   /**
@@ -699,3 +695,5 @@ export class InteractiveFabricObject<
     // for subclasses
   }
 }
+Object.assign(InteractiveFabricObject.prototype, InteractiveFabricObject.ownDefaults);
+Object.assign(InteractiveFabricObject.prototype, {controls: createObjectDefaultControls()});

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -296,7 +296,7 @@ export class FabricObject<
   static ownDefaults = fabricObjectDefaultValues;
 
   static getDefaults(): Record<string, any> {
-    return { ...FabricObject.ownDefaults };
+    return {};
   }
 
   /**
@@ -1629,6 +1629,8 @@ export class FabricObject<
     return this._fromObject(object, options);
   }
 }
+
+Object.assign(FabricObject.prototype, FabricObject.ownDefaults);
 
 classRegistry.setClass(FabricObject);
 classRegistry.setClass(FabricObject, 'object');

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -417,7 +417,7 @@ export class FabricText<
   static type = 'Text';
 
   static getDefaults(): Record<string, any> {
-    return { ...super.getDefaults(), ...FabricText.ownDefaults };
+    return {};
   }
 
   constructor(text: string, options: Props = {} as Props) {
@@ -1914,6 +1914,7 @@ export class FabricText<
   }
 }
 
+Object.assign(FabricText.prototype, FabricText.ownDefaults);
 applyMixins(FabricText, [TextSVGExportMixin]);
 classRegistry.setClass(FabricText);
 classRegistry.setSVGClass(FabricText);


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description
This is currently a proof of concept that should not be merged, but opening for visibility.  

See #9852 for full context.  In short, creating a large number of objects in v6 is significantly slower than doing so in v5.  The root cause is the switch from assigning default values using object prototypes to setting defaults using `getDefaults` and `Object.assign`.

The relevant PR is here: https://github.com/fabricjs/fabric.js/pull/8719
The relevant block of code is here: https://github.com/fabricjs/fabric.js/blob/26ed225b47288f775e598f719e218a660dd58dd0/src/shapes/Object/Object.ts#L285-L288

This PR implements the quick fix described in [this comment](https://github.com/fabricjs/fabric.js/issues/9852#issuecomment-2096055572), which essentially rolls back the change shown above.

1. The `IText.getDefaults` function, and all `getDefaults` functions it calls, are edited to return an empty object.
2. The properties that would have been returned by these `getDefaults` functions are assigned to the object prototypes instead.

This is currently a proof of concept--the final implementation obviously shouldn't have a bunch of `getDefaults` functions that do nothing.

## In Action

The improvement can be confirmed by visiting [this web page](https://scribeocr.github.io/fabric.js-benchmark/) containing a benchmark, and opening up the console (source code [here](https://github.com/scribeocr/fabric.js-benchmark)).  The relevant comparison is `v6` (the master branch) and `v6 edited` (this PR).  On my system the following is printed:

```
Mean time v6: 205.18 ms vs. v6 edited: 138.3 ms.
```

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->


