### PR TITLE
chore(): enable @typescript-eslint/no-unnecessary-type-arguments lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): enable @typescript-eslint/no-unnecessary-type-arguments lint rule [#10631](https://github.com/fabricjs/fabric.js/pull/10631)
 - fix(): Polygon controls util should invalidate cache [#10628](https://github.com/fabricjs/fabric.js/pull/10628)
 - chore(): modernize eslint config [#10624](https://github.com/fabricjs/fabric.js/pull/10624)
 - chore(): enable no-unnecessary-type-assertion lint rule [#10626](https://github.com/fabricjs/fabric.js/pull/10626)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/consistent-type-exports': 'error',
       '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/no-unnecessary-type-arguments': 'error',
       '@typescript-eslint/no-restricted-types': 1,
       '@typescript-eslint/ban-ts-comment': 1,
       '@typescript-eslint/no-explicit-any': ['warn'],

--- a/extensions/data_updaters/origins/index.ts
+++ b/extensions/data_updaters/origins/index.ts
@@ -52,7 +52,7 @@ export const installOriginWrapperUpdater = (
   originY?: TOriginY,
 ) => {
   // @ts-expect-error the _fromObject parameter could be instantiated differently
-  BaseFabricObject._fromObject = originUpdaterWrapper<FabricObject>(
+  BaseFabricObject._fromObject = originUpdaterWrapper(
     BaseFabricObject._fromObject,
     originX,
     originY,

--- a/src/filters/BaseFilter.ts
+++ b/src/filters/BaseFilter.ts
@@ -412,7 +412,7 @@ export class BaseFilter<
   static async fromObject(
     { type, ...filterOptions }: Record<string, any>,
     _options?: Abortable,
-  ): Promise<BaseFilter<string, object>> {
+  ): Promise<BaseFilter<string>> {
     return new this(filterOptions);
   }
 }

--- a/src/filters/Composed.ts
+++ b/src/filters/Composed.ts
@@ -27,10 +27,7 @@ export class Composed extends BaseFilter<
   static type = 'Composed';
 
   constructor(
-    options: { subFilters?: BaseFilter<string, object>[] } & Record<
-      string,
-      any
-    > = {},
+    options: { subFilters?: BaseFilter<string>[] } & Record<string, any> = {},
   ) {
     super(options);
     this.subFilters = options.subFilters || [];
@@ -79,11 +76,10 @@ export class Composed extends BaseFilter<
     options?: { signal: AbortSignal },
   ): Promise<Composed> {
     return Promise.all(
-      ((object.subFilters || []) as BaseFilter<string, object>[]).map(
-        (filter) =>
-          classRegistry
-            .getClass<typeof BaseFilter>(filter.type)
-            .fromObject(filter, options),
+      ((object.subFilters || []) as BaseFilter<string>[]).map((filter) =>
+        classRegistry
+          .getClass<typeof BaseFilter>(filter.type)
+          .fromObject(filter, options),
       ),
     ).then((enlivedFilters) => new this({ subFilters: enlivedFilters }));
   }

--- a/src/shapes/IText/ITextBehavior.ts
+++ b/src/shapes/IText/ITextBehavior.ts
@@ -125,7 +125,7 @@ export abstract class ITextBehavior<
     toValue: number;
     duration: number;
     delay?: number;
-    onComplete?: TOnAnimationChangeCallback<number, void>;
+    onComplete?: TOnAnimationChangeCallback<number>;
   }) {
     return animate({
       startValue: this._currentCursorOpacity,

--- a/src/util/animation/AnimationBase.ts
+++ b/src/util/animation/AnimationBase.ts
@@ -24,8 +24,8 @@ export abstract class AnimationBase<
   declare protected readonly easing: TEasingFunction<T>;
 
   declare private readonly _onStart: VoidFunction;
-  declare private readonly _onChange: TOnAnimationChangeCallback<T, void>;
-  declare private readonly _onComplete: TOnAnimationChangeCallback<T, void>;
+  declare private readonly _onChange: TOnAnimationChangeCallback<T>;
+  declare private readonly _onComplete: TOnAnimationChangeCallback<T>;
   declare private readonly _abort: TAbortCallback<T>;
 
   /**


### PR DESCRIPTION
Prevents passing redundant types to places where they are already infered or are already default ones
