### PR TITLE
ci(): Write a workflow that can comment coverage on the PR

### DIFF
--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -36,17 +36,27 @@ jobs:
           name: coverage-visual
           run-id: ${{ github.event.workflow_run.id }}
           path: ./.nyc_output
+      - uses: actions/download-artifact@v4
+        with:
+          name: prnumber
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./
       - run: ls -l ./.nyc_output
       - name: Build the report
         id: report
         run: |
           npm run coverage:report > cov.txt
           echo "report=$(cat cov.txt)" >> $GITHUB_OUTPUT
+      - name: Add pr number to output
+        id: prnumber
+        run: |
+          npm run coverage:report > cov.txt
+          echo "pr_number=$(cat prnumber.txt)" >> $GITHUB_OUTPUT
       - name: Comment on PR for coverage
         uses: edumserrano/find-create-or-update-comment@v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ steps.prnumber.outputs.pr_number }}
           body-includes: '${{ env.unique_id }}'
           comment-author: 'github-actions[bot]'
           body: |

--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -51,7 +51,7 @@ jobs:
         id: prnumber
         run: |
           npm run coverage:report > cov.txt
-          echo "pr_number=$(cat prnumber.txt)" >> $GITHUB_OUTPUT
+          echo "pr_number=$(cat ./prnumber.txt)" >> $GITHUB_OUTPUT
       - name: Comment on PR for coverage
         uses: edumserrano/find-create-or-update-comment@v3.0.0
         with:

--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -1,0 +1,55 @@
+name: 'Comment coverage on PR'
+on:
+  workflow_run:
+    workflows: ['🧪']
+    types:
+      - completed
+jobs:
+  coverage:
+    env:
+      unique_id: <!-- coverage-report -->
+    name: Coverage reporting
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cached-install
+        with:
+          node-version: 20.x
+          install-system-deps: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-e2e
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./.nyc_output
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-vitest
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./.nyc_output
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-unit
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./.nyc_output
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-visual
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./.nyc_output
+      - run: ls -l ./.nyc_output
+      - name: Build the report
+        id: report
+        run: |
+          npm run coverage:report > cov.txt
+          echo "report=$(cat cov.txt)" >> $GITHUB_OUTPUT
+      - name: Comment on PR for coverage
+        uses: edumserrano/find-create-or-update-comment@v3.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: '${{ env.unique_id }}'
+          comment-author: 'github-actions[bot]'
+          body: |
+            ${{ env.unique_id }}
+            ${{ steps.report.outputs.report }}
+          edit-mode: replace

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,3 +147,11 @@ jobs:
           name: coverage-e2e
           path: ./e2e/test-results/**/coverage.json
           include-hidden-files: true
+      - name: Create prnumber artifact
+        run: echo "${{ github.event.pull_request.number }}" >> "./prnumber.txt"
+      - name: Upload Pr Number
+        uses: actions/upload-artifact@v4
+        with:
+          name: prnumber
+          path: ./prnumber.txt
+          include-hidden-files: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,36 +147,3 @@ jobs:
           name: coverage-e2e
           path: ./e2e/test-results/**/coverage.json
           include-hidden-files: true
-  coverage:
-    needs: [node-coverage, e2e]
-    name: Coverage reporting
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/cached-install
-        with:
-          node-version: 18.x
-          install-system-deps: false
-      - uses: actions/download-artifact@v4
-        with:
-          name: coverage-e2e
-          path: ./.nyc_output
-      - uses: actions/download-artifact@v4
-        with:
-          name: coverage-vitest
-          path: ./.nyc_output
-      - uses: actions/download-artifact@v4
-        with:
-          name: coverage-unit
-          path: ./.nyc_output
-      - uses: actions/download-artifact@v4
-        with:
-          name: coverage-visual
-          path: ./.nyc_output
-      - run: ls -l ./.nyc_output
-      - run: npm run coverage:report
-      - uses: romeovs/lcov-reporter-action@v0.4.0
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          delete-old-comments: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): Write a workflow that can comment coverage on the PR. [#10516](https://github.com/fabricjs/fabric.js/pull/10516)
 - chore(): update typescript to 5.8 [#10514](https://github.com/fabricjs/fabric.js/pull/10514)
 - ci(): Avoid failure status when the intent is to comment [#10508](https://github.com/fabricjs/fabric.js/pull/10508)
 - refactor(tests): move observable tests from qunit to vitest [#10501](https://github.com/fabricjs/fabric.js/pull/10501)


### PR DESCRIPTION
## Description

This PR creates a workflow that can safely use the secrets to put the coverage on a pr.
This will allow prs from fork to display coverage correctly.

Quality of the report will be lower for the first iteration.
Missing: recover PR number from an artifact
