### PR TITLE
ci(): Node 22 hiccups. See if with canvas 3 native dependencies are still necessary for running ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: ./.github/actions/cached-install
         with:
           node-version: ${{ matrix.node-version }}
-          install-system-deps: ${{ matrix.node-version >= 22 }}
+          install-system-deps: false
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
       - name: Run ${{ matrix.suite }} tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [next]
 
-- ci(): Node 22 hiccups. See if with canvas 3 native dependencies are still necessary for running ci [#10498](https://github.com/fabricjs/fabric.js/pull/10498)
+- ci(): Remove system deps installation for node22, use prebuilt. [#10498](https://github.com/fabricjs/fabric.js/pull/10498)
 - refactor(tests): move circle tests from qunit to vitest [#10491](https://github.com/fabricjs/fabric.js/pull/10491)
 - refactor(tests): migrate remaining active selection tests from qunit to vitest [#10490](https://github.com/fabricjs/fabric.js/pull/10490)
 - ci(): update playwright to latest [#10496](https://github.com/fabricjs/fabric.js/pull/10496)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): Node 22 hiccups. See if with canvas 3 native dependencies are still necessary for running ci [#10498](https://github.com/fabricjs/fabric.js/pull/10498)
 - refactor(tests): move circle tests from qunit to vitest [#10491](https://github.com/fabricjs/fabric.js/pull/10491)
 - refactor(tests): migrate remaining active selection tests from qunit to vitest [#10490](https://github.com/fabricjs/fabric.js/pull/10490)
 - ci(): update playwright to latest [#10496](https://github.com/fabricjs/fabric.js/pull/10496)


### PR DESCRIPTION
## Description

Remove the call to APT get that is failing on node22

