### PR TITLE
chore(): remove axios

### DIFF
--- a/.codesandbox/deploy.mjs
+++ b/.codesandbox/deploy.mjs
@@ -80,18 +80,22 @@ export async function createCodeSandbox(appPath) {
   };
   fs.readdirSync(appPath).forEach(processFile);
   try {
-    const response = await fetch('https://codesandbox.io/api/v1/sandboxes/define?json=1', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      'https://codesandbox.io/api/v1/sandboxes/define?json=1',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          template: JSON.parse(
+            fs.readFileSync(path.resolve(appPath, 'sandbox.config.json')) ||
+              null,
+          ).template,
+          files,
+        }),
       },
-      body: JSON.stringify({
-        template: JSON.parse(
-          fs.readFileSync(path.resolve(appPath, 'sandbox.config.json')) || null,
-        ).template,
-        files,
-      }),
-    });
+    );
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => null);

--- a/.codesandbox/deploy.mjs
+++ b/.codesandbox/deploy.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import Axios from 'axios';
 import fs from 'fs-extra';
 import _ from 'lodash';
 import match from 'micromatch';
@@ -81,19 +80,27 @@ export async function createCodeSandbox(appPath) {
   };
   fs.readdirSync(appPath).forEach(processFile);
   try {
-    const {
-      data: { sandbox_id },
-    } = await Axios.post(
-      'https://codesandbox.io/api/v1/sandboxes/define?json=1',
-      {
+    const response = await fetch('https://codesandbox.io/api/v1/sandboxes/define?json=1', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
         template: JSON.parse(
           fs.readFileSync(path.resolve(appPath, 'sandbox.config.json')) || null,
         ).template,
         files,
-      },
-    );
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      throw errorData || new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const { sandbox_id } = await response.json();
     return `https://codesandbox.io/s/${sandbox_id}`;
   } catch (error) {
-    throw error.response?.data || error;
+    throw error;
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): remove axios in favor of native fetch [#10500](https://github.com/fabricjs/fabric.js/pull/10500)
 - refactor(tests): move point tests from qunit to vitest [#10492](https://github.com/fabricjs/fabric.js/pull/10492)
 - ci(): Remove system deps installation for node22, use prebuilt. [#10498](https://github.com/fabricjs/fabric.js/pull/10498)
 - refactor(tests): move circle tests from qunit to vitest [#10491](https://github.com/fabricjs/fabric.js/pull/10491)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@typescript-eslint/eslint-plugin": "^8.1.0",
         "@typescript-eslint/parser": "^8.1.0",
         "@vitest/coverage-v8": "^3.0.4",
-        "axios": "^0.27.2",
         "babel-plugin-import-json-value": "^0.1.2",
         "babel-plugin-transform-imports": "git+https://git@github.com/fabricjs/babel-plugin-transform-imports.git",
         "busboy": "^1.6.0",
@@ -4358,17 +4357,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "devOptional": true
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
+      "optional": true
     },
     "node_modules/babel-plugin-import-json-value": {
       "version": "0.1.2",
@@ -5091,7 +5080,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5454,7 +5443,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6404,7 +6393,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@typescript-eslint/eslint-plugin": "^8.1.0",
     "@typescript-eslint/parser": "^8.1.0",
     "@vitest/coverage-v8": "^3.0.4",
-    "axios": "^0.27.2",
     "babel-plugin-import-json-value": "^0.1.2",
     "babel-plugin-transform-imports": "git+https://git@github.com/fabricjs/babel-plugin-transform-imports.git",
     "busboy": "^1.6.0",


### PR DESCRIPTION
seems like axios is used only for deploying the codesandbox and also the version installed is flagged as one with security vulnerability
this attempts to remove axios in favor of native fetch
I am not sure if this works and on which node version deploy script is called, I guess we will need to see what CI says.
Anyway it is always good to have less dependencies installed if not necessary