### PR TITLE
update(Group): The fromObject method supports custom groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): Custom group inherited from the group, and the bug of the custom layout type. [10198](https://github.com/fabricjs/fabric.js/issues/10198)
 - feat(IText): expose getCursorRenderingData() function. [#10204](https://github.com/fabricjs/fabric.js/pull/10204)
 - fix(Canvas): allowTouchScrolling interactions [#10078](https://github.com/fabricjs/fabric.js/pull/10078)
 - update(IText): Add method enterEditingImpl/exitEditingImpl that executes the logic of enterEditing/exitEditing without events [#10187](https://github.com/fabricjs/fabric.js/issues/10187)


### PR DESCRIPTION
When the user customizes a group and sets a custom layout type, it is necessary to override the fromObject method of the custom group to meet the default custom layout type. This PR fixes only the fromObject method of the custom group without affecting previous functionality, allowing users not to override the fromObject method to meet their needs.

[#10198](https://github.com/fabricjs/fabric.js/issues/10198)
