### PR TITLE
Fix IText selection not rendering while editing inside of cached Group

### DIFF
--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -35,6 +35,7 @@ import {
 import type { SerializedLayoutManager } from '../LayoutManager/LayoutManager';
 import type { FitContentLayout } from '../LayoutManager';
 import type { DrawContext } from './Object/Object';
+import { IText } from './IText/IText';
 
 /**
  * This class handles the specific case of creating a group using {@link Group#fromObject} and is not meant to be used in any other case.
@@ -512,6 +513,29 @@ export class Group
       }
     }
     this._drawClipPath(ctx, this.clipPath, context);
+  }
+
+  /**
+   * @override
+   */
+  renderCache(options?: any) {
+    super.renderCache(options);
+
+    const isITextAndHasSelection = (obj: FabricObject): obj is IText =>
+      obj instanceof IText &&
+      obj.isEditing &&
+      obj.selectionStart !== obj.selectionEnd;
+
+    // If there's an active IText, ensure its selection gets rendered
+    if (this._objects.some(isITextAndHasSelection) && this.canvas) {
+      this.canvas.contextTopDirty = true;
+
+      this._objects.forEach((obj) => {
+        if (isITextAndHasSelection(obj)) {
+          obj.renderCursorOrSelection();
+        }
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

This pull request addresses a bug where the text selection highlight does not appear when using `Cmd/Ctrl + A` in a `Textbox` or `IText` within a `Group`.

The root cause is that the `Group` class does not properly handle rendering the selection highlight for an IText object in editing mode when the selection is triggered programmatically (e.g., via Cmd/Ctrl + A). While cursor-based or Shift + Arrow selections correctly display the highlight, the Cmd/Ctrl + A action selects the text but fails to render the visual highlight, though the text is still technically selected.

In a direct-on-canvas `IText`, after the `cmdAll` command clears the context, it gets properly restored (with selection) via directly rendering the object. On the other hand, grouped `IText`s are restored from cache, and the cache does not include the selection (visually).

The fix modifies the `Group` class' `renderCache` method to check for active `IText` objects in editing mode with a valid selection range. If such an object is found, the canvas's `contextTopDirty` flag is set to true, and the `renderCursorOrSelection` method is called on the IText object to ensure the selection highlight is rendered (similar to how ungrouped `IText`s behave.)

### Related Issue

Issue #10593

## In Action

TODO