### PR TITLE
fix(): Simplify some regexes in order to avoid slowness with craft bad string

### DIFF
--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -210,7 +210,8 @@ export class Color {
    * @return {TRGBAColorSource | undefined} source
    */
   static sourceFromRgb(color: string): TRGBAColorSource | undefined {
-    const match = color.match(reRGBa());
+    const cleanedColor = color.replace(/\s+/g, ' ');
+    const match = cleanedColor.match(reRGBa());
     if (match) {
       const [r, g, b] = match.slice(1, 4).map((value) => {
         const parsedValue = parseFloat(value);
@@ -248,7 +249,8 @@ export class Color {
    * @see http://http://www.w3.org/TR/css3-color/#hsl-color
    */
   static sourceFromHsl(color: string): TRGBAColorSource | undefined {
-    const match = color.match(reHSLa());
+    const cleanedColor = color.replace(/\s+/g, ' ');
+    const match = cleanedColor.match(reHSLa());
     if (!match) {
       return;
     }

--- a/src/color/constants.ts
+++ b/src/color/constants.ts
@@ -2,6 +2,10 @@
  * Regex matching color in RGB or RGBA formats (ex: `rgb(0, 0, 0)`, `rgba(255, 100, 10, 0.5)`, `rgba( 255 , 100 , 10 , 0.5 )`, `rgb(1,1,1)`, `rgba(100%, 60%, 10%, 0.5)`)
  * Also matching rgba(r g b / a) as per new specs
  * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
+ *
+ * In order to avoid performance issues, you have to clean the input string for this regex from multiple spaces before.
+ * ex: colorString.replace(/\s+/g, ' ');
+ *
  * Formal syntax at the time of writing:
  * <rgb()> =
  *  rgb( [ <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )  |
@@ -13,35 +17,35 @@
  *
  * /^          # Beginning of the string
  * rgba?       # "rgb" or "rgba"
- * \(\s*       # Opening parenthesis and optional whitespace
+ * \(\s?       # Opening parenthesis and zero or one whitespace character
  * (\d{0,3}    # 0 to three digits R channel
  *  (?:\.\d+)? # Optional decimal with one or more digits
  * )           # End of capturing group for the first color component
  * %?          # Optional percent sign after the first color component
- * \s*         # Optional whitespace
+ * \s?         # Zero or one whitespace character
  * [\s|,]      # Separator between color components can be a space or comma
- * \s*         # Optional whitespace
+ * \s?         # Zero or one whitespace character
  * (\d{0,3}    # 0 to three digits G channel
  *  (?:\.\d+)? # Optional decimal with one or more digits
  * )           # End of capturing group for the second color component
  * %?          # Optional percent sign after the second color component
- * \s*         # Optional whitespace
+ * \s?         # Zero or one whitespace character
  * [\s|,]      # Separator between color components can be a space or comma
- * \s*         # Optional whitespace
+ * \s?         # Zero or one whitespace character
  * (\d{0,3}    # 0 to three digits B channel
  *  (?:\.\d+)? # Optional decimal with one or more digits
  * )           # End of capturing group for the third color component
  * %?          # Optional percent sign after the third color component
- * \s*         # Optional whitespace
+ * \s?         # Zero or one whitespace character
  * (?:         # Beginning of non-capturing group for alpha value
- *  \s*        # Optional whitespace
+ *  \s?        # Zero or one whitespace character
  *  [,/]       # Comma or slash separator for alpha value
- *  \s*        # Optional whitespace
+ *  \s?        # Zero or one whitespace character
  *  (\d{0,3}   # Zero to three digits
  *    (?:\.\d+)? # Optional decimal with one or more digits
  *  )          # End of capturing group for alpha value
  *  %?         # Optional percent sign after alpha value
- *  \s*        # Optional whitespace
+ *  \s?        # Zero or one whitespace character
  * )?          # End of non-capturing group for alpha value (optional)
  * \)          # Closing parenthesis
  * $           # End of the string
@@ -52,12 +56,14 @@
  * So the spec does not allow for `rgba(30 , 45%  35, 49%)` but this will work anyways for us
  */
 export const reRGBa = () =>
-  /^rgba?\(\s*(\d{0,3}(?:\.\d+)?%?)\s*[\s|,]\s*(\d{0,3}(?:\.\d+)?%?)\s*[\s|,]\s*(\d{0,3}(?:\.\d+)?%?)\s*(?:\s*[,/]\s*(\d{0,3}(?:\.\d+)?%?)\s*)?\)$/i;
+  /^rgba?\(\s?(\d{0,3}(?:\.\d+)?%?)\s?[\s|,]\s?(\d{0,3}(?:\.\d+)?%?)\s?[\s|,]\s?(\d{0,3}(?:\.\d+)?%?)\s?(?:\s?[,/]\s?(\d{0,3}(?:\.\d+)?%?)\s?)?\)$/i;
 
 /**
- * Regex matching color in HSL or HSLA formats (ex: hsl(0, 0, 0), rgba(255, 100, 10, 0.5), rgba( 255 , 100 , 10 , 0.5 ), rgb(1,1,1), rgba(100%, 60%, 10%, 0.5))
- * Also matching rgba(r g b / a) as per new specs
+ * Regex matching color in HSL or HSLA formats (ex: hsl(0deg 0%, 0%), hsla(160, 100, 10, 0.5), hsla( 180 , 100 , 10 , 0.5 ), hsl(1,1,1))
+ * Also matching hsla(h s l / a) as per new specs
  * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
+ * In order to avoid performance issues, you have to clean the input string for this regex from multiple spaces before.
+ * ex: colorString.replace(/\s+/g, ' ');
  * Formal syntax at the time of writing:
  * <hsl()> =
  *   hsl( [ <hue> | none ] [ <percentage> | none ] [ <percentage> | none ] [ / [ <alpha-value> | none ] ]? )
@@ -74,30 +80,30 @@ export const reRGBa = () =>
  * Regular expression for matching an hsla or hsl CSS color value
  *
  * /^hsla?\(         // Matches the beginning of the string and the opening parenthesis of "hsl" or "hsla"
- * \s*               // Matches any whitespace characters (space, tab, etc.) zero or more times
+ * \s?               // Matches any whitespace character (space, tab, etc.) zero or one time
  * (\d{0,3}          // Hue: 0 to three digits - start capture in a group
  * (?:\.\d+)?        // Hue: Optional (non capture group) decimal with one or more digits.
  * (?:deg|turn|rad)? // Hue: Optionally include suffix deg or turn or rad
  * )                 // Hue: End capture group
- * \s*               // Matches any whitespace characters zero or more times
+ * \s?               // Matches any whitespace character zero or one time
  * [\s|,]            // Matches a space, tab or comma
- * \s*               // Matches any whitespace characters zero or more times
+ * \s?               // Matches any whitespace character zero or one time
  * (\d{0,3}          // Saturation: 0 to three digits - start capture in a group
  * (?:\.\d+)?        // Saturation: Optional decimal with one or more digits in a non-capturing group
  * %?)               // Saturation: match optional % character and end capture group
- * \s*               // Matches any whitespace characters zero or more times
+ * \s?               // Matches any whitespace character zero or one time
  * [\s|,]            // Matches a space, tab or comma
- * \s*               // Matches any whitespace characters zero or more times
+ * \s?               // Matches any whitespace character zero or one time
  * (\d{0,3}          // Lightness: 0 to three digits - start capture in a group
  * (?:\.\d+)?        // Lightness: Optional decimal with one or more digits in a non-capturing group
  * %?)                // Lightness: match % character and end capture group
- * \s*               // Matches any whitespace characters zero or more times
+ * \s?               // Matches any whitespace character zero or one time
  * (?:               // Alpha: Begins a non-capturing group for the alpha value
- *   \s*             // Matches any whitespace characters zero or more times
+ *   \s?             // Matches any whitespace character zero or one time
  *   [,/]            // Matches a comma or forward slash
- *   \s*             // Matches any whitespace characters zero or more times
+ *   \s?             // Matches any whitespace character zero or one time
  *   (\d*(?:\.\d+)?%?) // Matches zero or more digits, optionally followed by a decimal point and one or more digits, followed by an optional percentage sign and captures it in a group
- *   \s*             // Matches any whitespace characters zero or more times
+ *   \s?             // Matches any whitespace character zero or one time
  * )?                // Makes the alpha value group optional
  * \)                // Matches the closing parenthesis
  * $/i               // Matches the end of the string and sets the regular expression to case-insensitive mode
@@ -106,7 +112,7 @@ export const reRGBa = () =>
  * So the spec does not allow `hsl(30 , 45%  35, 49%)` but this will work anyways for us.
  */
 export const reHSLa = () =>
-  /^hsla?\(\s*([+-]?\d{0,3}(?:\.\d+)?(?:deg|turn|rad)?)\s*[\s|,]\s*(\d{0,3}(?:\.\d+)?%?)\s*[\s|,]\s*(\d{0,3}(?:\.\d+)?%?)\s*(?:\s*[,/]\s*(\d*(?:\.\d+)?%?)\s*)?\)$/i;
+  /^hsla?\(\s?([+-]?\d{0,3}(?:\.\d+)?(?:deg|turn|rad)?)\s?[\s|,]\s?(\d{0,3}(?:\.\d+)?%?)\s?[\s|,]\s?(\d{0,3}(?:\.\d+)?%?)\s?(?:\s?[,/]\s?(\d*(?:\.\d+)?%?)\s?)?\)$/i;
 
 /**
  * Regex matching color in HEX format (ex: #FF5544CC, #FF5555, 010155, aff)

--- a/src/gradient/parser/parseCoords.ts
+++ b/src/gradient/parser/parseCoords.ts
@@ -11,17 +11,16 @@ function convertPercentUnitsToValues<
   { width, height, gradientUnits }: TSize & { gradientUnits: GradientUnits },
 ) {
   let finalValue;
-  return (Object.keys(valuesToConvert) as K[]).reduce(
-    (acc, prop) => {
-      const propValue = valuesToConvert[prop];
+  return (Object.entries(valuesToConvert) as [K, string | number][]).reduce(
+    (acc, [prop, propValue]) => {
       if (propValue === 'Infinity') {
         finalValue = 1;
       } else if (propValue === '-Infinity') {
         finalValue = 0;
       } else {
-        finalValue =
-          typeof propValue === 'string' ? parseFloat(propValue) : propValue;
-        if (typeof propValue === 'string' && isPercent(propValue)) {
+        const isString = typeof propValue === 'string';
+        finalValue = isString ? parseFloat(propValue) : propValue;
+        if (isString && isPercent(propValue)) {
           finalValue *= 0.01;
           if (gradientUnits === 'pixels') {
             // then we need to fix those percentages here in svg parsing

--- a/src/parser/percent.ts
+++ b/src/parser/percent.ts
@@ -1,22 +1,28 @@
 import { ifNaN } from '../util/internals/ifNaN';
 import { capValue } from '../util/misc/capValue';
 
-const RE_PERCENT = /^(\d+\.\d+)%|(\d+)%$/;
+// Matches strings that end with a percent sign (%)
+const RE_PERCENT = /%$/;
 
+/**
+ * Will loosely accept as percent numbers that are not like
+ * 3.4a%. This function does not check for the correctness of a percentage
+ * but it checks that values that are in theory correct are or arent percentages
+ */
 export function isPercent(value: string | null) {
-  return value && RE_PERCENT.test(value);
+  return value && RE_PERCENT.test(value) && Number.isFinite(parseFloat(value));
 }
 
 /**
- *
+ * Parse a percentage value in an svg.
  * @param value
- * @param valueIfNaN
+ * @param fallback in case of not possible to parse the number
  * @returns ∈ [0, 1]
  */
 export function parsePercent(
   value: string | number | null | undefined,
   valueIfNaN?: number,
-) {
+): number {
   const parsed =
     typeof value === 'number'
       ? value


### PR DESCRIPTION
## Description

This PR removes some vulnerable regexes by:
- simplify the percentage check to something more lax
- simplify the ReRGBa and ReHSLa regexes by requiring a space normalization before.

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
