### PR TITLE
fix: toDataURL will incorrectly trigger the before:render and after:render hooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- fix(): toDataURL will incorrectly trigger the before:render and after:render [#10397](https://github.com/fabricjs/fabric.js/issues/10397)
+
 ## [6.5.4]
 
 - docs() perf(): Reorder caching conditions for most common scenario and docs fixes. [#10366](https://github.com/fabricjs/fabric.js/pull/10366)

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -571,7 +571,7 @@ export class StaticCanvas<
     ctx.imageSmoothingEnabled = this.imageSmoothingEnabled;
     // @ts-expect-error node-canvas stuff
     ctx.patternQuality = 'best';
-    this.fire('before:render', { ctx });
+    if (!this.skipControlsDrawing) this.fire('before:render', { ctx });
     this._renderBackground(ctx);
 
     ctx.save();
@@ -595,7 +595,7 @@ export class StaticCanvas<
     if (this.controlsAboveOverlay && !this.skipControlsDrawing) {
       this.drawControls(ctx);
     }
-    this.fire('after:render', { ctx });
+    if (!this.skipControlsDrawing) this.fire('after:render', { ctx });
 
     if (this.__cleanupTask) {
       this.__cleanupTask();

--- a/src/canvas/__tests__/SelectableCanvas.spec.ts
+++ b/src/canvas/__tests__/SelectableCanvas.spec.ts
@@ -57,4 +57,15 @@ describe('Canvas', () => {
       expect(canvas._objectsToRender).toBeUndefined();
     });
   });
+
+  it('toDataURL will not trigger render hooks', () => {
+    const canvas = new Canvas();
+    const beforeMock = jest.fn();
+    const afterMock = jest.fn();
+    canvas.on('before:render', beforeMock);
+    canvas.on('after:render', afterMock);
+    canvas.toDataURL();
+    expect(beforeMock).toHaveBeenCalledTimes(0);
+    expect(afterMock).toHaveBeenCalledTimes(0);
+  });
 });


### PR DESCRIPTION
I found the toDataURL method and noticed a variable skipControlsDrawing used to indicate it is exporting, so I made additional checks based on this variable.


https://github.com/fabricjs/fabric.js/issues/10397