### PR TITLE
Add support for decimals in hsla colors and some tests for strings->colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- feat(Color): add support for decimals and different angle types in HSL color parsing [#9915](https://github.com/fabricjs/fabric.js/pull/9915)
 - fix(Controls): add support for numeric origins to changeWidth [#9909](https://github.com/fabricjs/fabric.js/pull/9909)
 - fix(\_renderControls): fixed render order so group controls are rendered over child objects [#9914](https://github.com/fabricjs/fabric.js/pull/9914)
 - fix(filters): RemoveColor has missing getFragmentSource method ( typo ) [#9911](https://github.com/fabricjs/fabric.js/pull/9911)

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -333,7 +333,6 @@ export class Color {
     const numeric = parseFloat(lowercase);
 
     if (lowercase.includes('rad')) {
-      const numeric = parseFloat(lowercase.replace('rad', ''));
       return radiansToDegrees(numeric);
     }
 

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -255,14 +255,13 @@ export class Color {
    * @see http://http://www.w3.org/TR/css3-color/#hsl-color
    */
   static sourceFromHsl(color: string): TRGBAColorSource | undefined {
-    const noNone = color.replaceAll('none', '0');
-    const match = noNone.match(reHSLa());
+    const match = color.match(reHSLa());
     if (!match) {
       return;
     }
     const match1degrees = Color.parseAngletoDegrees(match[1]);
 
-    const h = (((parseFloat(match1degrees) % 360) + 360) % 360) / 360,
+    const h = (((match1degrees % 360) + 360) % 360) / 360,
       s = parseFloat(match[2]) / 100,
       l = parseFloat(match[3]) / 100;
     let r: number, g: number, b: number;
@@ -329,23 +328,20 @@ export class Color {
    * @param {String} value ex: 0deg, 0.5turn, 2rad
    * @return {String} numeric string in degrees, or '0' for improper input
    */
-  static parseAngletoDegrees(value: string): string {
+  static parseAngletoDegrees(value: string): number {
     const lowercase = value.toLowerCase();
-    if (lowercase.indexOf('deg') > -1) {
-      return lowercase.replace('deg', '');
-    }
+    const numeric = parseFloat(lowercase);
 
-    if (lowercase.indexOf('rad') > -1) {
+    if (lowercase.includes('rad')) {
       const numeric = parseFloat(lowercase.replace('rad', ''));
-      return numeric === undefined ? '0' : radiansToDegrees(numeric).toString();
+      return radiansToDegrees(numeric);
     }
 
-    if (lowercase.indexOf('turn') > -1) {
-      const numeric = parseFloat(lowercase.replace('turn', ''));
-      return numeric === undefined ? '0' : (numeric * 360).toString();
+    if (lowercase.includes('turn')) {
+      return numeric * 360;
     }
 
     // Value is probably just a number already in degrees eg '50'
-    return lowercase;
+    return numeric;
   }
 }

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -1,3 +1,4 @@
+import { radiansToDegrees } from '../util/misc/radiansDegreesConversion';
 import { ColorNameMap } from './color_map';
 import { reHSLa, reHex, reRGBa } from './constants';
 import type { TRGBAColorSource, TColorArg } from './typedefs';
@@ -254,12 +255,15 @@ export class Color {
    * @see http://http://www.w3.org/TR/css3-color/#hsl-color
    */
   static sourceFromHsl(color: string): TRGBAColorSource | undefined {
-    const match = color.match(reHSLa());
+    const noNone = color.replaceAll('none', '0');
+    console.log(noNone);
+    const match = noNone.match(reHSLa());
     if (!match) {
       return;
     }
+    const match1degrees = Color.parseAngletoDegrees(match[1]);
 
-    const h = (((parseFloat(match[1]) % 360) + 360) % 360) / 360,
+    const h = (((parseFloat(match1degrees) % 360) + 360) % 360) / 360,
       s = parseFloat(match[2]) / 100,
       l = parseFloat(match[3]) / 100;
     let r: number, g: number, b: number;
@@ -316,5 +320,33 @@ export class Color {
       );
       return [r, g, b, a / 255];
     }
+  }
+
+  /**
+   * Converts a string that could be any angle notation (50deg, 0.5turn, 2rad)
+   * into degrees without the 'deg' suffix
+   * @static
+   * @memberOf Color
+   * @param {String} value ex: 0deg, 0.5turn, 2rad
+   * @return {String} numeric string in degrees, or '0' for improper input
+   */
+  static parseAngletoDegrees(value: string): string {
+    const lowercase = value.toLowerCase();
+    if (lowercase.indexOf('deg') > -1) {
+      return lowercase.replace('deg', '');
+    }
+
+    if (lowercase.indexOf('rad') > -1) {
+      const numeric = parseFloat(lowercase.replace('rad', ''));
+      return numeric === undefined ? '0' : radiansToDegrees(numeric).toString();
+    }
+
+    if (lowercase.indexOf('turn') > -1) {
+      const numeric = parseFloat(lowercase.replace('turn', ''));
+      return numeric === undefined ? '0' : (numeric * 360).toString();
+    }
+
+    // Value is probably just a number already in degrees eg '50'
+    return lowercase;
   }
 }

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -326,7 +326,7 @@ export class Color {
    * @static
    * @memberOf Color
    * @param {String} value ex: 0deg, 0.5turn, 2rad
-   * @return {String} numeric string in degrees, or '0' for improper input
+   * @return {Number} number in degrees or NaN if inputs are invalid
    */
   static parseAngletoDegrees(value: string): number {
     const lowercase = value.toLowerCase();

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -256,7 +256,6 @@ export class Color {
    */
   static sourceFromHsl(color: string): TRGBAColorSource | undefined {
     const noNone = color.replaceAll('none', '0');
-    console.log(noNone);
     const match = noNone.match(reHSLa());
     if (!match) {
       return;

--- a/src/color/color.test.ts
+++ b/src/color/color.test.ts
@@ -1,0 +1,34 @@
+import { Color } from './Color';
+
+describe('Color regex and conversion tests', () => {
+    it('Converts a hsl color to rgba', () => {
+      const color1 = new Color('hsl(120, 100%, 50%)');
+      expect(color1.getSource().toString()).toBe([0, 255, 0, 1].toString());
+    });
+
+    it('Converts a hsl color with minuses and decimals to rgba', () => {
+        const color1 = new Color('hsl(-20, 50.5%, 50%)');
+        expect(color1.getSource().toString()).toBe([192, 63, 106, 1].toString());
+    });
+
+    it('Converts a hsla color with minuses and decimals to rgba', () => {
+        const color1 = new Color('hsla(-20, 50.5%, 50%, 0.4)');
+        expect(color1.getSource().toString()).toBe([192, 63, 106, 0.4].toString());
+    });
+
+    it('Converts a hsla color with minuses and decimals and a % alpha to rgba', () => {
+        const color1 = new Color('hsla(-20, 50.5%, 50%, 25%)');
+        expect(color1.getSource().toString()).toBe([192, 63, 106, 0.25].toString());
+    });
+
+    it('Creates a color from rgba with decimals', () => {
+        const color1 = new Color('rgba(120.1, 60.2, 30.3, 0.5)');
+        expect(color1.getSource().toString()).toBe([120.1, 60.2, 30.3, 0.5].toString());
+    });
+
+    it('Creates a color from rgb with decimals', () => {
+        const color1 = new Color('rgb(120.1, 60.2, 30.3)');
+        expect(color1.getSource().toString()).toBe([120.1, 60.2, 30.3, 1].toString());
+    });
+  
+});

--- a/src/color/color.test.ts
+++ b/src/color/color.test.ts
@@ -1,34 +1,57 @@
 import { Color } from './Color';
 
 describe('Color regex and conversion tests', () => {
-    it('Converts a hsl color to rgba', () => {
-      const color1 = new Color('hsl(120, 100%, 50%)');
-      expect(color1.getSource().toString()).toBe([0, 255, 0, 1].toString());
-    });
+  it('Converts a hsl color to rgba', () => {
+    const color1 = new Color('hsl(120, 100%, 50%)');
+    expect(color1.getSource().toString()).toBe([0, 255, 0, 1].toString());
+  });
 
-    it('Converts a hsl color with minuses and decimals to rgba', () => {
-        const color1 = new Color('hsl(-20, 50.5%, 50%)');
-        expect(color1.getSource().toString()).toBe([192, 63, 106, 1].toString());
-    });
+  it('Converts a hsl color with minuses and decimals to rgba', () => {
+    const color1 = new Color('hsl(-20, 50.5%, 50%)');
+    expect(color1.getSource().toString()).toBe([192, 63, 106, 1].toString());
+  });
 
-    it('Converts a hsla color with minuses and decimals to rgba', () => {
-        const color1 = new Color('hsla(-20, 50.5%, 50%, 0.4)');
-        expect(color1.getSource().toString()).toBe([192, 63, 106, 0.4].toString());
-    });
+  it('Converts a hsla color with minuses and decimals to rgba', () => {
+    const color1 = new Color('hsla(-20, 50.5%, 50%, 0.4)');
+    expect(color1.getSource().toString()).toBe([192, 63, 106, 0.4].toString());
+  });
 
-    it('Converts a hsla color with minuses and decimals and a % alpha to rgba', () => {
-        const color1 = new Color('hsla(-20, 50.5%, 50%, 25%)');
-        expect(color1.getSource().toString()).toBe([192, 63, 106, 0.25].toString());
-    });
+  it('Converts a hsla color with minuses and decimals and a % alpha to rgba', () => {
+    const color1 = new Color('hsla(-20, 50.5%, 50%, 25%)');
+    expect(color1.getSource().toString()).toBe([192, 63, 106, 0.25].toString());
+  });
 
-    it('Creates a color from rgba with decimals', () => {
-        const color1 = new Color('rgba(120.1, 60.2, 30.3, 0.5)');
-        expect(color1.getSource().toString()).toBe([120.1, 60.2, 30.3, 0.5].toString());
-    });
+  it('Converts a hsla color with empty entries to rgba', () => {
+    const color1 = new Color('hsla(none,none,50%,0.5)');
+    expect(color1.getSource().toString()).toBe([128, 128, 128, 0.5].toString());
+  });
 
-    it('Creates a color from rgb with decimals', () => {
-        const color1 = new Color('rgb(120.1, 60.2, 30.3)');
-        expect(color1.getSource().toString()).toBe([120.1, 60.2, 30.3, 1].toString());
-    });
-  
+  it('Converts a hsla color with angle deg to rgba', () => {
+    const color1 = new Color('hsl(120deg,100%,50%)');
+    expect(color1.getSource().toString()).toBe([0, 255, 0, 1].toString());
+  });
+
+  it('Converts a hsla color with angle rad to rgba', () => {
+    const color1 = new Color('hsl(2.0rad, 60%, 60%)');
+    expect(color1.getSource().toString()).toBe([103, 214, 92, 1].toString());
+  });
+
+  it('Converts a hsla color with angle turn to rgba', () => {
+    const color1 = new Color('hsl(0.5turn , 100%, 50%)');
+    expect(color1.getSource().toString()).toBe([0, 255, 255, 1].toString());
+  });
+
+  it('Creates a color from rgba with decimals', () => {
+    const color1 = new Color('rgba(120.1, 60.2, 30.3, 0.5)');
+    expect(color1.getSource().toString()).toBe(
+      [120.1, 60.2, 30.3, 0.5].toString()
+    );
+  });
+
+  it('Creates a color from rgb with decimals', () => {
+    const color1 = new Color('rgb(120.1, 60.2, 30.3)');
+    expect(color1.getSource().toString()).toBe(
+      [120.1, 60.2, 30.3, 1].toString()
+    );
+  });
 });

--- a/src/color/color.test.ts
+++ b/src/color/color.test.ts
@@ -21,11 +21,6 @@ describe('Color regex and conversion tests', () => {
     expect(color1.getSource().toString()).toBe([192, 63, 106, 0.25].toString());
   });
 
-  it('Converts a hsla color with empty entries to rgba', () => {
-    const color1 = new Color('hsla(none,none,50%,0.5)');
-    expect(color1.getSource().toString()).toBe([128, 128, 128, 0.5].toString());
-  });
-
   it('Converts a hsla color with angle deg to rgba', () => {
     const color1 = new Color('hsl(120deg,100%,50%)');
     expect(color1.getSource().toString()).toBe([0, 255, 0, 1].toString());

--- a/src/color/constants.ts
+++ b/src/color/constants.ts
@@ -75,15 +75,22 @@ export const reRGBa = () =>
  *
  * /^hsla?\(         // Matches the beginning of the string and the opening parenthesis of "hsl" or "hsla"
  * \s*               // Matches any whitespace characters (space, tab, etc.) zero or more times
- * ([\d\.]+)         // Hue: Matches one or more digits with decimal and captures it in a group
+ * (\d{0,3}          // Hue: 0 to three digits - start capture in a group
+ * (?:\.\d+)?        // Hue: Optional (non capture group) decimal with one or more digits.
+ * (?:deg|turn|rad)? // Hue: Optionally include suffix deg or turn or rad
+ * )                 // Hue: End capture group
  * \s*               // Matches any whitespace characters zero or more times
  * [\s|,]            // Matches a space, tab or comma
  * \s*               // Matches any whitespace characters zero or more times
- * ([\d\.]+%)        // Saturation: Matches digits/decimal followed by a percentage sign and captures it in a group
+ * (\d{0,3}          // Saturation: 0 to three digits - start capture in a group
+ * (?:\.\d+)?        // Saturation: Optional decimal with one or more digits in a non-capturing group
+ * %?)               // Saturation: match optional % character and end capture group
  * \s*               // Matches any whitespace characters zero or more times
  * [\s|,]            // Matches a space, tab or comma
  * \s*               // Matches any whitespace characters zero or more times
- * ([\d\.]+%)        // Lightness: Matches digits or decimal followed by a percentage sign and captures it in a group
+ * (\d{0,3}          // Lightness: 0 to three digits - start capture in a group
+ * (?:\.\d+)?        // Lightness: Optional decimal with one or more digits in a non-capturing group
+ * %?)                // Lightness: match % character and end capture group
  * \s*               // Matches any whitespace characters zero or more times
  * (?:               // Alpha: Begins a non-capturing group for the alpha value
  *   \s*             // Matches any whitespace characters zero or more times
@@ -99,7 +106,7 @@ export const reRGBa = () =>
  * So the spec does not allow `hsl(30 , 45%  35, 49%)` but this will work anyways for us.
  */
 export const reHSLa = () =>
-  /^hsla?\(\s*([+-]?[\d\.]+)\s*[\s|,]\s*([\d\.]+%)\s*[\s|,]\s*([\d\.]+%)\s*(?:\s*[,/]\s*(\d*(?:\.\d+)?%?)\s*)?\)$/i;
+  /^hsla?\(\s*([+-]?\d{0,3}(?:\.\d+)?(?:deg|turn|rad)?)\s*[\s|,]\s*(\d{0,3}(?:\.\d+)?%?)\s*[\s|,]\s*(\d{0,3}(?:\.\d+)?%?)\s*(?:\s*[,/]\s*(\d*(?:\.\d+)?%?)\s*)?\)$/i;
 
 /**
  * Regex matching color in HEX format (ex: #FF5544CC, #FF5555, 010155, aff)

--- a/src/color/constants.ts
+++ b/src/color/constants.ts
@@ -75,15 +75,15 @@ export const reRGBa = () =>
  *
  * /^hsla?\(         // Matches the beginning of the string and the opening parenthesis of "hsl" or "hsla"
  * \s*               // Matches any whitespace characters (space, tab, etc.) zero or more times
- * (\d{1,3})         // Hue: Matches one to three digits and captures it in a group
+ * ([\d\.]+)         // Hue: Matches one or more digits with decimal and captures it in a group
  * \s*               // Matches any whitespace characters zero or more times
  * [\s|,]            // Matches a space, tab or comma
  * \s*               // Matches any whitespace characters zero or more times
- * (\d{1,3}%)        // Saturation: Matches one to three digits followed by a percentage sign and captures it in a group
+ * ([\d\.]+%)        // Saturation: Matches digits/decimal followed by a percentage sign and captures it in a group
  * \s*               // Matches any whitespace characters zero or more times
  * [\s|,]            // Matches a space, tab or comma
  * \s*               // Matches any whitespace characters zero or more times
- * (\d{1,3}%)        // Lightness: Matches one to three digits followed by a percentage sign and captures it in a group
+ * ([\d\.]+%)        // Lightness: Matches digits or decimal followed by a percentage sign and captures it in a group
  * \s*               // Matches any whitespace characters zero or more times
  * (?:               // Alpha: Begins a non-capturing group for the alpha value
  *   \s*             // Matches any whitespace characters zero or more times
@@ -99,7 +99,7 @@ export const reRGBa = () =>
  * So the spec does not allow `hsl(30 , 45%  35, 49%)` but this will work anyways for us.
  */
 export const reHSLa = () =>
-  /^hsla?\(\s*([+-]?\d{1,3})\s*[\s|,]\s*(\d{1,3}%)\s*[\s|,]\s*(\d{1,3}%)\s*(?:\s*[,/]\s*(\d*(?:\.\d+)?%?)\s*)?\)$/i;
+  /^hsla?\(\s*([+-]?[\d\.]+)\s*[\s|,]\s*([\d\.]+%)\s*[\s|,]\s*([\d\.]+%)\s*(?:\s*[,/]\s*(\d*(?:\.\d+)?%?)\s*)?\)$/i;
 
 /**
  * Regex matching color in HEX format (ex: #FF5544CC, #FF5555, 010155, aff)


### PR DESCRIPTION
I have added support for numerals with decimal places when parsing hsla colors.

These can appear in svg files especially, they are otherwise rendered black.

I also added some jest tests to support this.

Thanks !
