### PR TITLE
perf(): Remove redundant matrix multiplication in multiplayTransformMatrixArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- perf(): Remove redundant matrix multiplication in multiplayTransformMatrixArray [#9893](https://github.com/fabricjs/fabric.js/pull/9893)
 - test(): Convert Animation tests to jest [#9892](https://github.com/fabricjs/fabric.js/pull/9892)
 - perf(ObjectGeometry): replace cache key string with array [#9887](https://github.com/fabricjs/fabric.js/pull/9887)
 - docs(): Improve JSDOCs for BlendImage [#9876](https://github.com/fabricjs/fabric.js/pull/9876)

--- a/src/util/misc/matrix.ts
+++ b/src/util/misc/matrix.ts
@@ -99,9 +99,11 @@ export const multiplyTransformMatrixArray = (
 ) =>
   matrices.reduceRight(
     (product: TMat2D, curr) =>
-      curr ? multiplyTransformMatrices(curr, product, is2x2) : product,
-    iMatrix
-  );
+      curr && product
+        ? multiplyTransformMatrices(curr, product, is2x2)
+        : curr || product,
+    undefined as unknown as TMat2D
+  ) || iMatrix.concat();
 
 export const calcPlaneRotation = ([a, b]: TMat2D) =>
   Math.atan2(b, a) as TRadian;


### PR DESCRIPTION
Original code from https://github.com/fabricjs/fabric.js/pull/9860 just reduced from the bare minimum