### PR TITLE
chore(): Remove mouse wheel console warning by setting default explicitly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): Remove mouse wheel violation [#5710](https://github.com/fabricjs/fabric.js/issues/5710)
 - chore(): Fixes to TypeDoc for compilation [#10709](https://github.com/fabricjs/fabric.js/pull/10709)
 - chore(): Update typescript 5.9, eslint, babel and rollup to latest [#10708](https://github.com/fabricjs/fabric.js/pull/10708)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): Remove mouse wheel console warning by setting default explicitly. [#10712](https://github.com/fabricjs/fabric.js/pull/10712)
 - chore(): Remove mouse wheel violation [#5710](https://github.com/fabricjs/fabric.js/issues/5710)
 - chore(): Fixes to TypeDoc for compilation [#10709](https://github.com/fabricjs/fabric.js/pull/10709)
 - chore(): Update typescript 5.9, eslint, babel and rollup to latest [#10708](https://github.com/fabricjs/fabric.js/pull/10708)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## [next]
 
 - chore(): Remove mouse wheel console warning by setting default explicitly. [#10712](https://github.com/fabricjs/fabric.js/pull/10712)
-- chore(): Remove mouse wheel violation [#5710](https://github.com/fabricjs/fabric.js/issues/5710)
 - chore(): Fixes to TypeDoc for compilation [#10709](https://github.com/fabricjs/fabric.js/pull/10709)
 - chore(): Update typescript 5.9, eslint, babel and rollup to latest [#10708](https://github.com/fabricjs/fabric.js/pull/10708)
 

--- a/src/canvas/Canvas.ts
+++ b/src/canvas/Canvas.ts
@@ -177,7 +177,7 @@ export class Canvas extends SelectableCanvas implements CanvasOptions {
     );
     functor(canvasElement, `${eventTypePrefix}out`, this._onMouseOut);
     functor(canvasElement, `${eventTypePrefix}enter`, this._onMouseEnter);
-    functor(canvasElement, 'wheel', this._onMouseWheel);
+    functor(canvasElement, 'wheel', this._onMouseWheel, { passive: false });
     functor(canvasElement, 'contextmenu', this._onContextMenu);
     functor(canvasElement, 'click', this._onClick);
     // decide if to remove in fabric 7.0


### PR DESCRIPTION
#5710 

Even if we don't set passive, its behavior is the same as passive=false. Why not proactively set passive while also removing the violation?

When the third parameter only includes passive, there's no need to add the third parameter when removing the event. This is why I only modified the `addEventListener` but not the `removeEventListener`.