### PR TITLE
feat(): Edge resize controls for images

### DIFF
--- a/.codesandbox/templates/vanilla/src/testcases/croppingControls.ts
+++ b/.codesandbox/templates/vanilla/src/testcases/croppingControls.ts
@@ -11,6 +11,16 @@ export async function testCase(canvas: fabric.Canvas) {
   // Remove original controls and apply cropping controls
   image.once('mousedblclick', extensions.enterCropMode);
 
+  // Apply edge resize controls to replace default ml, mr, mt, mb
+  // These resize within crop bounds, then switch to uniform scaling
+  const edgeControls = extensions.createImageEdgeResizeControls();
+  Object.assign(image.controls, {
+    ml: edgeControls.mle,
+    mr: edgeControls.mre,
+    mt: edgeControls.mte,
+    mb: edgeControls.mbe,
+  });
+
   // Set some initial crop to demonstrate the controls
   image.set({
     scaleX: 0.5,
@@ -22,6 +32,7 @@ export async function testCase(canvas: fabric.Canvas) {
     height: 400,
     cornerStrokeColor: 'blue',
     cornerColor: 'white',
+    borderColor: 'blue',
     borderScaleFactor: 2,
     transparentCorners: false,
     cornerStyle: 'circle',

--- a/extensions/cropping_controls/croppingControls.ts
+++ b/extensions/cropping_controls/croppingControls.ts
@@ -6,8 +6,11 @@ import {
   changeCropY,
   ghostScalePositionHandler,
   scaleEquallyCropGenerator,
+  changeEdgeWidth,
+  changeEdgeHeight,
 } from './croppingHandlers';
 import { renderCornerControl } from './renderCornerControl';
+import { renderEdgeControl } from './renderEdgeControl';
 
 const { scaleCursorStyleHandler } = controlsUtils;
 
@@ -146,5 +149,58 @@ export const createImageCroppingControls = () => ({
       return height || width;
     },
     getActionName: cropActionName,
+  }),
+});
+
+const edgeActionName = () => 'resizing';
+
+// edge resize controls - resize within crop bounds, then uniform scale when exhausted
+export const createImageEdgeResizeControls = () => ({
+  mle: new Control({
+    x: -0.5,
+    y: 0,
+    angle: 90,
+    sizeX: 8,
+    sizeY: 20,
+    render: renderEdgeControl,
+    cursorStyleHandler: scaleCursorStyleHandler,
+    actionHandler: changeEdgeWidth,
+    getActionName: edgeActionName,
+  }),
+
+  mre: new Control({
+    x: 0.5,
+    y: 0,
+    angle: 90,
+    sizeX: 8,
+    sizeY: 20,
+    render: renderEdgeControl,
+    cursorStyleHandler: scaleCursorStyleHandler,
+    actionHandler: changeEdgeWidth,
+    getActionName: edgeActionName,
+  }),
+
+  mte: new Control({
+    x: 0,
+    y: -0.5,
+    angle: 0,
+    sizeX: 20,
+    sizeY: 8,
+    render: renderEdgeControl,
+    cursorStyleHandler: scaleCursorStyleHandler,
+    actionHandler: changeEdgeHeight,
+    getActionName: edgeActionName,
+  }),
+
+  mbe: new Control({
+    x: 0,
+    y: 0.5,
+    angle: 0,
+    sizeX: 20,
+    sizeY: 8,
+    render: renderEdgeControl,
+    cursorStyleHandler: scaleCursorStyleHandler,
+    actionHandler: changeEdgeHeight,
+    getActionName: edgeActionName,
   }),
 });

--- a/extensions/cropping_controls/renderEdgeControl.ts
+++ b/extensions/cropping_controls/renderEdgeControl.ts
@@ -1,0 +1,64 @@
+import {
+  type ControlRenderingStyleOverride,
+  type InteractiveFabricObject,
+  util,
+  type Control,
+} from 'fabric';
+
+const { degreesToRadians } = util;
+
+/**
+ * Render a line control for middle edge handles.
+ * Uses Control.angle for orientation, cornerStrokeColor outline and cornerColor fill.
+ * @param {CanvasRenderingContext2D} ctx context to render on
+ * @param {Number} left x coordinate where the control center should be
+ * @param {Number} top y coordinate where the control center should be
+ * @param {Object} styleOverride override for FabricObject controls style
+ * @param {FabricObject} fabricObject the fabric object for which we are rendering controls
+ */
+export function renderEdgeControl(
+  this: Control,
+  ctx: CanvasRenderingContext2D,
+  left: number,
+  top: number,
+  styleOverride: ControlRenderingStyleOverride,
+  fabricObject: InteractiveFabricObject,
+) {
+  ctx.save();
+  const { stroke, xSize, ySize } = this.commonRenderProps(
+      ctx,
+      left,
+      top,
+      fabricObject,
+      styleOverride,
+    ),
+    length = Math.max(xSize, ySize),
+    thickness = Math.min(xSize, ySize),
+    halfLength = length / 2;
+
+  // offset outward to align with border stroke
+  const borderOffset = (fabricObject.borderScaleFactor || 1) / 2;
+  if (this.x === -0.5) ctx.translate(-borderOffset, 0);
+  else if (this.x === 0.5) ctx.translate(borderOffset, 0);
+  if (this.y === -0.5) ctx.translate(0, -borderOffset);
+  else if (this.y === 0.5) ctx.translate(0, borderOffset);
+
+  ctx.rotate(degreesToRadians(this.angle));
+  ctx.lineCap = 'round';
+
+  if (stroke) {
+    ctx.lineWidth = thickness;
+    ctx.beginPath();
+    ctx.moveTo(-halfLength, 0);
+    ctx.lineTo(halfLength, 0);
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = ctx.fillStyle;
+  ctx.lineWidth = stroke ? thickness - 4 : thickness;
+  ctx.beginPath();
+  ctx.moveTo(-halfLength, 0);
+  ctx.lineTo(halfLength, 0);
+  ctx.stroke();
+  ctx.restore();
+}

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -17,11 +17,16 @@ export {
   rotateEventHandler,
 } from './westures_integration';
 
-export { createImageCroppingControls } from './cropping_controls/croppingControls';
+export {
+  createImageCroppingControls,
+  createImageEdgeResizeControls,
+} from './cropping_controls/croppingControls';
 export {
   changeCropY,
   changeCropX,
   changeCropWidth,
   changeCropHeight,
+  changeEdgeWidth,
+  changeEdgeHeight,
 } from './cropping_controls/croppingHandlers';
 export { enterCropMode } from './cropping_controls/enterCropMode';


### PR DESCRIPTION
**Summary**
- Adds edge resize controls (`mle`, `mre`, `mte`, `mbe`) for images
- When dragging an edge, it first resizes within crop bounds
- When crop bounds are exhausted, it switches to uniform scale with bounce-back
- New `renderEdgeControl` draws line-style handles that align with borders

**Usage**
```typescript
import { createImageEdgeResizeControls } from 'fabric/extensions';

image.controls = {
  ...image.controls,
  ...createImageEdgeResizeControls(),
};
```

**Tests**
- [x] Unit tests for `changeImageEdgeWidth` and `changeImageEdgeHeight`
- [ ] Visual test in demo app (I might need some help - I'm not farmiliar with this kind of screenshot e2e but II'll try)