### PR TITLE
fix(): Fix broken exports for filters that do not have a static defaults value.

### DIFF
--- a/src/filters/BaseFilter.ts
+++ b/src/filters/BaseFilter.ts
@@ -377,11 +377,13 @@ export class BaseFilter<
 
   /**
    * Returns object representation of an instance
+   * It will automatically export the default values of a filter,
+   * stored in the static defaults property.
    * @return {Object} Object representation of an instance
    */
   toObject(): { type: Name } & OwnProps {
     const defaultKeys = Object.keys(
-      (this.constructor as typeof BaseFilter).defaults,
+      (this.constructor as typeof BaseFilter).defaults || {},
     ) as (keyof OwnProps)[];
 
     return {


### PR DESCRIPTION


## Description

When refactoring filters recently i didn't think of possible filters that do not have needs for defaults values.
Those filters as today can't call the base filter export because the undefined static defaults will throw an error when converted to keys.
