### PR TITLE
feat(): Add webp to ImageFormat (Issue: #10431)

### DIFF
--- a/.codesandbox/templates/vanilla/src/index.ts
+++ b/.codesandbox/templates/vanilla/src/index.ts
@@ -11,4 +11,9 @@ canvas.setDimensions({
   height: 500,
 });
 
+canvas.toDataURL({
+  format: 'webp',
+  multiplier: 2,
+});
+
 testCase(canvas);

--- a/.codesandbox/templates/vanilla/src/index.ts
+++ b/.codesandbox/templates/vanilla/src/index.ts
@@ -11,9 +11,4 @@ canvas.setDimensions({
   height: 500,
 });
 
-canvas.toDataURL({
-  format: 'webp',
-  multiplier: 2,
-});
-
 testCase(canvas);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- feat(): Add webp to ImageFormat [#10435](https://github.com/fabricjs/fabric.js/pull/10435)
 - fix(): Allow for node-canvas images to work with the FabricImage class by making classList optional. [#10412](https://github.com/fabricjs/fabric.js/pull/10412)
 - fix(): Allow for brush subclassing moving some properties from private to protected. [#10416](https://github.com/fabricjs/fabric.js/pull/10416)
 - feat(): Add method toBlob. [#3283](https://github.com/fabricjs/fabric.js/issues/3283)

--- a/src/canvas/StaticCanvas.spec.ts
+++ b/src/canvas/StaticCanvas.spec.ts
@@ -9,4 +9,14 @@ describe('StaticCanvas', () => {
     expect(blob).toBeInstanceOf(Blob);
     expect(blob?.type).toBe('image/png');
   });
+  it('attempts webp format but may fallback to png in node environment', () => {
+    const canvas = new StaticCanvas(undefined, { width: 300, height: 300 }); 
+    const dataURL = canvas.toDataURL({
+      format: 'webp',
+      multiplier: 1,
+    });
+    // In browser environments this would be 'data:image/webp'
+    // In Node.js it falls back to PNG per HTML spec
+    expect(dataURL).toMatch(/^data:image\/(webp|png)/);
+  });
 });

--- a/src/canvas/StaticCanvas.spec.ts
+++ b/src/canvas/StaticCanvas.spec.ts
@@ -10,7 +10,7 @@ describe('StaticCanvas', () => {
     expect(blob?.type).toBe('image/png');
   });
   it('attempts webp format but may fallback to png in node environment', () => {
-    const canvas = new StaticCanvas(undefined, { width: 300, height: 300 }); 
+    const canvas = new StaticCanvas(undefined, { width: 300, height: 300 });
     const dataURL = canvas.toDataURL({
       format: 'webp',
       multiplier: 1,

--- a/src/canvas/StaticCanvas.spec.ts
+++ b/src/canvas/StaticCanvas.spec.ts
@@ -15,8 +15,11 @@ describe('StaticCanvas', () => {
       format: 'webp',
       multiplier: 1,
     });
-    // In browser environments this would be 'data:image/webp'
-    // In Node.js it falls back to PNG per HTML spec
+    /**
+     * In browser environments this would be 'data:image/webp'
+     * In Node.js environment (node-canvas) it falls back to PNG.
+     * @see https://github.com/Automattic/node-canvas/issues/1258 for possible workaround
+     */
     expect(dataURL).toMatch(/^data:image\/(webp|png)/);
   });
 });

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -43,6 +43,10 @@ export type TBBox = {
 
 export type Percent = `${number}%`;
 
+/**
+ * In order to support webp on node canvas a workaround is needed and is shared here:
+ * https://github.com/Automattic/node-canvas/issues/1258
+ */
 export type ImageFormat = 'jpeg' | 'png' | 'webp';
 
 export type SVGElementName = 'linearGradient' | 'radialGradient' | 'stop';

--- a/src/typedefs.ts
+++ b/src/typedefs.ts
@@ -43,7 +43,7 @@ export type TBBox = {
 
 export type Percent = `${number}%`;
 
-export type ImageFormat = 'jpeg' | 'png';
+export type ImageFormat = 'jpeg' | 'png' | 'webp';
 
 export type SVGElementName = 'linearGradient' | 'radialGradient' | 'stop';
 


### PR DESCRIPTION
## Description
`toDataURL` image format parameter does not accept `webp`, although it's possible (in most browsers).
Related to #10431 

