### PR TITLE
doc: Repair broken link in docs by targeting all demo and samples pages in old fabric docs.

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -5,8 +5,8 @@ type EventRegistryObject<E> = {
 };
 
 /**
- * @see {@link http://fabricjs.com/fabric-intro-part-2#events}
- * @see {@link http://fabricjs.com/events|Events demo}
+ * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-2#events}
+ * @see {@link http://fabric5.fabricjs.com/events|Events demo}
  */
 export class Observable<EventSpec> {
   private __eventListeners: Record<keyof EventSpec, TEventCallback[]> =

--- a/src/Pattern/Pattern.ts
+++ b/src/Pattern/Pattern.ts
@@ -14,8 +14,8 @@ import type {
 import { log } from '../util/internals/console';
 
 /**
- * @see {@link http://fabricjs.com/patterns demo}
- * @see {@link http://fabricjs.com/dynamic-patterns demo}
+ * @see {@link http://fabric5.fabricjs.com/patterns demo}
+ * @see {@link http://fabric5.fabricjs.com/dynamic-patterns demo}
  */
 export class Pattern {
   static type = 'Pattern';

--- a/src/Shadow.ts
+++ b/src/Shadow.ts
@@ -112,7 +112,7 @@ export class Shadow {
   static type = 'shadow';
 
   /**
-   * @see {@link http://fabricjs.com/shadows|Shadow demo}
+   * @see {@link http://fabric5.fabricjs.com/shadows|Shadow demo}
    * @param {Object|String} [options] Options object with any of color, blur, offsetX, offsetY properties or string (e.g. "rgba(0,0,0,0.2) 2px 2px 10px")
    */
   constructor(options?: Partial<TClassProperties<Shadow>>);

--- a/src/brushes/BaseBrush.ts
+++ b/src/brushes/BaseBrush.ts
@@ -5,7 +5,7 @@ import type { Canvas } from '../canvas/Canvas';
 import type { TBrushEventData } from './typedefs';
 
 /**
- * @see {@link http://fabricjs.com/freedrawing|Freedrawing demo}
+ * @see {@link http://fabric5.fabricjs.com/freedrawing|Freedrawing demo}
  */
 export abstract class BaseBrush {
   /**

--- a/src/canvas/SelectableCanvas.ts
+++ b/src/canvas/SelectableCanvas.ts
@@ -80,7 +80,7 @@ export type FullTargetsInfoWithContainer = TargetsInfoWithContainer & {
  * Canvas class
  * @class Canvas
  * @extends StaticCanvas
- * @see {@link http://fabricjs.com/fabric-intro-part-1#canvas}
+ * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-1#canvas}
  *
  * @fires object:modified at the end of a transform
  * @fires object:rotating while an object is being rotated from the control
@@ -212,7 +212,7 @@ export class SelectableCanvas<EventSpec extends CanvasEvents = CanvasEvents>
    * When true, mouse events on canvas (mousedown/mousemove/mouseup) result in free drawing.
    * After mousedown, mousemove creates a shape,
    * and then mouseup finalizes it and adds an instance of `fabric.Path` onto canvas.
-   * @see {@link http://fabricjs.com/fabric-intro-part-4#free_drawing}
+   * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-4#free_drawing}
    * @type Boolean
    */
   declare isDrawingMode: boolean;

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -75,7 +75,7 @@ export type TSVGExportOptions = {
 
 /**
  * Static canvas class
- * @see {@link http://fabricjs.com/static_canvas|StaticCanvas demo}
+ * @see {@link http://fabric5.fabricjs.com/static_canvas|StaticCanvas demo}
  * @fires before:render
  * @fires after:render
  * @fires canvas:cleared
@@ -781,7 +781,7 @@ export class StaticCanvas<
    * Having a toJSON method means you can do JSON.stringify(myCanvas)
    * JSON does not support additional properties because toJSON has its own signature
    * @return {Object} JSON compatible object
-   * @see {@link http://fabricjs.com/fabric-intro-part-3#serialization}
+   * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-3#serialization}
    * @see {@link http://jsfiddle.net/fabricjs/pec86/|jsFiddle demo}
    * @example <caption>JSON representation of canvas </caption>
    * const json = canvas.toJSON();
@@ -913,7 +913,7 @@ export class StaticCanvas<
    * @param {String} [options.height] desired height of svg with or without units
    * @param {Function} [reviver] Method for further parsing of svg elements, called after each fabric object converted into svg representation.
    * @return {String} SVG string
-   * @see {@link http://fabricjs.com/fabric-intro-part-3#serialization}
+   * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-3#serialization}
    * @see {@link http://jsfiddle.net/fabricjs/jQ3ZZ/|jsFiddle demo}
    * @example <caption>Normal SVG output</caption>
    * var svg = canvas.toSVG();
@@ -1204,7 +1204,7 @@ export class StaticCanvas<
    * @param {Object} [options] options
    * @param {AbortSignal} [options.signal] see https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal
    * @return {Promise<Canvas | StaticCanvas>} instance
-   * @see {@link http://fabricjs.com/fabric-intro-part-3#deserialization}
+   * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-3#deserialization}
    * @see {@link http://jsfiddle.net/fabricjs/fmgXt/|jsFiddle demo}
    * @example <caption>loadFromJSON</caption>
    * canvas.loadFromJSON(json).then((canvas) => canvas.requestRenderAll());

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -12,7 +12,7 @@ import {
 
 /**
  * @class Color common color operations
- * @see {@link http://fabricjs.com/fabric-intro-part-2/#colors colors}
+ * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-2#colors colors}
  */
 export class Color {
   declare private _source: TRGBAColorSource;

--- a/src/filters/ColorMatrix.ts
+++ b/src/filters/ColorMatrix.ts
@@ -19,7 +19,7 @@ export const colorMatrixDefaultValues: ColorMatrixOwnProps = {
 
 /**
    * Color Matrix filter class
-   * @see {@link http://fabricjs.com/image-filters|ImageFilters demo}
+   * @see {@link http://fabric5.fabricjs.com/image-filters|ImageFilters demo}
    * @see {@link http://phoboslab.org/log/2013/11/fast-image-filters-with-webgl demo}
    * @example <caption>Kodachrome filter</caption>
    * const filter = new ColorMatrix({

--- a/src/gradient/Gradient.ts
+++ b/src/gradient/Gradient.ts
@@ -24,7 +24,7 @@ import { isPath } from '../util/typeAssertions';
 /**
  * Gradient class
  * @class Gradient
- * @see {@link http://fabricjs.com/fabric-intro-part-2#gradients}
+ * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-2#gradients}
  */
 export class Gradient<
   S,

--- a/src/mixins/eraser_brush.mixin.ts
+++ b/src/mixins/eraser_brush.mixin.ts
@@ -28,14 +28,14 @@ import { uid } from '../util/internals/uid';
      * When set to `deep` the eraser will erase nested objects if they are erasable, leaving the group and the other objects untouched.
      * When set to `true` the eraser will erase the entire group. Once the group changes the eraser is propagated to its children for proper functionality.
      * When set to `false` the eraser will leave all objects including the group untouched.
-     * @see {@link http://fabricjs.com/erasing#erasable_property}
+     * @see {@link http://fabric5.fabricjs.com/erasing#erasable_property}
      * @type boolean | 'deep'
      * @default true
      */
     erasable: true,
 
     /**
-     * @see {@link http://fabricjs.com/erasing#eraser}
+     * @see {@link http://fabric5.fabricjs.com/erasing#eraser}
      * @type fabric.Eraser
      */
     eraser: undefined,
@@ -162,7 +162,7 @@ import { uid } from '../util/internals/uid';
 
     /**
      * Applies the group's eraser to its objects
-     * @see {@link http://fabricjs.com/erasing#erasable_property}
+     * @see {@link http://fabric5.fabricjs.com/erasing#erasable_property}
      * @returns {Promise<fabric.Path[]|fabric.Path[][]|void>}
      */
     applyEraserToObjects: function () {
@@ -343,7 +343,7 @@ import { uid } from '../util/internals/uid';
    * In order to update the EraserBrush call `preparePattern`.
    * It may come in handy when canvas changes during erasing (i.e animations) and you want the eraser to reflect the changes.
    *
-   * @see {@link http://fabricjs.com/erasing}
+   * @see {@link http://fabric5.fabricjs.com/erasing}
    * @class fabric.EraserBrush
    * @extends fabric.PencilBrush
    * @memberof fabric

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -72,7 +72,7 @@ export interface ImageProps extends FabricObjectProps, UniqueImageProps {}
 const IMAGE_PROPS = ['cropX', 'cropY'] as const;
 
 /**
- * @see {@link http://fabricjs.com/fabric-intro-part-1#images}
+ * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-1#images}
  */
 export class FabricImage<
     Props extends TOptions<ImageProps> = Partial<ImageProps>,

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -337,7 +337,7 @@ export class InteractiveFabricObject<
 
   /**
    * @override set controls' coordinates as well
-   * See {@link https://github.com/fabricjs/fabric.js/wiki/When-to-call-setCoords} and {@link http://fabricjs.com/fabric-gotchas}
+   * See {@link https://github.com/fabricjs/fabric.js/wiki/When-to-call-setCoords} and {@link https://fabric5.fabricjs.com/fabric-gotchas}
    * @return {void}
    */
   setCoords(): void {

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -149,7 +149,7 @@ export type DrawContext =
 
 /**
  * Root object class from which all 2d shape classes inherit from
- * @see {@link http://fabricjs.com/fabric-intro-part-1#objects}
+ * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-1#objects}
  *
  * @fires added
  * @fires removed
@@ -1512,7 +1512,7 @@ export class FabricObject<
    * Animates object's properties
    * @param {Record<string, number | number[] | TColorArg>} animatable map of keys and end values
    * @param {Partial<AnimationOptions<T>>} options
-   * @see {@link http://fabricjs.com/fabric-intro-part-2#animation}
+   * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-2#animation}
    * @return {Record<string, TAnimation<T>>} map of animation contexts
    *
    * As object — multiple properties

--- a/src/shapes/Object/ObjectGeometry.ts
+++ b/src/shapes/Object/ObjectGeometry.ts
@@ -444,7 +444,7 @@ export class ObjectGeometry<EventSpec extends ObjectEvents = ObjectEvents>
   /**
    * Sets corner and controls position coordinates based on current angle, width and height, left and top.
    * aCoords are used to quickly find an object on the canvas.
-   * See {@link https://github.com/fabricjs/fabric.js/wiki/When-to-call-setCoords} and {@link http://fabricjs.com/fabric-gotchas}
+   * See {@link https://github.com/fabricjs/fabric.js/wiki/When-to-call-setCoords} and {@link http://fabric5.fabricjs.com/fabric-gotchas}
    */
   setCoords(): void {
     this.aCoords = this.calcACoords();

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -123,7 +123,7 @@ export interface TextProps extends FabricObjectProps, UniqueTextProps {
 
 /**
  * Text class
- * @see {@link http://fabricjs.com/fabric-intro-part-2#text}
+ * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-2#text}
  */
 export class FabricText<
     Props extends TOptions<TextProps> = Partial<TextProps>,


### PR DESCRIPTION
## Description

Most broken links on documentation where part of old website docs.
While best solution would be to move those pages to new doc I dont really know how to do that :)
I propose in this PR to momentarily fix broken links.

## In Action
https://fabricjs.com/api/classes/basebrush/
See demo link was broken

https://fabricjs.com/api/classes/basefabricobject/
See http://fabricjs.com/fabric-intro-part-1#objects link was broken

Related to https://github.com/fabricjs/fabric.js/issues/10696 and partially to https://github.com/fabricjs/fabric.js/issues/10427

Recommanded follow-up to this PR :
1. Indicate clearly (on a banner ?) on old website that it is the old website with a link to current website.
2. Move all documentations to new docs, starting by those wonderfull 4 parts intro tutorials : 
 - https://fabric5.fabricjs.com/fabric-intro-part-1

As it is my first PR to fabricjs, do not hesitate to tell me anything I haven't done (build, test etc) that may applied.