### PR TITLE
fix(): Inconsistency of events when more buttons are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [next]
 
 ## [6.4.2]
-
+- Fix(): Inconsistency of events when more buttons are used [#10027](https://github.com/fabricjs/fabric.js/issues/10027)
 - Fix(): path parsing performance [#10123](https://github.com/fabricjs/fabric.js/pull/10123)
 
 ## [6.4.1]

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -625,12 +625,19 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
       this._onMouseDown as EventListener,
     );
   }
-
+  _checkMouseClick(e: MouseEvent) {
+    const button = e.button;
+    if (button == 1) return this.fireMiddleClick
+    if (button == 2) return this.fireRightClick
+    return true;
+  }
   /**
    * @private
    * @param {Event} e Event object fired on mousedown
    */
   _onMouseDown(e: TPointerEvent) {
+    const b = this._checkMouseClick(e as MouseEvent);
+    if (!b) return;
     this.__onMouseDown(e);
     this._resetTransformEventData();
     const canvasElement = this.upperCanvasEl,
@@ -697,6 +704,8 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
    * @param {Event} e Event object fired on mouseup
    */
   _onMouseUp(e: TPointerEvent) {
+    const b = this._checkMouseClick(e as MouseEvent);
+    if (!b) return;
     this.__onMouseUp(e);
     this._resetTransformEventData();
     const canvasElement = this.upperCanvasEl,
@@ -728,6 +737,8 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
    * @param {Event} e Event object fired on mousemove
    */
   _onMouseMove(e: TPointerEvent) {
+    const b = this._checkMouseClick(e as MouseEvent);
+    if (!b) return;
     const activeObject = this.getActiveObject();
     !this.allowTouchScrolling &&
       (!activeObject ||
@@ -777,17 +788,6 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     const transform = this._currentTransform;
     const isClick = this._isClick;
     const target = this._target;
-
-    // if right/middle click just fire events and return
-    // target undefined will make the _handleEvent search the target
-    const { button } = e as MouseEvent;
-    if (button) {
-      ((this.fireMiddleClick && button === 1) ||
-        (this.fireRightClick && button === 2)) &&
-        this._handleEvent(e, 'up');
-      this._resetTransformEventData();
-      return;
-    }
 
     if (this.isDrawingMode && this._isCurrentlyDrawing) {
       this._onMouseUpInDrawingMode(e);
@@ -988,16 +988,6 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     this._handleEvent(e, 'down:before');
 
     let target: FabricObject | undefined = this._target;
-
-    // if right/middle click just fire events
-    const { button } = e as MouseEvent;
-    if (button) {
-      ((this.fireMiddleClick && button === 1) ||
-        (this.fireRightClick && button === 2)) &&
-        this._handleEvent(e, 'down');
-      this._resetTransformEventData();
-      return;
-    }
 
     if (this.isDrawingMode) {
       this._onMouseDownInDrawingMode(e);


### PR DESCRIPTION
The judgment logic for middle mouse button clicks and right mouse button clicks will definitely trigger mouse:before, even if you set it to false. I changed it to perform the judgment and return when the mouse is pressed, to avoid triggering any subsequent events.



https://github.com/fabricjs/fabric.js/issues/10027