### PR TITLE
fix: After executing loadFromJSON, it unexpectedly adds an objects property to the canvas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): After executing loadFromJSON, it unexpectedly adds an objects property to the canvas.
 - fix(): Incorrect sha for commenting action
 - fix(IText): A form field element has neither an id nor a name attribute. [#10172](https://github.com/fabricjs/fabric.js/pull/10172)
 - docs(): change CN comment to EN [#10727](https://github.com/fabricjs/fabric.js/pull/10727)

--- a/src/canvas/StaticCanvas.spec.ts
+++ b/src/canvas/StaticCanvas.spec.ts
@@ -1392,7 +1392,7 @@ describe('StaticCanvas', () => {
     expect(canvas.loadFromJSON).toBeTypeOf('function');
 
     await canvas.loadFromJSON(PATH_JSON);
-    expect('objects' in canvas).toBe(false);
+    expect(canvas).not.toHaveProperty('objects');
     const obj = canvas.item(0);
 
     expect(canvas.isEmpty()).toBeFalsy();

--- a/src/canvas/StaticCanvas.spec.ts
+++ b/src/canvas/StaticCanvas.spec.ts
@@ -1392,6 +1392,7 @@ describe('StaticCanvas', () => {
     expect(canvas.loadFromJSON).toBeTypeOf('function');
 
     await canvas.loadFromJSON(PATH_JSON);
+    expect('objects' in canvas).toBe(false);
     const obj = canvas.item(0);
 
     expect(canvas.isEmpty()).toBeFalsy();

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -1228,15 +1228,10 @@ export class StaticCanvas<
     }
 
     // parse json if it wasn't already
-    const serialized = typeof json === 'string' ? JSON.parse(json) : json;
-    const {
-      objects = [],
-      backgroundImage,
-      background,
-      overlayImage,
-      overlay,
-      clipPath,
-    } = serialized;
+    const { objects = [], ...serialized } =
+      typeof json === 'string' ? JSON.parse(json) : json;
+    const { backgroundImage, background, overlayImage, overlay, clipPath } =
+      serialized;
     const renderOnAddRemove = this.renderOnAddRemove;
     this.renderOnAddRemove = false;
 


### PR DESCRIPTION
When the user imports the data that was just exported, the canvas gets an extra objects property added, which shouldn’t happen. I removed it.

```ts
(async () => {
...
console.log('objects' in canvas);    // false
const data = canvas.toJSON();
await this.canvas.loadFromJSON(data);
console.log('objects' in canvas);    // true

})();
```