### PR TITLE
Removing mainParameter and defaults from filters for better TS support

### DIFF
--- a/src/filters/BaseFilter.ts
+++ b/src/filters/BaseFilter.ts
@@ -37,21 +37,11 @@ export class BaseFilter {
    */
   static type = 'BaseFilter';
 
-  declare static defaults: Record<string, any>;
-
   /**
    * Array of attributes to send with buffers. do not modify
    * @private
    */
   vertexSource = vertexSource;
-
-  /**
-   * Name of the parameter that can be changed in the filter.
-   * Some filters have more than one parameter and there is no
-   * mainParameter
-   * @private
-   */
-  declare mainParameter?: keyof this | undefined;
 
   /**
    * Constructor
@@ -60,7 +50,6 @@ export class BaseFilter {
   constructor({ type, ...options }: Record<string, any> = {}) {
     Object.assign(
       this,
-      (this.constructor as typeof BaseFilter).defaults,
       options
     );
   }
@@ -233,22 +222,7 @@ export class BaseFilter {
    **/
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   isNeutralState(options?: any): boolean {
-    const main = this.mainParameter,
-      defaultValue = (this.constructor as typeof BaseFilter).defaults[
-        main as string
-      ];
-    if (main) {
-      const thisValue = this[main];
-      if (Array.isArray(defaultValue) && Array.isArray(thisValue)) {
-        return defaultValue.every(
-          (value: any, i: number) => value === thisValue[i]
-        );
-      } else {
-        return defaultValue === thisValue;
-      }
-    } else {
-      return false;
-    }
+    return false;
   }
 
   /**
@@ -350,16 +324,6 @@ export class BaseFilter {
     gl.activeTexture(gl.TEXTURE0);
   }
 
-  getMainParameter() {
-    return this.mainParameter ? this[this.mainParameter] : undefined;
-  }
-
-  setMainParameter(value: any) {
-    if (this.mainParameter) {
-      this[this.mainParameter] = value;
-    }
-  }
-
   /**
    * Send uniform data from this filter to its shader program on the GPU.
    *
@@ -393,10 +357,8 @@ export class BaseFilter {
    * @return {Object} Object representation of an instance
    */
   toObject() {
-    const mainP = this.mainParameter;
     return {
       type: this.type,
-      ...(mainP ? { [mainP]: this[mainP] } : {}),
     };
   }
 

--- a/src/filters/Blur.ts
+++ b/src/filters/Blur.ts
@@ -1,4 +1,3 @@
-import type { TClassProperties } from '../typedefs';
 import { createCanvasElement } from '../util/misc/dom';
 import { BaseFilter } from './BaseFilter';
 import type {
@@ -10,10 +9,7 @@ import { isWebGLPipelineState } from './utils';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/blur';
 
-export const blurDefaultValues: Partial<TClassProperties<Blur>> = {
-  blur: 0,
-  mainParameter: 'blur',
-};
+const defaultBlurValue = 0;
 
 /**
  * Blur filter class
@@ -33,14 +29,12 @@ export class Blur extends BaseFilter {
    * @type Number
    * @default
    */
-  declare blur: number;
+  public blur: number = defaultBlurValue;
 
   declare horizontal: boolean;
   declare aspectRatio: number;
 
   static type = 'Blur';
-
-  static defaults = blurDefaultValues;
 
   getFragmentSource(): string {
     return fragmentSource;
@@ -133,6 +127,17 @@ export class Blur extends BaseFilter {
   ): TWebGLUniformLocationMap {
     return {
       delta: gl.getUniformLocation(program, 'uDelta'),
+    };
+  }
+
+  isNeutralState(): boolean {
+    return this.blur === defaultBlurValue;
+  }
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      blur: this.blur
     };
   }
 

--- a/src/filters/Boilerplate.ts
+++ b/src/filters/Boilerplate.ts
@@ -1,11 +1,7 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 
-export const myFilterDefaultValues: Partial<TClassProperties<MyFilter>> = {
-  myParameter: 0,
-  mainParameter: 'myParameter',
-};
+const defaultMyParameterValue = 0;
 
 /**
  * MyFilter filter class
@@ -24,9 +20,7 @@ export class MyFilter extends BaseFilter {
    * @param {Number} myParameter
    * @default
    */
-  declare myParameter: number;
-
-  static defaults = myFilterDefaultValues;
+  public myParameter = defaultMyParameterValue;
 
   getFragmentSource() {
     return `
@@ -41,6 +35,7 @@ export class MyFilter extends BaseFilter {
         }
       `;
   }
+
   /**
    * Apply the MyFilter operation to a Uint8ClampedArray representing the pixels of an image.
    *
@@ -69,7 +64,18 @@ export class MyFilter extends BaseFilter {
     program: WebGLProgram
   ): TWebGLUniformLocationMap {
     return {
-      uMyParameter: gl.getUniformLocation(program, 'uMyParameter'),
+      uMyParameter: gl.getUniformLocation(program, 'uMyParameter')
+    };
+  }
+
+  isNeutralState(): boolean {
+    return this.myParameter === defaultMyParameterValue;
+  }
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      myParameter: this.myParameter
     };
   }
 

--- a/src/filters/Brightness.ts
+++ b/src/filters/Brightness.ts
@@ -1,12 +1,9 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/brightness';
-export const brightnessDefaultValues: Partial<TClassProperties<Brightness>> = {
-  brightness: 0,
-  mainParameter: 'brightness',
-};
+
+const defaultBrightnessValue = 0;
 
 /**
  * Brightness filter class
@@ -28,8 +25,6 @@ export class Brightness extends BaseFilter {
   declare brightness: number;
 
   static type = 'Brightness';
-
-  static defaults = brightnessDefaultValues;
 
   getFragmentSource() {
     return fragmentSource;
@@ -64,7 +59,18 @@ export class Brightness extends BaseFilter {
     program: WebGLProgram
   ): TWebGLUniformLocationMap {
     return {
-      uBrightness: gl.getUniformLocation(program, 'uBrightness'),
+      uBrightness: gl.getUniformLocation(program, 'uBrightness')
+    };
+  }
+
+  isNeutralState(): boolean {
+    return this.brightness === defaultBrightnessValue;
+  }
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      brightness: this.brightness
     };
   }
 

--- a/src/filters/ColorMatrix.ts
+++ b/src/filters/ColorMatrix.ts
@@ -1,32 +1,26 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/colorMatrix';
-export const colorMatrixDefaultValues: Partial<TClassProperties<ColorMatrix>> =
-  {
-    matrix: [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-    mainParameter: 'matrix',
-    colorsOnly: true,
-  };
 
 /**
-   * Color Matrix filter class
-   * @see {@link http://fabricjs.com/image-filters|ImageFilters demo}
-   * @see {@Link http://phoboslab.org/log/2013/11/fast-image-filters-with-webgl demo}
-   * @example <caption>Kodachrome filter</caption>
-   * const filter = new ColorMatrix({
-   *  matrix: [
-       1.1285582396593525, -0.3967382283601348, -0.03992559172921793, 0, 63.72958762196502,
-       -0.16404339962244616, 1.0835251566291304, -0.05498805115633132, 0, 24.732407896706203,
-       -0.16786010706155763, -0.5603416277695248, 1.6014850761964943, 0, 35.62982807460946,
-       0, 0, 0, 1, 0
-      ]
-   * });
-   * object.filters.push(filter);
-   * object.applyFilters();
-   */
+ * Color Matrix filter class
+ * @see {@link http://fabricjs.com/image-filters|ImageFilters demo}
+ * @see {@Link http://phoboslab.org/log/2013/11/fast-image-filters-with-webgl demo}
+ * @example <caption>Kodachrome filter</caption>
+ * const filter = new ColorMatrix({
+ *  matrix: [
+ 1.1285582396593525, -0.3967382283601348, -0.03992559172921793, 0, 63.72958762196502,
+ -0.16404339962244616, 1.0835251566291304, -0.05498805115633132, 0, 24.732407896706203,
+ -0.16786010706155763, -0.5603416277695248, 1.6014850761964943, 0, 35.62982807460946,
+ 0, 0, 0, 1, 0
+ ]
+ * });
+ * object.filters.push(filter);
+ * object.applyFilters();
+ */
 export class ColorMatrix extends BaseFilter {
+  public defaultMatrixValue = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0];
   /**
    * Colormatrix for pixels.
    * array of 20 floats. Numbers in positions 4, 9, 14, 19 loose meaning
@@ -43,11 +37,14 @@ export class ColorMatrix extends BaseFilter {
    * @type Boolean
    * @default true
    */
-  declare colorsOnly: boolean;
+  public colorsOnly = true;
 
   static type = 'ColorMatrix';
 
-  static defaults = colorMatrixDefaultValues;
+  constructor(options: Record<string, any> = {}) {
+    super(options);
+    this.matrix = this.defaultMatrixValue;
+  }
 
   setOptions({ matrix, ...options }: Record<string, any>) {
     if (matrix) {
@@ -93,6 +90,19 @@ export class ColorMatrix extends BaseFilter {
     }
   }
 
+  isNeutralState(): boolean {
+    return this.defaultMatrixValue.every(
+      (value: number, i: number) => value === this.matrix[i]
+    );
+  }
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      matrix: [...this.matrix]
+    };
+  }
+
   /**
    * Return WebGL uniform locations for this filter's shader.
    *
@@ -105,7 +115,7 @@ export class ColorMatrix extends BaseFilter {
   ): TWebGLUniformLocationMap {
     return {
       uColorMatrix: gl.getUniformLocation(program, 'uColorMatrix'),
-      uConstants: gl.getUniformLocation(program, 'uConstants'),
+      uConstants: gl.getUniformLocation(program, 'uConstants')
     };
   }
 
@@ -136,7 +146,7 @@ export class ColorMatrix extends BaseFilter {
         m[15],
         m[16],
         m[17],
-        m[18],
+        m[18]
       ],
       constants = [m[4], m[9], m[14], m[19]];
     gl.uniformMatrix4fv(uniformLocations.uColorMatrix, false, matrix);

--- a/src/filters/ColorMatrixFilters.ts
+++ b/src/filters/ColorMatrixFilters.ts
@@ -1,19 +1,12 @@
-import { ColorMatrix, colorMatrixDefaultValues } from './ColorMatrix';
+import { ColorMatrix } from './ColorMatrix';
 import { classRegistry } from '../ClassRegistry';
 
 export function createColorMatrixFilter(key: string, matrix: number[]) {
   const newClass = class extends ColorMatrix {
     static type = key;
-
-    static defaults = {
-      ...colorMatrixDefaultValues,
-      /**
-       * Lock the matrix export for this kind of static, parameter less filters.
-       */
-      mainParameter: undefined,
-      matrix,
-    };
+    public defaultMatrixValue = matrix;
   };
+
   classRegistry.setClass(newClass, key);
   return newClass;
 }

--- a/src/filters/Contrast.ts
+++ b/src/filters/Contrast.ts
@@ -1,12 +1,9 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/constrast';
-export const contrastDefaultValues: Partial<TClassProperties<Contrast>> = {
-  contrast: 0,
-  mainParameter: 'contrast',
-};
+
+const defaultContrastValue = 0;
 
 /**
  * Contrast filter class
@@ -23,11 +20,9 @@ export class Contrast extends BaseFilter {
    * @param {Number} contrast
    * @default 0
    */
-  declare contrast: number;
+  public contrast = defaultContrastValue;
 
   static type = 'Contrast';
-
-  static defaults = contrastDefaultValues;
 
   getFragmentSource() {
     return fragmentSource;
@@ -50,6 +45,17 @@ export class Contrast extends BaseFilter {
       data[i + 1] = contrastF * (data[i + 1] - 128) + 128;
       data[i + 2] = contrastF * (data[i + 2] - 128) + 128;
     }
+  }
+
+  isNeutralState() {
+    return this.contrast === defaultContrastValue;
+  }
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      contrast: this.contrast
+    };
   }
 
   /**

--- a/src/filters/Convolute.ts
+++ b/src/filters/Convolute.ts
@@ -1,13 +1,7 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/convolute';
-
-export const convoluteDefaultValues: Partial<TClassProperties<Convolute>> = {
-  opaque: false,
-  matrix: [0, 0, 0, 0, 1, 0, 0, 0, 0],
-};
 
 /**
  * Adapted from <a href="http://www.html5rocks.com/en/tutorials/canvas/imagefilters/">html5rocks article</a>
@@ -53,16 +47,14 @@ export class Convolute extends BaseFilter {
   /*
    * Opaque value (true/false)
    */
-  declare opaque: boolean;
+  public opaque = false;
 
   /*
    * matrix for the filter, max 9x9
    */
-  declare matrix: number[];
+  public matrix: number[] = [0, 0, 0, 0, 1, 0, 0, 0, 0];
 
   static type = 'Convolute';
-
-  static defaults = convoluteDefaultValues;
 
   getCacheKey() {
     return `${this.type}_${Math.sqrt(this.matrix.length)}_${

--- a/src/filters/Gamma.ts
+++ b/src/filters/Gamma.ts
@@ -1,14 +1,11 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/gamma';
+
 export type GammaInput = [number, number, number];
 
-export const gammaDefaultValues: Partial<TClassProperties<Gamma>> = {
-  mainParameter: 'gamma',
-  gamma: [1, 1, 1],
-};
+const defaultGammaValue: GammaInput = [1, 1, 1];
 
 /**
  * Gamma filter class
@@ -25,7 +22,7 @@ export class Gamma extends BaseFilter {
    * @param {Array} gamma
    * @default
    */
-  declare gamma: GammaInput;
+  public gamma: GammaInput = defaultGammaValue;
   declare rgbValues?: {
     r: Uint8Array;
     g: Uint8Array;
@@ -33,8 +30,6 @@ export class Gamma extends BaseFilter {
   };
 
   static type = 'Gamma';
-
-  static defaults = gammaDefaultValues;
 
   getFragmentSource() {
     return fragmentSource;
@@ -61,7 +56,7 @@ export class Gamma extends BaseFilter {
       this.rgbValues = {
         r: new Uint8Array(256),
         g: new Uint8Array(256),
-        b: new Uint8Array(256),
+        b: new Uint8Array(256)
       };
     }
 
@@ -80,6 +75,20 @@ export class Gamma extends BaseFilter {
     }
   }
 
+  isNeutralState() {
+    return defaultGammaValue.every(
+      (value: number, i: number) => value === this.gamma[i]
+    );
+  }
+
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      gamma: [...this.gamma]
+    };
+  }
+
   /**
    * Return WebGL uniform locations for this filter's shader.
    *
@@ -91,7 +100,7 @@ export class Gamma extends BaseFilter {
     program: WebGLProgram
   ): TWebGLUniformLocationMap {
     return {
-      uGamma: gl.getUniformLocation(program, 'uGamma'),
+      uGamma: gl.getUniformLocation(program, 'uGamma')
     };
   }
 

--- a/src/filters/Grayscale.ts
+++ b/src/filters/Grayscale.ts
@@ -1,4 +1,3 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
@@ -6,10 +5,7 @@ import { fragmentSource } from './shaders/grayscale';
 
 export type TGrayscaleMode = 'average' | 'lightness' | 'luminosity';
 
-export const grayscaleDefaultValues: Partial<TClassProperties<Grayscale>> = {
-  mode: 'average',
-  mainParameter: 'mode',
-};
+const defaultModeValue: TGrayscaleMode = 'average';
 
 /**
  * Grayscale image filter class
@@ -19,11 +15,9 @@ export const grayscaleDefaultValues: Partial<TClassProperties<Grayscale>> = {
  * object.applyFilters();
  */
 export class Grayscale extends BaseFilter {
-  declare mode: TGrayscaleMode;
+  public mode: TGrayscaleMode = defaultModeValue;
 
   static type = 'Grayscale';
-
-  static defaults = grayscaleDefaultValues;
 
   /**
    * Apply the Grayscale operation to a Uint8Array representing the pixels of an image.
@@ -62,6 +56,13 @@ export class Grayscale extends BaseFilter {
     return fragmentSource[this.mode];
   }
 
+  toObject() {
+    return {
+      ...super.toObject(),
+      mode: this.mode
+    };
+  }
+
   /**
    * Return WebGL uniform locations for this filter's shader.
    *
@@ -73,7 +74,7 @@ export class Grayscale extends BaseFilter {
     program: WebGLProgram
   ): TWebGLUniformLocationMap {
     return {
-      uMode: gl.getUniformLocation(program, 'uMode'),
+      uMode: gl.getUniformLocation(program, 'uMode')
     };
   }
 

--- a/src/filters/HueRotation.ts
+++ b/src/filters/HueRotation.ts
@@ -1,15 +1,10 @@
-import type { TClassProperties } from '../typedefs';
 import { cos } from '../util/misc/cos';
 import { sin } from '../util/misc/sin';
 import { ColorMatrix } from './ColorMatrix';
 import type { TWebGLPipelineState, T2DPipelineState } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 
-export const hueRotationDefaultValues: Partial<TClassProperties<HueRotation>> =
-  {
-    rotation: 0,
-    mainParameter: 'rotation',
-  };
+const defaultRotationValue = 0;
 
 /**
  * HueRotation filter class
@@ -20,16 +15,13 @@ export const hueRotationDefaultValues: Partial<TClassProperties<HueRotation>> =
  * object.filters.push(filter);
  * object.applyFilters();
  */
-// @ts-expect-error some babbling about mainParameter
 export class HueRotation extends ColorMatrix {
   /**
    * HueRotation value, from -1 to 1.
    */
-  declare rotation: number;
+  public rotation = defaultRotationValue;
 
   static type = 'HueRotation';
-
-  static defaults = hueRotationDefaultValues;
 
   calculateMatrix() {
     const rad = this.rotation * Math.PI,
@@ -52,7 +44,14 @@ export class HueRotation extends ColorMatrix {
 
   isNeutralState() {
     this.calculateMatrix();
-    return super.isNeutralState();
+    return this.rotation === defaultRotationValue;
+  }
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      rotation: this.rotation
+    };
   }
 
   applyTo(options: TWebGLPipelineState | T2DPipelineState) {

--- a/src/filters/Invert.ts
+++ b/src/filters/Invert.ts
@@ -1,14 +1,7 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/invert';
-
-export const invertDefaultValues: Partial<TClassProperties<Invert>> = {
-  alpha: false,
-  invert: true,
-  mainParameter: 'invert',
-};
 
 /**
  * @example
@@ -22,18 +15,16 @@ export class Invert extends BaseFilter {
    * @param {Boolean} alpha
    * @default
    **/
-  declare alpha: boolean;
+  public alpha = false;
 
   /**
    * Filter invert. if false, does nothing
    * @param {Boolean} invert
    * @default
    */
-  declare invert: boolean;
+  public invert = true;
 
   static type = 'Invert';
-
-  static defaults = invertDefaultValues;
 
   /**
    * Apply the Invert operation to a Uint8Array representing the pixels of an image.
@@ -57,11 +48,17 @@ export class Invert extends BaseFilter {
     return fragmentSource;
   }
 
+  toObject() {
+    return {
+      ...super.toObject(),
+      invert: this.invert
+    };
+  }
+
   /**
    * Invert filter isNeutralState implementation
    * Used only in image applyFilters to discard filters that will not have an effect
    * on the image
-   * @param {Object} options
    **/
   isNeutralState() {
     return !this.invert;

--- a/src/filters/Noise.ts
+++ b/src/filters/Noise.ts
@@ -1,13 +1,9 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/noise';
 
-export const noiseDefaultValues: Partial<TClassProperties<Noise>> = {
-  mainParameter: 'noise',
-  noise: 0,
-};
+const defaultNoiseValue = 0;
 
 /**
  * Noise filter class
@@ -25,11 +21,9 @@ export class Noise extends BaseFilter {
    * @param {Number} noise
    * @default
    */
-  declare noise: number;
+  public noise = defaultNoiseValue;
 
   static type = 'Noise';
-
-  static defaults = noiseDefaultValues;
 
   getFragmentSource() {
     return fragmentSource;
@@ -52,6 +46,10 @@ export class Noise extends BaseFilter {
       data[i + 1] += rand;
       data[i + 2] += rand;
     }
+  }
+
+  isNeutralState(): boolean {
+    return this.noise === defaultNoiseValue;
   }
 
   /**

--- a/src/filters/Pixelate.ts
+++ b/src/filters/Pixelate.ts
@@ -1,13 +1,9 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/pixelate';
 
-export const pixelateDefaultValues: Partial<TClassProperties<Pixelate>> = {
-  blocksize: 4,
-  mainParameter: 'blocksize',
-};
+const defaultBlockSizeValue = 4;
 
 /**
  * Pixelate filter class
@@ -19,11 +15,10 @@ export const pixelateDefaultValues: Partial<TClassProperties<Pixelate>> = {
  * object.applyFilters();
  */
 export class Pixelate extends BaseFilter {
-  declare blocksize: number;
+  public blocksize = defaultBlockSizeValue;
 
   static type = 'Pixelate';
 
-  static defaults = pixelateDefaultValues;
 
   /**
    * Apply the Pixelate operation to a Uint8ClampedArray representing the pixels of an image.
@@ -60,6 +55,14 @@ export class Pixelate extends BaseFilter {
     return this.blocksize === 1;
   }
 
+  toObject() {
+    return {
+      ...super.toObject(),
+      blocksize: this.blocksize
+    };
+  }
+
+
   protected getFragmentSource(): string {
     return fragmentSource;
   }
@@ -77,7 +80,7 @@ export class Pixelate extends BaseFilter {
     return {
       uBlocksize: gl.getUniformLocation(program, 'uBlocksize'),
       uStepW: gl.getUniformLocation(program, 'uStepW'),
-      uStepH: gl.getUniformLocation(program, 'uStepH'),
+      uStepH: gl.getUniformLocation(program, 'uStepH')
     };
   }
 

--- a/src/filters/RemoveColor.ts
+++ b/src/filters/RemoveColor.ts
@@ -1,15 +1,8 @@
 import { classRegistry } from '../ClassRegistry';
 import { Color } from '../color/Color';
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import { fragmentShader } from './shaders/removeColor';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
-export const removeColorDefaultValues: Partial<TClassProperties<RemoveColor>> =
-  {
-    color: '#FFFFFF',
-    distance: 0.02,
-    useAlpha: false,
-  };
 
 /**
  * Remove white filter class
@@ -27,23 +20,21 @@ export class RemoveColor extends BaseFilter {
    * @param {String} type
    * @default
    */
-  declare color: string;
+  public color = '#FFFFFF';
 
   /**
    * distance to actual color, as value up or down from each r,g,b
    * between 0 and 1
    **/
-  declare distance: number;
+  public distance = 0.2;
 
   /**
    * For color to remove inside distance, use alpha channel for a smoother deletion
    * NOT IMPLEMENTED YET
    **/
-  declare useAlpha: boolean;
+  public useAlpha = false;
 
   static type = 'RemoveColor';
-
-  static defaults = removeColorDefaultValues;
 
   getFragmentSource() {
     return fragmentShader;

--- a/src/filters/Saturation.ts
+++ b/src/filters/Saturation.ts
@@ -1,8 +1,10 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/saturation';
+
+const defaultSaturationValue = 0;
+
 
 /**
  * Saturate filter class
@@ -13,12 +15,6 @@ import { fragmentSource } from './shaders/saturation';
  * object.filters.push(filter);
  * object.applyFilters();
  */
-
-export const saturationDefaultValues: Partial<TClassProperties<Saturation>> = {
-  saturation: 0,
-  mainParameter: 'saturation',
-};
-
 export class Saturation extends BaseFilter {
   /**
    * Saturation value, from -1 to 1.
@@ -28,11 +24,10 @@ export class Saturation extends BaseFilter {
    * @param {Number} saturation
    * @default
    */
-  declare saturation: number;
+  public saturation = defaultSaturationValue;
 
   static type = 'Saturation';
 
-  static defaults = saturationDefaultValues;
 
   getFragmentSource() {
     return fragmentSource;
@@ -55,6 +50,17 @@ export class Saturation extends BaseFilter {
       data[i + 1] += max !== data[i + 1] ? (max - data[i + 1]) * adjust : 0;
       data[i + 2] += max !== data[i + 2] ? (max - data[i + 2]) * adjust : 0;
     }
+  }
+
+  isNeutralState(): boolean {
+    return this.saturation === defaultSaturationValue;
+  }
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      saturation: this.saturation
+    };
   }
 
   /**

--- a/src/filters/Vibrance.ts
+++ b/src/filters/Vibrance.ts
@@ -1,13 +1,9 @@
-import type { TClassProperties } from '../typedefs';
 import { BaseFilter } from './BaseFilter';
 import type { T2DPipelineState, TWebGLUniformLocationMap } from './typedefs';
 import { classRegistry } from '../ClassRegistry';
 import { fragmentSource } from './shaders/vibrance';
 
-export const vibranceDefaultValues: Partial<TClassProperties<Vibrance>> = {
-  vibrance: 0,
-  mainParameter: 'vibrance',
-};
+const defaultVibranceValue = 0;
 
 /**
  * Vibrance filter class
@@ -27,11 +23,9 @@ export class Vibrance extends BaseFilter {
    * @param {Number} vibrance
    * @default
    */
-  declare vibrance: number;
+  public vibrance = defaultVibranceValue;
 
   static type = 'Vibrance';
-
-  static defaults = vibranceDefaultValues;
 
   getFragmentSource() {
     return fragmentSource;
@@ -58,6 +52,17 @@ export class Vibrance extends BaseFilter {
     }
   }
 
+  isNeutralState(): boolean {
+    return this.vibrance === defaultVibranceValue;
+  }
+
+  toObject() {
+    return {
+      ...super.toObject(),
+      vibrance: this.vibrance
+    };
+  }
+
   /**
    * Return WebGL uniform locations for this filter's shader.
    *
@@ -69,7 +74,7 @@ export class Vibrance extends BaseFilter {
     program: WebGLProgram
   ): TWebGLUniformLocationMap {
     return {
-      uVibrance: gl.getUniformLocation(program, 'uVibrance'),
+      uVibrance: gl.getUniformLocation(program, 'uVibrance')
     };
   }
 


### PR DESCRIPTION

- Removed mainParameter from baseFilter, fixing ts error that appeared when using filters (https://github.com/fabricjs/fabric.js/issues/8891).
- I replaced the static default property from baseFilter and used class default values instead.

**Why did I do it?**
As mentioned here: https://github.com/fabricjs/fabric.js/issues/8891, using filters right now gives a TS error. This is because of the hacky mainParameter property in BaseFilter. I was able to remove it without repeating the code unnecessarily.

**What did I do?**
The mainParameter was solely utilized in the isNeutralState function of baseFilters. I modified this function to return false in BaseFilter and override it in child classes to return values relative to their defaults. The 'defaults' class static property in basefilter was also removed as it became redundant after the mainParameter was removed. Additionally, the getMainParameter/setMainParameter functions were eliminated as they were not used anywhere, leading to a more readable and TS friendly code structure.

