### PR TITLE
Add more generic font families to FabricText.genericFonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
 
 - ci(): Add some prebuilt fabric in the dist folder [#10178](https://github.com/fabricjs/fabric.js/pull/10178)
+- chore(): Add more generic font families to FabricText.genericFonts [#10167](https://github.com/fabricjs/fabric.js/pull/10167)
 
 ## [6.4.2]
 

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -1790,12 +1790,24 @@ export class FabricText<
     return 1;
   }
 
+  /**
+   * List of generic font families
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name
+   */
   static genericFonts = [
-    'sans-serif',
     'serif',
+    'sans-serif',
+    'monospace',
     'cursive',
     'fantasy',
-    'monospace',
+    'system-ui',
+    'ui-serif',
+    'ui-sans-serif',
+    'ui-monospace',
+    'ui-rounded',
+    'math',
+    'emoji',
+    'fangsong',
   ];
 
   /* _FROM_SVG_START_ */


### PR DESCRIPTION
Extends the list of genericFonts based on https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#generic-name.