### PR TITLE
chore(): remove chalk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): remove chalk [#10758](https://github.com/fabricjs/fabric.js/pull/10758)
 - chore(deps-dev): bump commander from 14.0.0 to 14.0.1 [#10754](https://github.com/fabricjs/fabric.js/pull/10754)
 - chore(deps-dev): bump chalk from 5.6.0 to 5.6.2 [#10752](https://github.com/fabricjs/fabric.js/pull/10752)
 - fix(): Fix some weaknesses in the changelog-update action ( various CWE ) [#10747](https://github.com/fabricjs/fabric.js/pull/10747)

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
         "babel-plugin-transform-imports": "git+https://git@github.com/fabricjs/babel-plugin-transform-imports.git",
-        "chalk": "^5.6.0",
         "commander": "^14.0.0",
         "es-toolkit": "1.39.10",
         "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "babel-plugin-transform-imports": "git+https://git@github.com/fabricjs/babel-plugin-transform-imports.git",
-    "chalk": "^5.6.0",
     "commander": "^14.0.0",
     "es-toolkit": "1.39.10",
     "eslint-config-prettier": "^10.1.8",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,7 +3,7 @@ import terser from '@rollup/plugin-terser';
 import ts from '@rollup/plugin-typescript';
 import { babel } from '@rollup/plugin-babel';
 import path from 'path';
-import chalk from 'chalk';
+import { redBright } from './scripts/colors.mjs';
 // import dts from "rollup-plugin-dts";
 
 const splitter = /\n|\s|,/g;
@@ -52,7 +52,7 @@ function onwarn(warning, warn) {
       !warning.message.includes('sourcemap')) ||
     warning.code === 'CIRCULAR_DEPENDENCY'
   ) {
-    console.error(chalk.redBright(warning));
+    console.error(redBright(String(warning)));
     if (process.env.CI) {
       throw Object.assign(new Error(), warning);
     }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -52,7 +52,7 @@ function onwarn(warning, warn) {
       !warning.message.includes('sourcemap')) ||
     warning.code === 'CIRCULAR_DEPENDENCY'
   ) {
-    console.error(redBright(String(warning)));
+    console.error(redBright(warning));
     if (process.env.CI) {
       throw Object.assign(new Error(), warning);
     }

--- a/scripts/buildLock.mjs
+++ b/scripts/buildLock.mjs
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { cyanBright } from './colors.mjs';
 import fs from 'fs-extra';
 import moment from 'moment';
 import path from 'node:path';
@@ -40,7 +40,7 @@ export function isLocked() {
 export function awaitBuild() {
   return new Promise((resolve) => {
     if (isLocked()) {
-      console.log(chalk.cyanBright('> waiting for build to finish...'));
+      console.log(cyanBright('> waiting for build to finish...'));
       const watcher = subscribe((locked) => {
         if (!locked) {
           watcher.close();

--- a/scripts/colors.mjs
+++ b/scripts/colors.mjs
@@ -1,0 +1,10 @@
+import { styleText } from 'node:util';
+
+export const red = (s) => styleText('red', String(s));
+export const redBright = (s) => styleText('redBright', String(s));
+export const green = (s) => styleText('green', String(s));
+export const yellow = (s) => styleText('yellow', String(s));
+export const gray = (s) => styleText('gray', String(s));
+export const blue = (s) => styleText('blue', String(s));
+export const cyanBright = (s) => styleText('cyanBright', String(s));
+export const bold = (s) => styleText('bold', String(s));

--- a/scripts/index.mjs
+++ b/scripts/index.mjs
@@ -11,7 +11,7 @@
  * Failing to do so will make CI report a false positive 📉.
  */
 
-import chalk from 'chalk';
+import { red, green, yellow, gray, bold } from './colors.mjs';
 import cp from 'child_process';
 import * as commander from 'commander';
 import fs from 'fs-extra';
@@ -35,7 +35,7 @@ function startWebsite() {
     JSON.parse(fs.readFileSync(path.resolve(websiteDir, 'package.json')))
       .name !== 'fabricjs.com'
   ) {
-    console.log(chalk.red('Could not locate fabricjs.com directory'));
+    console.log(red('Could not locate fabricjs.com directory'));
   }
   const args = ['run', 'start:dev'];
 
@@ -44,12 +44,12 @@ function startWebsite() {
   // os.platform() === 'win32' && args.push('--', '--force_polling', '--livereload');
   if (os.platform() === 'win32') {
     console.log(
-      chalk.green(
+      green(
         'Consider using ubuntu on WSL to run jekyll with the following options:',
       ),
     );
-    console.log(chalk.yellow('-- force_polling --livereload'));
-    console.log(chalk.gray('https://github.com/microsoft/WSL/issues/216'));
+    console.log(yellow('-- force_polling --livereload'));
+    console.log(gray('https://github.com/microsoft/WSL/issues/216'));
   }
 
   cp.spawn('npm', args, {
@@ -120,16 +120,14 @@ function exportAssetsToWebsite(options) {
     copy(path.resolve(wd, p), path.resolve(websiteDir, './build/files', p)),
   );
   console.log(
-    chalk.bold(`[${moment().format('HH:mm')}] exported assets to fabricjs.com`),
+    bold(`[${moment().format('HH:mm')}] exported assets to fabricjs.com`),
   );
   options.watch &&
     BUILD_SOURCE.forEach((p) => {
       watch(path.resolve(wd, p), () => {
         copy(path.resolve(wd, p), path.resolve(websiteDir, './build/files', p));
         console.log(
-          chalk.bold(
-            `[${moment().format('HH:mm')}] exported ${p} to fabricjs.com`,
-          ),
+          bold(`[${moment().format('HH:mm')}] exported ${p} to fabricjs.com`),
         );
       });
     });

--- a/scripts/sandbox.mjs
+++ b/scripts/sandbox.mjs
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { red, blue, yellow, cyanBright, bold } from './colors.mjs';
 import * as commander from 'commander';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
@@ -47,7 +47,7 @@ sandbox
   )
   .action(async (deploy, { template }, context) => {
     if (!deploy && !template) {
-      console.log(chalk.red(`Provide "path" or "--template"`));
+      console.log(red(`Provide "path" or "--template"`));
       context.help({ error: true });
       return;
     } else if (
@@ -61,7 +61,7 @@ sandbox
         {
           type: 'confirm',
           name: 'confirm',
-          message: `Did you mean to run ${chalk.blue(
+          message: `Did you mean to run ${blue(
             `npm run sandbox deploy -- -t ${template}\n`,
           )}?`,
           default: true,
@@ -75,7 +75,7 @@ sandbox
     const uri = await createCodeSandbox(
       deploy || path.resolve(codesandboxTemplatesDir, template),
     );
-    console.log(chalk.yellow(`> created codesandbox ${uri}`));
+    console.log(yellow(`> created codesandbox ${uri}`));
   });
 
 sandbox
@@ -96,9 +96,7 @@ sandbox
       filter: (src) => !ignore(templateDir, path.relative(templateDir, src)),
     });
     console.log(
-      `${chalk.blue(
-        `> building ${chalk.bold(template)} sandbox`,
-      )} at ${chalk.cyanBright(destination)}`,
+      `${blue(`> building ${bold(template)} sandbox`)} at ${cyanBright(destination)}`,
     );
     startSandbox(destination, watch, true);
   });
@@ -123,7 +121,7 @@ sandbox
         {
           type: 'confirm',
           name: 'confirm',
-          message: `Did you mean to run ${chalk.blue(
+          message: `Did you mean to run ${blue(
             `npm run sandbox start -- -t ${pathToSandbox}\n`,
           )}?`,
           default: true,
@@ -136,7 +134,7 @@ sandbox
       template = pathToSandbox;
       pathToSandbox = undefined;
     } else if (!fs.existsSync(pathToSandbox)) {
-      console.log(chalk.blue('Did you mean to use the build command?'));
+      console.log(blue('Did you mean to use the build command?'));
       context.help({ error: true });
       return;
     }


### PR DESCRIPTION
## Pull Request Overview
This PR removes the chalk dependency and replaces it with Node.js's native styleText utility for terminal color formatting. The change reduces external dependencies while maintaining the same colored output functionality.

- Replaces all chalk usage with native Node.js styleText from the node:util module
- Creates a new colors.mjs module that provides color utility functions
- Removes the chalk dependency from package.json