### PR TITLE
fix(BlendImage): Update Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- docs(): Improve JSDOCs for BlendImage [#9876](https://github.com/fabricjs/fabric.js/pull/9876)
 - fix(Polyline): safeguard points arg from options [#9855](https://github.com/fabricjs/fabric.js/pull/9855)
 - feat(IText): Adjust cursor blinking for better feedback [#9823](https://github.com/fabricjs/fabric.js/pull/9823)
 - feat(FabricObject): pass `e` to `shouldStartDragging` [#9843](https://github.com/fabricjs/fabric.js/pull/9843)

--- a/src/filters/BlendColor.ts
+++ b/src/filters/BlendColor.ts
@@ -33,8 +33,7 @@ export const blendColorDefaultValues: Partial<TClassProperties<BlendColor>> = {
  *
  * const filter = new BlendImage({
  *  image: fabricImageObject,
- *  mode: 'multiply',
- *  alpha: 0.5
+ *  mode: 'multiply'
  * });
  * object.filters.push(filter);
  * object.applyFilters();

--- a/src/filters/BlendImage.ts
+++ b/src/filters/BlendImage.ts
@@ -39,8 +39,7 @@ export const blendImageDefaultValues: Partial<TClassProperties<BlendImage>> = {
  *
  * const filter = new BlendImage({
  *  image: fabricImageObject,
- *  mode: 'multiply',
- *  alpha: 0.5
+ *  mode: 'multiply'
  * });
  * object.filters.push(filter);
  * object.applyFilters();
@@ -48,11 +47,19 @@ export const blendImageDefaultValues: Partial<TClassProperties<BlendImage>> = {
  */
 export class BlendImage extends BaseFilter {
   /**
-   * Color to make the blend operation with. default to a reddish color since black or white
-   * gives always strong result.
+   * Image to make the blend operation with.
    **/
   declare image: FabricImage;
 
+  /**
+   * Blend mode for the filter: either 'multiply' or 'mask'. 'multiply' will
+   * multiply the values of each channel (R, G, B, and A) of the filter image by
+   * their corresponding values in the base image. 'mask' will only look at the
+   * alpha channel of the filter image, and apply those values to the base
+   * image's alpha channel.
+   * @type String
+   * @default
+   **/
   declare mode: TBlendImageMode;
 
   /**


### PR DESCRIPTION


## Description
Updating docs for the BlendImage filter, after finding inconsistencies in [Issue #5797](https://github.com/fabricjs/fabric.js/issues/5797#issuecomment-2102098544) 

- corrected JSDoc comment for BlendImage filter's 'image' property
- added JSDoc comments for BlendImage filter's 'mode' property
- removed 'alpha' from BlendImage filter example in two places. Since the alpha property is not supported, it shouldn't be in the example.