### PR TITLE
BREAKING(): Deprecate fireRightClick, fireMiddleClick, stopContextMenu and change their default value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- BREAKING(): Deprecate fireRightClick, fireMiddleClick, stopContextMenu and change their default value. [#10720](https://github.com/fabricjs/fabric.js/pull/10720)
 - fix(): The mouse enter and leave events of child elements will be executed twice. [10698](https://github.com/fabricjs/fabric.js/issues/10698)
 - chore(): Remove mouse wheel console warning by setting default explicitly. [#10712](https://github.com/fabricjs/fabric.js/pull/10712)
 - chore(): Fixes to TypeDoc for compilation [#10709](https://github.com/fabricjs/fabric.js/pull/10709)

--- a/src/canvas/CanvasOptions.ts
+++ b/src/canvas/CanvasOptions.ts
@@ -191,6 +191,9 @@ export interface TargetFindOptions {
 export interface CanvasEventsOptions {
   /**
    * Indicates if the right click on canvas can output the context menu or not
+   * The default value changed from false to true in Fabric 7.0
+   * @see https://fabricjs.com/docs/upgrading/upgrading-to-fabric-70/
+   * @deprecated since 7.0, Will be removed in Fabric 8.0
    * @type Boolean
    * @since 1.6.5
    */
@@ -198,6 +201,9 @@ export interface CanvasEventsOptions {
 
   /**
    * Indicates if the canvas can fire right click events
+   * The default value changed from false to true in Fabric 7.0
+   * @see https://fabricjs.com/docs/upgrading/upgrading-to-fabric-70/
+   * @deprecated since 7.0, Will be removed in Fabric 8.0
    * @type Boolean
    * @since 1.6.5
    */
@@ -205,6 +211,9 @@ export interface CanvasEventsOptions {
 
   /**
    * Indicates if the canvas can fire middle click events
+   * The default value changed from false to true in Fabric 7.0
+   * @see https://fabricjs.com/docs/upgrading/upgrading-to-fabric-70/
+   * @deprecated since 7.0, Will be removed in Fabric 8.0
    * @type Boolean
    * @since 1.7.8
    */
@@ -268,9 +277,9 @@ export const canvasDefaults: TOptions<CanvasOptions> = {
   targetFindTolerance: 0,
   skipTargetFind: false,
 
-  stopContextMenu: false,
-  fireRightClick: false,
-  fireMiddleClick: false,
+  stopContextMenu: true,
+  fireRightClick: true,
+  fireMiddleClick: true,
   enablePointerEvents: false,
 
   containerClass: 'canvas-container',


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

Those 3 properties were added in fabric 1.6 onward, before 2.0
They were added to allow for more control on mouse events without breaking current functionalities for the apps.
Looking back now i would expect my mouse event to always fire, regardless of what button i press.
There will be some adjustments to do in your app if you have events that absolutely shouldn't run outside the mouse button, like adding a check on the mouse button press and return.
If you don't want to do that you can still change back these defaults in your app to false and then rethink if you will update to fabric 8.0 in the future.

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
