### PR TITLE
chore(TS): Add missing export type for Text events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(TS): Add missing export type for Text events [#10076](https://github.com/fabricjs/fabric.js/pull/10076)
 - chore(CI): Move test actions to Node 20 [#10073](https://github.com/fabricjs/fabric.js/pull/10073)
 - feat(Object): Object serialization for common properties [#10072](https://github.com/fabricjs/fabric.js/pull/10072)
 - feat(): Support easy serialization of custom properties [#10071](https://github.com/fabricjs/fabric.js/pull/10071)

--- a/fabric.ts
+++ b/fabric.ts
@@ -8,6 +8,8 @@ export { runningAnimations } from './src/util/animation/AnimationRegistry';
 export * from './src/typedefs';
 
 export * from './src/EventTypeDefs';
+export type { ITextEvents } from './src/shapes/IText/ITextBehavior';
+
 export { Observable } from './src/Observable';
 
 export type {


### PR DESCRIPTION
## Description
closes #10074
