### PR TITLE
feat(extensions): Add demo.html files for extensions

### DIFF
--- a/extensions/README.MD
+++ b/extensions/README.MD
@@ -3,6 +3,8 @@
 Extensions and/or plugins are all those features that do no have a place in the library itself.
 FabricJS is a rendering library with an interactive layer and serialization support and has already a lot of features and needs to avoid more scope creep.
 
+## What are extensions?
+
 Extension are all those pieces of codes that are more features and less api, as examples:
 
 - filters with a niche use case
@@ -25,3 +27,10 @@ It may be a class or a function that wrap an existing class, or a series of func
 Refer to each README file for explanations
 
 Feature are not built in the main FabricJS bundle and are available both in form of ES module or an extension bundle.
+
+## Demos
+
+Download and open in your browser to try it:
+
+- `aligning_guidelines/demo.html` - Snap alignment when dragging objects
+- `cropping_controls/demo.html` - Image cropping with drag-to-reposition

--- a/extensions/aligning_guidelines/demo.html
+++ b/extensions/aligning_guidelines/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Aligning Guidelines</title>
+  <style>
+    body { font-family: system-ui; padding: 20px; background: #f5f5f5; }
+    p { color: #666; margin: 0 0 12px; }
+  </style>
+</head>
+<body>
+  <p>Drag objects to see alignment guides</p>
+  <canvas id="c" width="800" height="600"></canvas>
+
+  <script src="https://cdn.jsdelivr.net/npm/fabric@7/dist/index.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fabric@7/dist-extensions/fabric-extensions.min.js"></script>
+  <script>
+  const canvas = new fabric.Canvas('c', { backgroundColor: '#ddd' });
+
+  new fabricExtensions.AligningGuidelines(canvas);
+
+  // Background "canvas" rect - locked in place
+  canvas.add(new fabric.Rect({
+    left: 400,
+    top: 300,
+    width: 600,
+    height: 400,
+    fill: '#fff',
+    selectable: false,
+    evented: false,
+    lockMovementX: true,
+    lockMovementY: true,
+  }));
+
+  canvas.add(new fabric.Rect({ left: 150, top: 150, width: 100, height: 100, fill: '#3b82f6' }));
+  canvas.add(new fabric.Rect({ left: 350, top: 200, width: 120, height: 80, fill: '#22c55e' }));
+  canvas.add(new fabric.Circle({ left: 550, top: 250, radius: 50, fill: '#f59e0b' }));
+  canvas.add(new fabric.Triangle({ left: 300, top: 380, width: 100, height: 100, fill: '#ef4444' }));
+  </script>
+</body>
+</html>

--- a/extensions/cropping_controls/demo.html
+++ b/extensions/cropping_controls/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Cropping Controls</title>
+  <style>
+    body { font-family: system-ui; padding: 20px; background: #f5f5f5; }
+    p { color: #666; margin: 0 0 12px; }
+  </style>
+</head>
+<body>
+  <p>Double-click image to toggle crop mode</p>
+  <canvas id="c" width="900" height="700"></canvas>
+
+  <script src="https://cdn.jsdelivr.net/npm/fabric@7/dist/index.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fabric@7/dist-extensions/fabric-extensions.min.js"></script>
+  <script>
+  const canvas = new fabric.Canvas('c', { backgroundColor: '#eee' });
+
+  fabric.FabricImage.fromURL('https://fabricjs.com/assets/dragon.jpg', { crossOrigin: 'anonymous' })
+    .then(img => {
+      img.set({
+        scaleX: 0.3,
+        scaleY: 0.3,
+        angle: 10,
+        cropX: 90,
+        cropY: 150,
+        width: 600,
+        height: 600,
+      });
+      img.once('mousedblclick', fabricExtensions.enterCropMode);
+      canvas.add(img);
+      canvas.centerObject(img);
+      canvas.setActiveObject(img);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds simple `demo.html` files to extensions that can be downloaded and opened directly in a browser - no build tools required.

## Why

I've been working on contributing to the cropping extension, but found it difficult to quickly test and understand what's already built without setting up a full dev environment. 

For devs who aren't JS-first (I'm mainly a PHP/Laravel dev), the friction between "knowing extensions exist" and "actually seeing them work" is significant. These demos let anyone validate what's built in seconds. (download file > open in browser > play)

Website demos would be ideal long-term, I can even imagine a pretty feature rich multi-extension playground, but downloadable HTML files are better than nothing right now, require no maintenance, and are still useful for quickly previewing individual extensions (no git/install/build required). 

## Changes

- `extensions/README.MD` - Added Demos section
- `extensions/aligning_guidelines/demo.html` - New
- `extensions/cropping_controls/demo.html` - New

## Next

If this direction is welcome, I'd like to continue contributing to the extensions (already discussed some ideas in #10825).