### PR TITLE
feat(): Add support for text decoration tickness

### DIFF
--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -107,6 +107,7 @@ interface UniqueTextProps {
   textAlign: string;
   direction: CanvasDirection;
   path?: Path;
+  textDecorationTickness: number;
 }
 
 export interface SerializedTextProps
@@ -294,6 +295,16 @@ export class FabricText<
    * @default
    */
   declare path?: Path;
+
+  /**
+   * The text decoration tickness for underline, overline and strikethrough
+   * The tickness is expressed in thousandths of fontSize ( em ).
+   * The original value was 1/15 that translates to 66.6667 thousandths.
+   * The choice of unit of measure is to align with charSpacing.
+   * @type Number
+   * @default
+   */
+  declare textDecorationTickness: number;
 
   /**
    * Offset amount for text path starting position
@@ -1599,7 +1610,7 @@ export class FabricText<
             -charBox.kernedWidth / 2,
             offsetY * currentSize + currentDy,
             charBox.kernedWidth,
-            this.fontSize / 15,
+            this.fontSize * this.textDecorationTickness,
           );
           ctx.restore();
         } else if (
@@ -1620,7 +1631,7 @@ export class FabricText<
               drawStart,
               top + offsetY * size + dy,
               boxWidth,
-              this.fontSize / 15,
+              this.fontSize * this.textDecorationTickness,
             );
           }
           boxStart = charBox.left;
@@ -1644,7 +1655,7 @@ export class FabricText<
           drawStart,
           top + offsetY * size + dy,
           boxWidth - charSpacing,
-          this.fontSize / 15,
+          this.fontSize * this.textDecorationTickness,
         );
       topOffset += heightOfLine;
     }

--- a/src/shapes/Text/constants.ts
+++ b/src/shapes/Text/constants.ts
@@ -33,6 +33,7 @@ export const additionalProps = [
   ...textDecorationProperties,
   'textBackgroundColor',
   'direction',
+  'textDecorationTickness',
 ] as const;
 
 export type StylePropertiesType =
@@ -47,7 +48,8 @@ export type StylePropertiesType =
   | 'deltaY'
   | 'overline'
   | 'underline'
-  | 'linethrough';
+  | 'linethrough'
+  | 'textDecorationTickness';
 
 export const styleProperties: Readonly<StylePropertiesType[]> = [
   ...fontProperties,
@@ -57,6 +59,7 @@ export const styleProperties: Readonly<StylePropertiesType[]> = [
   FILL,
   'deltaY',
   'textBackgroundColor',
+  'textDecorationTickness',
 ] as const;
 
 // @TODO: Many things here are configuration related and shouldn't be on the class nor prototype
@@ -103,6 +106,7 @@ export const textDefaultValues: Partial<TClassProperties<FabricText>> = {
   direction: 'ltr',
   CACHE_FONT_SIZE: 400,
   MIN_TEXT_WIDTH: 2,
+  textDecorationTickness: 66.667,
 };
 
 export const JUSTIFY = 'justify';


### PR DESCRIPTION

## Description

closes #10640.

This PR implements the basic feature requested in the linked issue.
The reason behind chosing the current unit of measure is to align with the current charSpacing api.

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
