### PR TITLE
Fix Next.js compatibility by removing node export restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,14 +128,12 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "node": null,
       "types": "./dist/index.d.ts",
       "import": "./dist/index.min.mjs",
       "require": "./dist/index.min.js",
       "default": "./dist/index.min.js"
     },
     "./es": {
-      "node": null,
       "types": "./dist/index.d.ts",
       "import": "./dist/fabric.min.mjs",
       "require": null,


### PR DESCRIPTION
Fix Next.js compatibility by removing node export restriction

<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md
        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.
        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.
        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description
Fixes #10679 

This PR removes the `"node": null` entries from the package.json exports field that were causing import errors in Next.js environments.

The issue was that Next.js build process treats the `"node": null` export restriction as blocking the import, causing:

## Changes
- Removed `"node": null` from main export (`.`)
- Removed `"node": null` from es export (`./es`)

## Testing
This change allows fabric.js to be properly imported in Next.js applications without the module resolution error.

## In Action
Tested with Next.js template - import now works without module resolution errors.
<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
