### PR TITLE
feat(Canvas): Avoid styling the lower canvas with absolute positioning

### DIFF
--- a/.codesandbox/templates/vanilla/src/index.ts
+++ b/.codesandbox/templates/vanilla/src/index.ts
@@ -1,6 +1,6 @@
 import * as fabric from 'fabric';
 import './styles.css';
-import { testCase } from './testcases/guidelines';
+import { testCase } from './testcases/responsive';
 
 const el = document.getElementById('canvas');
 const canvas = (window.canvas = new fabric.Canvas(el));

--- a/.codesandbox/templates/vanilla/src/testcases/responsive.ts
+++ b/.codesandbox/templates/vanilla/src/testcases/responsive.ts
@@ -1,0 +1,9 @@
+import * as fabric from 'fabric';
+
+export async function testCase(canvas: fabric.Canvas) {
+  const rect = new fabric.Rect({ width: 50, height: 50, fill: 'blue' });
+  const rect2 = new fabric.Rect({ width: 50, height: 50, fill: 'blue' });
+
+  canvas.add(rect, rect2);
+  canvas.setDimensions({ width: '100%', height: 'auto' }, { cssOnly: true });
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- feat(Canvas): Avoid styling the lower canvas with absolute positioning [#10077](https://github.com/fabricjs/fabric.js/pull/10077)
 - chore(TS): Add missing export type for Text events [#10076](https://github.com/fabricjs/fabric.js/pull/10076)
 - chore(CI): Move test actions to Node 20 [#10073](https://github.com/fabricjs/fabric.js/pull/10073)
 - feat(Object): Object serialization for common properties [#10072](https://github.com/fabricjs/fabric.js/pull/10072)

--- a/src/canvas/DOMManagers/CanvasDOMManager.ts
+++ b/src/canvas/DOMManagers/CanvasDOMManager.ts
@@ -2,14 +2,11 @@ import { getEnv, getFabricDocument } from '../../env';
 import type { TSize } from '../../typedefs';
 import { createCanvasElement, setStyle } from '../../util';
 import type { CSSDimensions } from './util';
-import {
-  allowTouchScrolling,
-  makeElementUnselectable,
-  setCSSDimensions,
-} from './util';
+import { makeElementUnselectable, setCSSDimensions } from './util';
 import type { CanvasItem } from './StaticCanvasDOMManager';
 import { StaticCanvasDOMManager } from './StaticCanvasDOMManager';
 import { setCanvasDimensions } from './util';
+import { NONE } from '../../constants';
 
 export class CanvasDOMManager extends StaticCanvasDOMManager {
   upper: CanvasItem;
@@ -85,11 +82,14 @@ export class CanvasDOMManager extends StaticCanvasDOMManager {
     element: HTMLCanvasElement,
     options: {
       allowTouchScrolling?: boolean;
-      styles?: string | Record<string, string>;
+      styles?: Record<string, string>;
     },
   ) {
-    setStyle(element, options.styles);
-    allowTouchScrolling(element, options.allowTouchScrolling);
+    const { styles, allowTouchScrolling } = options;
+    setStyle(element, {
+      ...styles,
+      'touch-action': allowTouchScrolling ? 'manipulation' : NONE,
+    });
     makeElementUnselectable(element);
   }
 

--- a/src/canvas/DOMManagers/CanvasDOMManager.ts
+++ b/src/canvas/DOMManagers/CanvasDOMManager.ts
@@ -37,6 +37,11 @@ export class CanvasDOMManager extends StaticCanvasDOMManager {
     });
     this.applyCanvasStyle(upperCanvasEl, {
       allowTouchScrolling,
+      styles: {
+        position: 'absolute',
+        left: '0',
+        top: '0',
+      },
     });
     const container = this.createContainerElement();
     container.classList.add(containerClass);
@@ -78,14 +83,13 @@ export class CanvasDOMManager extends StaticCanvasDOMManager {
    */
   protected applyCanvasStyle(
     element: HTMLCanvasElement,
-    { allowTouchScrolling: allow }: { allowTouchScrolling: boolean },
+    options: {
+      allowTouchScrolling?: boolean;
+      styles?: string | Record<string, string>;
+    },
   ) {
-    setStyle(element, {
-      position: 'absolute',
-      left: '0',
-      top: '0',
-    });
-    allowTouchScrolling(element, allow);
+    setStyle(element, options.styles);
+    allowTouchScrolling(element, options.allowTouchScrolling);
     makeElementUnselectable(element);
   }
 

--- a/src/canvas/DOMManagers/util.ts
+++ b/src/canvas/DOMManagers/util.ts
@@ -22,7 +22,7 @@ export const setCanvasDimensions = (
   }
 };
 
-export function allowTouchScrolling(element: HTMLElement, allow: boolean) {
+export function allowTouchScrolling(element: HTMLElement, allow?: boolean) {
   const touchAction = allow ? 'manipulation' : NONE;
   setStyle(element, {
     'touch-action': touchAction,

--- a/src/canvas/DOMManagers/util.ts
+++ b/src/canvas/DOMManagers/util.ts
@@ -5,7 +5,6 @@ import {
   getWindowFromElement,
   getScrollLeftTop,
 } from '../../util/dom_misc';
-import { setStyle } from '../../util/dom_style';
 
 export const setCanvasDimensions = (
   el: HTMLCanvasElement,
@@ -21,14 +20,6 @@ export const setCanvasDimensions = (
     ctx.scale(retinaScaling, retinaScaling);
   }
 };
-
-export function allowTouchScrolling(element: HTMLElement, allow?: boolean) {
-  const touchAction = allow ? 'manipulation' : NONE;
-  setStyle(element, {
-    'touch-action': touchAction,
-    '-ms-touch-action': touchAction,
-  });
-}
 
 export type CSSDimensions = {
   width: number | string;

--- a/src/util/dom_style.ts
+++ b/src/util/dom_style.ts
@@ -7,7 +7,7 @@
  */
 export function setStyle(
   element: HTMLElement,
-  styles: string | Record<string, string>,
+  styles: string | Record<string, string> = {},
 ) {
   const elementStyle = element.style;
   if (!elementStyle) {

--- a/src/util/dom_style.ts
+++ b/src/util/dom_style.ts
@@ -7,13 +7,13 @@
  */
 export function setStyle(
   element: HTMLElement,
-  styles: string | Record<string, string> = {},
+  styles: string | Record<string, string>,
 ) {
   const elementStyle = element.style;
-  if (!elementStyle) {
+  if (!elementStyle || !styles) {
     return;
   } else if (typeof styles === 'string') {
-    element.style.cssText += ';' + styles;
+    elementStyle.cssText += ';' + styles;
   } else {
     Object.entries(styles).forEach(([property, value]) =>
       elementStyle.setProperty(property, value),


### PR DESCRIPTION
## Description

It seems to me that having both canvases as absolute positioning is kind of unnecessary but more importantly makes the container very hard to fit in a flow.
If we want to have the canvas container set as 'fit-content' or height: auto, it will collapse to 0 because the content is absolute positioned.

This change seems to break nothing and allow for a more dynamic setup.
