### PR TITLE
Allow field access for PencilBrush subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- fix(): Allow for brush subclassing moving some properties from private to protected.
+
 ## [6.5.4]
 
 - docs() perf(): Reorder caching conditions for most common scenario and docs fixes. [#10366](https://github.com/fabricjs/fabric.js/pull/10366)

--- a/src/brushes/PencilBrush.ts
+++ b/src/brushes/PencilBrush.ts
@@ -40,9 +40,9 @@ export class PencilBrush extends BaseBrush {
    */
   straightLineKey: ModifierKey | undefined | null = 'shiftKey';
 
-  private declare _points: Point[];
-  private declare _hasStraightLine: boolean;
-  private declare oldEnd?: Point;
+  protected declare _points: Point[];
+  protected declare _hasStraightLine: boolean;
+  protected declare oldEnd?: Point;
 
   constructor(canvas: Canvas) {
     super(canvas);


### PR DESCRIPTION
## Description

Subclasses of `PencilBrush` don't have access to private fields. This PR will allow method overrides to work with what are currently private fields without hacks.
