### PR TITLE
ci(): Modify test run action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,21 +20,21 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/cached-install
         with:
-          node-version: 20.x
+          node-version: 22.x
           install-system-deps: false
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
   node-coverage:
     needs: [prime-build]
     runs-on: ubuntu-24.04
-    name: Node 20.x visual qunit tests
+    name: Node 22.x visual tests qunit
     strategy:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cached-install
         with:
-          node-version: 20.x
+          node-version: 22.x
           install-system-deps: false
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
@@ -51,7 +51,7 @@ jobs:
 
   browser:
     needs: [prime-build]
-    name: ${{ matrix.target }} visual tests
+    name: ${{ matrix.target }} visual tests qunit
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/cached-install
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
       - name: Run ${{ matrix.target }} visual headless test
@@ -70,32 +70,27 @@ jobs:
   node:
     needs: [prime-build]
     runs-on: ubuntu-24.04
-    name: Node ${{ matrix.node-version }} visual tests
+    name: Node 18 visual tests qunit
     strategy:
       fail-fast: false
-      matrix:
-        # For more information see:
-        # https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-        # supported Node.js release schedule: https://nodejs.org/en/about/releases/
-        node-version: [18, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cached-install
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           install-system-deps: false
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
       - name: Run visual qunit tests
         run: npm run test -- -c node -s visual
-  vitest:
-    name: Vitest tests
+  vitest-coverage:
+    name: Vitest tests on node 22
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cached-install
         with:
-          node-version: 20.x
+          node-version: 22.x
           install-system-deps: false
       - name: Run Vitest unit test
         run: npm run test:vitest:coverage
@@ -105,7 +100,42 @@ jobs:
           name: coverage-vitest
           path: ./.nyc_output/*.json
           include-hidden-files: true
-
+  vitest-browser:
+    name: Vitest tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cached-install
+        with:
+          node-version: 22.x
+          install-system-deps: false
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run Vitest unit test
+        run: npm run test:vitest:chromium
+      - name: Upload test coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-vitest
+          path: ./.nyc_output/*.json
+          include-hidden-files: true
+  vitest-node-18:
+    name: Vitest tests node 18
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/cached-install
+        with:
+          node-version: 18.x
+          install-system-deps: false
+      - name: Run Vitest unit test
+        run: npm run test:vitest
+      - name: Upload test coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-vitest
+          path: ./.nyc_output/*.json
+          include-hidden-files: true
   e2e:
     needs: [prime-build]
     name: Playwright tests
@@ -114,7 +144,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cached-install
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Build fabric.js
         uses: ./.github/actions/build-fabric-cached
         # Playwright suggests against caching the browser install


### PR DESCRIPTION
## Description

Coverage tests now run on the base of node 22, or the highest node available, also when running on browsers.
Hoping that the newer the node, the faster.
Tests also will run on the lowest node supported ( in this case 18 ) but no more in intermediate versions.

