### PR TITLE
fixed renderControls order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- fix(_renderControls): fixed render order so group controls are rendered over child objects
+- fix(_renderControls): fixed render order so group controls are rendered over child objects [#9914](https://github.com/fabricjs/fabric.js/pull/9914)
 - fix(filters): RemoveColor has missing getFragmentSource method ( typo ) [#9911](https://github.com/fabricjs/fabric.js/pull/9911)
 - types(): Make event type explicit - non generic, and fix pattern fromObject type [#9907](https://github.com/fabricjs/fabric.js/pull/9907)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(_renderControls): fixed render order so group controls are rendered over child objects
 - types(): Make event type explicit - non generic, and fix pattern fromObject type [#9907](https://github.com/fabricjs/fabric.js/pull/9907)
 
 ## [6.0.0-rc2]

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -237,7 +237,6 @@ export class ActiveSelection extends Group {
   ) {
     ctx.save();
     ctx.globalAlpha = this.isMoving ? this.borderOpacityWhenMoving : 1;
-    super._renderControls(ctx, styleOverride);
     const options = {
       hasControls: false,
       ...childrenOverride,
@@ -246,6 +245,7 @@ export class ActiveSelection extends Group {
     for (let i = 0; i < this._objects.length; i++) {
       this._objects[i]._renderControls(ctx, options);
     }
+    super._renderControls(ctx, styleOverride);
     ctx.restore();
   }
 }


### PR DESCRIPTION
Fixed controls render order for ActiveSelection

**Before**
Child controls renders over ActiveSelection
<img width="113" alt="image" src="https://github.com/fabricjs/fabric.js/assets/11871242/ec9cdcbf-972e-4a8b-95a8-1e62fbb05a8b">


**After**
ActiveSelection controls renders over child's
<img width="106" alt="image" src="https://github.com/fabricjs/fabric.js/assets/11871242/ac54f824-22b9-4090-a1a3-c54c118ef9ac">


This is my first contribution to this project, please let me know if I have missed out anything.