### PR TITLE
`types/ControlProps.ts`: add missing `@default`s, minor

### DIFF
--- a/src/shapes/Object/types/ControlProps.ts
+++ b/src/shapes/Object/types/ControlProps.ts
@@ -30,10 +30,10 @@ export interface ControlProps {
   /**
    * Color of controlling corners of an object (when it's active and transparentCorners false)
    * @since 1.6.2
-   * @type String | null
-   * @default null
+   * @type String
+   * @default ''
    */
-  cornerStrokeColor: string | null;
+  cornerStrokeColor: string;
 
   /**
    * Specify style of control, 'rect' or 'circle'
@@ -41,7 +41,7 @@ export interface ControlProps {
    * And you can swap it with one of the alternative proposed with the control api
    * @since 1.6.2
    * @type 'rect' | 'circle'
-   * @default rect
+   * @default 'rect'
    * @deprecated
    */
   cornerStyle: 'rect' | 'circle';

--- a/src/shapes/Object/types/ControlProps.ts
+++ b/src/shapes/Object/types/ControlProps.ts
@@ -30,10 +30,10 @@ export interface ControlProps {
   /**
    * Color of controlling corners of an object (when it's active and transparentCorners false)
    * @since 1.6.2
-   * @type String
+   * @type String | null
    * @default null
    */
-  cornerStrokeColor: string;
+  cornerStrokeColor: string | null;
 
   /**
    * Specify style of control, 'rect' or 'circle'
@@ -50,6 +50,7 @@ export interface ControlProps {
    * Array specifying dash pattern of an object's control (hasBorder must be true)
    * @since 1.6.2
    * @type Array | null
+   * @default null
    */
   cornerDashArray: number[] | null;
 
@@ -63,7 +64,7 @@ export interface ControlProps {
   /**
    * When set to `false`, object's controls are not displayed and can not be used to manipulate object
    * @type Boolean
-   * @default
+   * @default true
    */
   hasControls: boolean;
 }


### PR DESCRIPTION
I noticed `hasControls` was lacking a defined default value, this PR adds that.

Unless perhaps `src/shapes/Object/types/ControlProps.ts` is generated automatically somehow?

Default value of `true` as per:
https://github.com/fabricjs/fabric.js/blob/55438be/src/shapes/Object/defaultValues.ts#L106

Edit: I also:

1. Changed `cornerStrokeColor` default from `null` to `''`, also as per `defaultValues.ts`
2. Changed `cornerStyle` default from `rect` to `'rect'`
3. Added missing default of `null` to `cornerDashArray`