### PR TITLE
fix(textarea): A form field element has neither an id nor a name attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [6.4.2]
 
+- Fix(Textarea): A form field element has neither an id nor a name attribute.
 - Fix(): path parsing performance [#10123](https://github.com/fabricjs/fabric.js/pull/10123)
 
 ## [6.4.1]

--- a/src/shapes/IText/ITextKeyBehavior.ts
+++ b/src/shapes/IText/ITextKeyBehavior.ts
@@ -72,6 +72,7 @@ export abstract class ITextKeyBehavior<
       spellcheck: 'false',
       'data-fabric': 'textarea',
       wrap: 'off',
+      name: "fabricTextarea",
     }).map(([attribute, value]) => textarea.setAttribute(attribute, value));
     const { top, left, fontSize } = this._calcTextareaPosition();
     // line-height: 1px; was removed from the style to fix this:


### PR DESCRIPTION
Every time I create a textbox element, the console gives me a suggestion with the following information. I found that the textbox creates a hidden textarea, so I decided to add a name to it to resolve this suggestion.

<img width="417" alt="image" src="https://github.com/user-attachments/assets/0a834b81-ffe5-4eee-9f55-6bfeab93141f">
