### PR TITLE
fix(): FabricImage was missing cachekey when filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- fix(): FabricImage was missing cachekey when filtering [#10441](https://github.com/fabricjs/fabric.js/pull/10441)
+
 ## [6.6.0]
 
 - feat(): Add webp to ImageFormat [#10435](https://github.com/fabricjs/fabric.js/pull/10435)

--- a/src/shapes/Image.spec.ts
+++ b/src/shapes/Image.spec.ts
@@ -1,5 +1,14 @@
 import { FabricImage } from './Image';
 import { Shadow } from '../Shadow';
+import { Brightness } from '../filters/Brightness';
+
+const mockApplyFilter = jest.fn();
+
+jest.mock('../filters/FilterBackend', () => ({
+  getFilterBackend: () => ({
+    applyFilters: mockApplyFilter,
+  }),
+}));
 
 describe('FabricImage', () => {
   describe('Svg export', () => {
@@ -23,5 +32,19 @@ describe('FabricImage', () => {
       });
       expect(img.toSVG()).toMatchSnapshot();
     });
+  });
+  describe('ApplyFilter use cacheKey', () => {
+    const imgElement = new Image(200, 200);
+    const img = new FabricImage(imgElement);
+    img.filters = [new Brightness({ brightness: 0.2 })];
+    img.applyFilters();
+    expect(mockApplyFilter).toHaveBeenCalledWith(
+      img.filters,
+      img._originalElement,
+      200,
+      200,
+      img.getElement(),
+      'texture0',
+    );
   });
 });

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -571,6 +571,7 @@ export class FabricImage<
       sourceWidth,
       sourceHeight,
       this._element as HTMLCanvasElement,
+      this.cacheKey,
     );
     if (
       this._originalElement.width !== this._element.width ||

--- a/src/shapes/__snapshots__/Image.spec.ts.snap
+++ b/src/shapes/__snapshots__/Image.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`FabricImage Svg export It exports an svg with styles for an image with stroke 1`] = `
 "<g transform="matrix(1 0 0 1 83.5 83.5)"  >
-<filter id="SVGID_0" y="-45.33%" height="190.66%" x="-36%" width="172%" >
+<filter id="SVGID_1" y="-45.33%" height="190.66%" x="-36%" width="172%" >
 	<feGaussianBlur in="SourceAlpha" stdDeviation="12"></feGaussianBlur>
 	<feOffset dx="0" dy="14" result="oBlur" ></feOffset>
 	<feFlood flood-color="rgb(0,0,0)" flood-opacity="0.5"/>
@@ -12,11 +12,11 @@ exports[`FabricImage Svg export It exports an svg with styles for an image with 
 		<feMergeNode in="SourceGraphic"></feMergeNode>
 	</feMerge>
 </filter>
-<clipPath id="imageCrop_2">
+<clipPath id="imageCrop_3">
 	<rect x="-75" y="-75" width="150" height="150" />
 </clipPath>
-	<image style="stroke: rgb(255,0,0); stroke-width: 11; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;filter: url(#SVGID_0);"  xlink:href="" x="-85" y="-85" width="200" height="200" clip-path="url(#imageCrop_2)" ></image>
-	<rect x="-75" y="-75" width="150" height="150" style="stroke: rgb(255,0,0); stroke-width: 11; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: none; fill-rule: nonzero; opacity: 1;filter: url(#SVGID_0);" />
+	<image style="stroke: rgb(255,0,0); stroke-width: 11; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;filter: url(#SVGID_1);"  xlink:href="" x="-85" y="-85" width="200" height="200" clip-path="url(#imageCrop_3)" ></image>
+	<rect x="-75" y="-75" width="150" height="150" style="stroke: rgb(255,0,0); stroke-width: 11; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: none; fill-rule: nonzero; opacity: 1;filter: url(#SVGID_1);" />
 </g>
 "
 `;


### PR DESCRIPTION
## Description

When converting image to TS, the cacheKey parameter during the function call was deleted.
Fixes #10436
close #10436
