### PR TITLE
BREAKING: change default originX and originY to center/center

### DIFF
--- a/src/shapes/Object/defaultValues.ts
+++ b/src/shapes/Object/defaultValues.ts
@@ -7,6 +7,7 @@ import {
   SKEW_Y,
   FILL,
   STROKE,
+  CENTER,
 } from '../../constants';
 import type { TClassProperties } from '../../typedefs';
 import type { InteractiveFabricObject } from './InteractiveObject';
@@ -63,8 +64,8 @@ export const fabricObjectDefaultValues: Partial<
   minScaleLimit: 0,
   skewX: 0,
   skewY: 0,
-  originX: LEFT,
-  originY: TOP,
+  originX: CENTER,
+  originY: CENTER,
   strokeWidth: 1,
   strokeUniform: false,
   padding: 0,


### PR DESCRIPTION

## Description

This change is meant to lessen the burden for when originX and originY are removed.
Is easy to opt out from this change and just move to 7.0 anyway, this PR aims to evaluate how much investigation i need to do to see if something really break in tests.


