### PR TITLE
fix(Control): corner coords definition order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [next]
-
+- fix(Control): corner coords definition order [#9884](https://github.com/fabricjs/fabric.js/pull/9884)
 - fix(Polyline): safeguard points arg from options [#9855](https://github.com/fabricjs/fabric.js/pull/9855)
 - feat(IText): Adjust cursor blinking for better feedback [#9823](https://github.com/fabricjs/fabric.js/pull/9823)
 - feat(FabricObject): pass `e` to `shouldStartDragging` [#9843](https://github.com/fabricjs/fabric.js/pull/9843)

--- a/src/controls/Control.spec.ts
+++ b/src/controls/Control.spec.ts
@@ -1,4 +1,6 @@
 import { Canvas } from '../canvas/Canvas';
+import { Intersection } from '../Intersection';
+import { Point } from '../Point';
 import { FabricObject } from '../shapes/Object/FabricObject';
 import { Control } from './Control';
 
@@ -46,5 +48,21 @@ describe('Controls', () => {
     expect(mouseDownHandler.mock.contexts).toEqual([control]);
     expect(actionHandler.mock.contexts).toEqual([control]);
     expect(mouseUpHandler.mock.contexts).toEqual([control, control]);
+  });
+
+  test('corners coords definition order', () => {
+    const control = new Control({ sizeX: 20, sizeY: 20 });
+    const coords = control.calcCornerCoords(
+      0,
+      0,
+      10,
+      10,
+      false,
+      new FabricObject()
+    );
+
+    expect(
+      Intersection.isPointInPolygon(new Point(15, 10), Object.values(coords))
+    ).toBe(true);
   });
 });

--- a/src/controls/Control.ts
+++ b/src/controls/Control.ts
@@ -327,8 +327,8 @@ export class Control {
     return {
       tl: new Point(-0.5, -0.5).transform(t),
       tr: new Point(0.5, -0.5).transform(t),
-      bl: new Point(-0.5, 0.5).transform(t),
       br: new Point(0.5, 0.5).transform(t),
+      bl: new Point(-0.5, 0.5).transform(t),
     };
   }
 


### PR DESCRIPTION
`Control.calcCornerCoords` returns corners in an order which make them an incorrect polygon, whereas it should just be a rect. That's because `bl` is defined before `br`.

Since ES2015 object keys are returned in insertion-order by spec (https://stackoverflow.com/a/23202095/6860493) so I believe we should fix this in `calcCornerCoords` instead of manually sorting the coords before calling `Intersection.isPointInPolygon`. That's more convenient and it works correctly out-of-the-box.

If you revert the fix, you'll see the test failing.