### PR TITLE
fix(TS): Add missing export for type DrawContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- add missing export [#10281](https://github.com/fabricjs/fabric.js/pull/10281)
+
 ## [6.5.0]
 
 - fix(Canvas): Holding down Shift to select multiple shapes unexpectedly triggers the text exit event. [#10228](https://github.com/fabricjs/fabric.js/issues/10228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- add missing export [#10281](https://github.com/fabricjs/fabric.js/pull/10281)
+- fix(TS): Add missing export for type DrawContext [#10281](https://github.com/fabricjs/fabric.js/pull/10281)
 
 ## [6.5.0]
 

--- a/fabric.ts
+++ b/fabric.ts
@@ -64,7 +64,10 @@ export {
 /**
  * Exported so we can tweak default values
  */
-export { FabricObject as BaseFabricObject } from './src/shapes/Object/Object';
+export {
+  FabricObject as BaseFabricObject,
+  type DrawContext,
+} from './src/shapes/Object/Object';
 /**
  * Exported so we can tweak default values
  */


### PR DESCRIPTION


## Description

Draw context missing in exports

close #10280 

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
