### PR TITLE
fix(): When the perPixelTargetFind is set to true, the selected transparent graphic cannot be moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- fix(): When the perPixelTargetFind is set to true, the selected transparent graphic cannot be moved [10444](https://github.com/fabricjs/fabric.js/issues/10444)
+
 ## [6.6.1]
 
 - fix(): FabricImage was missing cachekey when filtering [#10441](https://github.com/fabricjs/fabric.js/pull/10441)

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -820,7 +820,8 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
     ) {
       if (
         (this.perPixelTargetFind || obj.perPixelTargetFind) &&
-        !(obj as unknown as IText).isEditing
+        !(obj as unknown as IText).isEditing &&
+        this._activeObject != obj
       ) {
         if (!this.isTargetTransparent(obj, pointer.x, pointer.y)) {
           return true;

--- a/src/canvas/__tests__/eventData.test.ts
+++ b/src/canvas/__tests__/eventData.test.ts
@@ -627,6 +627,13 @@ describe('Event targets', () => {
         target: triangle,
         targets: [],
       });
+
+      canvas.setActiveObject(triangle);
+
+      expect(findTarget(canvas, { clientX: 5, clientY: 5 })).toEqual({
+        target: triangle,
+        targets: [],
+      });
     });
 
     describe('findTarget with perPixelTargetFind in nested group', () => {
@@ -869,7 +876,7 @@ describe('Event targets', () => {
       });
 
       expect(findTarget(canvas, { clientX: 15, clientY: 15 })).toEqual({
-        target: undefined,
+        target: activeSelection,
         targets: [],
       });
     });


### PR DESCRIPTION
When a graphic is in the selected state, check its current position. Whether it is transparent or not should no longer be considered. I disabled this logic to ensure that transparent graphics can be operated normally


https://github.com/fabricjs/fabric.js/issues/10444