### PR TITLE
fix(filter): pixelate behaves differently under webgl, and should be squares rather than image scale

### DIFF
--- a/src/filters/shaders/pixelate.ts
+++ b/src/filters/shaders/pixelate.ts
@@ -7,7 +7,7 @@ export const fragmentSource = `
   varying vec2 vTexCoord;
   void main() {
     float blockW = uBlocksize * uStepW;
-    float blockH = uBlocksize * uStepW;
+    float blockH = uBlocksize * uStepH;
     int posX = int(vTexCoord.x / blockW);
     int posY = int(vTexCoord.y / blockH);
     float fposX = float(posX);


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

In `Pixelate.applyTo2d`, Pixels are squared, which is consistent with the expected performance
But in webgl, pixels follow the width and height of the image.

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
