### PR TITLE
fix(color): Support uppercase keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(Color): Support uppercase keywords [#10300](https://github.com/fabricjs/fabric.js/pull/10300)
 - fix(): The \_setLineDash method has additional side effects, altering the value of strokeDashArray [#10292](https://github.com/fabricjs/fabric.js/issues/10292)
 - fix(): for object caching over invalidating the cache [#10294](https://github.com/fabricjs/fabric.js/pull/10294)
 

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -42,6 +42,7 @@ export class Color {
    * @returns {TRGBAColorSource}
    */
   protected _tryParsingColor(color: string) {
+    color = color.toLowerCase();
     if (color in ColorNameMap) {
       color = ColorNameMap[color as keyof typeof ColorNameMap];
     }

--- a/src/color/color.test.ts
+++ b/src/color/color.test.ts
@@ -55,4 +55,12 @@ describe('Color regex and conversion tests', () => {
     expect(color1.isUnrecognised).toBe(true);
     expect(color1.getSource().toString()).toBe([0, 0, 0, 1].toString());
   });
+
+  it('Create colors through keywords', () => {
+    const color1 = new Color("red");
+    const color2 = new Color("RED");
+    const red = "rgb(255,0,0)";
+    expect(color1.toRgb()).toBe(red);
+    expect(color2.toRgb()).toBe(red);
+  })
 });

--- a/src/color/color.test.ts
+++ b/src/color/color.test.ts
@@ -62,5 +62,5 @@ describe('Color regex and conversion tests', () => {
     const red = "rgb(255,0,0)";
     expect(color1.toRgb()).toBe(red);
     expect(color2.toRgb()).toBe(red);
-  })
+  });
 });

--- a/src/color/color.test.ts
+++ b/src/color/color.test.ts
@@ -57,9 +57,9 @@ describe('Color regex and conversion tests', () => {
   });
 
   it('Create colors through keywords', () => {
-    const color1 = new Color("red");
-    const color2 = new Color("RED");
-    const red = "rgb(255,0,0)";
+    const color1 = new Color('red');
+    const color2 = new Color('RED');
+    const red = 'rgb(255,0,0)';
     expect(color1.toRgb()).toBe(red);
     expect(color2.toRgb()).toBe(red);
   });


### PR DESCRIPTION
In the CSS style, when I set the color of an element using uppercase keywords like PINK or YELLOW, they are correctly recognized. However, in Fabric, only lowercase color keywords are currently supported. Therefore, I fixed it to ensure it supports uppercase keywords as well.


[bug demo](https://codepen.io/zhe-he-the-vuer/pen/mybywqP)