### PR TITLE
fix(Canvas): Holding down Shift to select multiple shapes unexpectedly triggers the text exit event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Canvas): Holding down Shift to select multiple shapes unexpectedly triggers the text exit event. [#10228](https://github.com/fabricjs/fabric.js/issues/10228)
 - feat(IText): expose getCursorRenderingData() function. [#10204](https://github.com/fabricjs/fabric.js/pull/10204)
 - fix(Canvas): allowTouchScrolling interactions [#10078](https://github.com/fabricjs/fabric.js/pull/10078)
 - update(IText): Add method enterEditingImpl/exitEditingImpl that executes the logic of enterEditing/exitEditing without events [#10187](https://github.com/fabricjs/fabric.js/issues/10187)

--- a/src/canvas/Canvas.spec.ts
+++ b/src/canvas/Canvas.spec.ts
@@ -1,5 +1,6 @@
 import { Canvas } from './Canvas';
 import { Rect } from '../shapes/Rect';
+import { IText } from '../shapes/IText/IText';
 
 describe('Canvas', () => {
   describe('touchStart', () => {
@@ -111,4 +112,32 @@ describe('Canvas', () => {
       expect(evt.preventDefault).not.toHaveBeenCalled();
     });
   });
+
+  describe("handleMultiSelection", () => {
+    const canvas = new Canvas();
+    const rect = new Rect({ left: 100, width: 100, height: 100 });
+    const iText = new IText("itext");
+    canvas.add(rect, iText);
+    test("Selecting shapes containing text does not trigger the exit event", () => {
+      const exitMock = jest.fn();
+      iText.on('editing:exited', exitMock);
+
+      const firstClick = new MouseEvent('click', {
+        clientX: 0,
+        clientY: 0
+      });
+      canvas._onMouseDown(firstClick);
+      canvas._onMouseUp(firstClick);
+      const secondClick = new MouseEvent("click", {
+        shiftKey: true,
+        clientX: 100,
+        clientY: 0,
+      });
+      canvas._onMouseDown(secondClick);
+      canvas._onMouseUp(secondClick);
+
+      expect(exitMock).toHaveBeenCalledTimes(0);
+    })
+  });
+  
 });

--- a/src/canvas/Canvas.spec.ts
+++ b/src/canvas/Canvas.spec.ts
@@ -1,6 +1,7 @@
 import { Canvas } from './Canvas';
 import { Rect } from '../shapes/Rect';
 import { IText } from '../shapes/IText/IText';
+import '../shapes/ActiveSelection';
 
 describe('Canvas', () => {
   describe('touchStart', () => {
@@ -141,22 +142,22 @@ describe('Canvas', () => {
     });
   });
 
-  describe("handleMultiSelection", () => {
+  describe('handleMultiSelection', () => {
     const canvas = new Canvas();
     const rect = new Rect({ left: 100, width: 100, height: 100 });
-    const iText = new IText("itext");
+    const iText = new IText('itext');
     canvas.add(rect, iText);
-    test("Selecting shapes containing text does not trigger the exit event", () => {
+    test('Selecting shapes containing text does not trigger the exit event', () => {
       const exitMock = jest.fn();
       iText.on('editing:exited', exitMock);
 
       const firstClick = new MouseEvent('click', {
         clientX: 0,
-        clientY: 0
+        clientY: 0,
       });
       canvas._onMouseDown(firstClick);
       canvas._onMouseUp(firstClick);
-      const secondClick = new MouseEvent("click", {
+      const secondClick = new MouseEvent('click', {
         shiftKey: true,
         clientX: 100,
         clientY: 0,
@@ -165,7 +166,6 @@ describe('Canvas', () => {
       canvas._onMouseUp(secondClick);
 
       expect(exitMock).toHaveBeenCalledTimes(0);
-    })
+    });
   });
-  
 });

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -1445,7 +1445,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
         }
         this._fireSelectionEvents(prevActiveObjects, e);
       } else {
-        (activeObject as IText).exitEditing &&
+        (activeObject as IText).isEditing &&
           (activeObject as IText).exitEditing();
         // add the active object and the target to the active selection and set it as the active object
         const klass =


### PR DESCRIPTION
#10228 