### PR TITLE
fix(): Fix some weaknesses in the changelog-update action ( various CWE )

### DIFF
--- a/.github/workflows/changelog_upate.yml
+++ b/.github/workflows/changelog_upate.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           ref: ${{ steps.changelog_data.outputs.pr_ref }}
           repository: ${{ steps.changelog_data.outputs.full_name }}
+          sparse-checkout: |
+            ${{ env.file }}
+            .prettierrc
+            .prettierignore
       - name: Update ${{ env.file }} from PR title
         id: update
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v6.4.1
@@ -78,7 +82,6 @@ jobs:
       - name: Commit & Push
         if: fromJson(steps.update.outputs.result)
         run: |
-          npm ci
           npx prettier --write ${{ env.file }}
           git diff
           git config user.name github-actions[bot]

--- a/.github/workflows/changelog_upate.yml
+++ b/.github/workflows/changelog_upate.yml
@@ -11,20 +11,23 @@ jobs:
     env:
       file: CHANGELOG.md
     steps:
+      - name: 'Create an empty tmp directory'
+        run: |
+          mkdir ${{ runner.temp }}/artifacts
       - name: Recover build stats
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: changelog_artifact
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ./
+          path: ${{ runner.temp }}/artifacts
       - name: Parse the artifact in github output
         id: changelog_data
         run: |
-          echo "log=$(cat ./changelog_artifact.txt | jq -r '.log')" >> $GITHUB_OUTPUT
-          echo "prev_log=$(cat ./changelog_artifact.txt | jq -r '.prev_log')" >> $GITHUB_OUTPUT
-          echo "full_name=$(cat ./changelog_artifact.txt | jq -r '.full_name')" >> $GITHUB_OUTPUT
-          echo "pr_ref=$(cat ./changelog_artifact.txt | jq -r '.pr_ref')" >> $GITHUB_OUTPUT
+          echo "log=$(cat ${{ runner.temp }}/artifacts/changelog_artifact.txt | jq -r '.log')" >> $GITHUB_OUTPUT
+          echo "prev_log=$(cat ${{ runner.temp }}/artifacts/changelog_artifact.txt | jq -r '.prev_log')" >> $GITHUB_OUTPUT
+          echo "full_name=$(cat ${{ runner.temp }}/artifacts/changelog_artifact.txt | jq -r '.full_name')" >> $GITHUB_OUTPUT
+          echo "pr_ref=$(cat ${{ runner.temp }}/artifacts/changelog_artifact.txt | jq -r '.pr_ref')" >> $GITHUB_OUTPUT
       - name: Pull down the correct branch and repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -41,11 +44,11 @@ jobs:
           result-encoding: string
           script: |
             const fs = require('fs');
-            const file = './${{ env.file }}';
+            const file = process.ENV.file;
             let content = fs.readFileSync(file).toString();
-            const title = '[${{ env.next_version }}]';
-            const log = '${{ env.log }}';
-            const prev_log = '${{ env.prev_log }}';
+            const title = `[${process.ENV.next_version}]`;
+            const log = process.ENV.log;
+            const prev_log = process.ENV.prev_log;
             const prev_log_exists = prev_log && content.includes(prev_log);
             const log_exists = log && content.includes(log);
             let modified = false;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(): Fix some weaknesses in the changelog-update action ( various CWE ) [#10747](https://github.com/fabricjs/fabric.js/pull/10747)
 - fix(): CWE-1333 CWE-400 CWE-730 Simplify some regexes in order to avoid slowness with craft bad string [#10746](https://github.com/fabricjs/fabric.js/pull/10746)
 - fix(): CWE-1333 CWE-400 CWE-730 in Text.ts regex [#10745](https://github.com/fabricjs/fabric.js/pull/10745)
 - ci(): fix CWE-829 in action build-stats [#10744](https://github.com/fabricjs/fabric.js/pull/10744)


### PR DESCRIPTION
## Description

Improve the security of the changelog action by:
- extract artifacts in an empty isolated folder
- avoid use templates in scripts when we can use process.ENV from node
- avoid npm ci on pr branches
- checkout only needed files for changelog update
