### PR TITLE
fix(Controls): allow for smooth scaling fo text at any zoom level 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Controls): changeWidth can change width with decimals [#10186](https://github.com/fabricjs/fabric.js/pull/10186)
 - ci(): Add some prebuilt fabric in the dist folder [#10178](https://github.com/fabricjs/fabric.js/pull/10178)
 
 ## [6.4.2]

--- a/src/controls/changeWidth.test.ts
+++ b/src/controls/changeWidth.test.ts
@@ -43,6 +43,15 @@ describe('changeWidth', () => {
     expect(target.top).toBe(0);
   });
 
+  test('changeWidth changes the width with decimals', () => {
+    expect(target.width).toBe(100);
+    const changed = changeWidth(eventData, transform, 200.2, 300);
+    expect(changed).toBe(true);
+    expect(target.width).toBe(199.2);
+    expect(target.left).toBe(0);
+    expect(target.top).toBe(0);
+  });
+
   test('changeWidth does not change the width', () => {
     const target = new Rect({ width: 100, height: 100, canvas });
     jest.spyOn(target, '_set').mockImplementation(function _set(this: Rect) {

--- a/src/controls/changeWidth.ts
+++ b/src/controls/changeWidth.ts
@@ -42,7 +42,7 @@ export const changeObjectWidth: TransformActionHandler = (
       oldWidth = target.width,
       newWidth =
         Math.abs((localPoint.x * multiplier) / target.scaleX) - strokePadding;
-    target.set('width', Math.max(newWidth, 0));
+    target.set('width', Math.max(newWidth, 1));
     //  check against actual target width in case `newWidth` was rejected
     return oldWidth !== target.width;
   }

--- a/src/controls/changeWidth.ts
+++ b/src/controls/changeWidth.ts
@@ -40,9 +40,8 @@ export const changeObjectWidth: TransformActionHandler = (
         target.strokeWidth / (target.strokeUniform ? target.scaleX : 1),
       multiplier = isTransformCentered(transform) ? 2 : 1,
       oldWidth = target.width,
-      newWidth = Math.ceil(
-        Math.abs((localPoint.x * multiplier) / target.scaleX) - strokePadding,
-      );
+      newWidth =
+        Math.abs((localPoint.x * multiplier) / target.scaleX) - strokePadding;
     target.set('width', Math.max(newWidth, 0));
     //  check against actual target width in case `newWidth` was rejected
     return oldWidth !== target.width;


### PR DESCRIPTION
## Description

Removed a call to Math.ceil when calculating new width in the mr and ml control resize handlers.