### PR TITLE
fix(SVGParser): Corrected CSS rule parsing for multiple style tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(SVGParser): Corrected CSS rule parsing for multiple style tags. [#10683](https://github.com/fabricjs/fabric.js/issues/10683)
 - fix(): Refactor findCornerQuadrant to fix the flip + cursor issue. [#10654](https://github.com/fabricjs/fabric.js/issues/10654)
 - chore(): A simple npm-update [#10674](https://github.com/fabricjs/fabric.js/pull/10674)
 - chore(): update playwright [#10657](https://github.com/fabricjs/fabric.js/pull/10657)

--- a/src/parser/getCSSRules.spec.ts
+++ b/src/parser/getCSSRules.spec.ts
@@ -1,6 +1,7 @@
 import { loadSVGFromString } from './loadSVGFromString';
-
+import { Circle } from '../shapes/Circle';
 import { describe, expect, test } from 'vitest';
+Circle;
 
 describe('getCSSRules', () => {
   test('can load svgs with style tags with import statement', async () => {
@@ -29,5 +30,28 @@ describe('getCSSRules', () => {
       </svg>
     `);
     expect(loaded.objects).toHaveLength(1);
+  });
+
+  test('can load svgs with multiple style tags', async () => {
+    const loaded = await loadSVGFromString(`
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 20">
+        <style>
+          .blue {
+            stroke: blue;
+            fill: blue;
+          }
+        </style>
+        <style>
+          .red {
+            stroke: red;
+            fill: red;
+          }
+        </style>
+        <circle class="blue" r="9" cx="10" cy="10"></circle>
+        <circle class="red" r="9" cx="30" cy="10"></circle>
+      </svg>
+    `);
+    expect(loaded.objects[0]).toMatchObject({ fill: 'blue', stroke: 'blue' });
+    expect(loaded.objects[1]).toMatchObject({ fill: 'red', stroke: 'red' });
   });
 });

--- a/src/parser/getCSSRules.spec.ts
+++ b/src/parser/getCSSRules.spec.ts
@@ -36,22 +36,16 @@ describe('getCSSRules', () => {
     const loaded = await loadSVGFromString(`
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 20">
         <style>
-          .blue {
-            stroke: blue;
-            fill: blue;
-          }
+          .blue { fill: blue; }
         </style>
         <style>
-          .red {
-            stroke: red;
-            fill: red;
-          }
+          .red { fill: red; }
         </style>
         <circle class="blue" r="9" cx="10" cy="10"></circle>
         <circle class="red" r="9" cx="30" cy="10"></circle>
       </svg>
     `);
-    expect(loaded.objects[0]).toMatchObject({ fill: 'blue', stroke: 'blue' });
-    expect(loaded.objects[1]).toMatchObject({ fill: 'red', stroke: 'red' });
+    expect(loaded.objects[0]).toMatchObject({ fill: 'blue' });
+    expect(loaded.objects[1]).toMatchObject({ fill: 'red' });
   });
 });

--- a/src/parser/getCSSRules.spec.ts
+++ b/src/parser/getCSSRules.spec.ts
@@ -1,7 +1,7 @@
-import { loadSVGFromString } from './loadSVGFromString';
-import { Circle } from '../shapes/Circle';
 import { describe, expect, test } from 'vitest';
-Circle;
+import { loadSVGFromString } from './loadSVGFromString';
+// Add `Circle` to the class registry, making it available during SVG parsing.
+import '../shapes/Circle';
 
 describe('getCSSRules', () => {
   test('can load svgs with style tags with import statement', async () => {

--- a/src/parser/getCSSRules.ts
+++ b/src/parser/getCSSRules.ts
@@ -7,12 +7,10 @@ import type { CSSRules } from './typedefs';
  */
 export function getCSSRules(doc: Document) {
   const styles = doc.getElementsByTagName('style');
-  let i;
-  let len;
   const allRules: CSSRules = {};
 
   // very crude parsing of style contents
-  for (i = 0, len = styles.length; i < len; i++) {
+  for (let i = 0; i < styles.length; i++) {
     const styleContents = (styles[i].textContent || '').replace(
       // remove comments
       /\/\*[\s\S]*?\*\//g,
@@ -47,8 +45,8 @@ export function getCSSRules(doc: Document) {
             return pair.trim();
           });
 
-        for (i = 0, len = propertyValuePairs.length; i < len; i++) {
-          const pair = propertyValuePairs[i].split(':'),
+        for (let j = 0; j < propertyValuePairs.length; j++) {
+          const pair = propertyValuePairs[j].split(':'),
             property = pair[0].trim(),
             value = pair[1].trim();
           ruleObj[property] = value;


### PR DESCRIPTION
Fixes [#10683](https://github.com/fabricjs/fabric.js/issues/10683)