### PR TITLE
feat(extensions): Cropping controls with edge resize and flip support

### DIFF
--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -108,8 +108,9 @@ interface TEventWithTarget<E extends Event = TPointerEvent> extends TEvent<E> {
   target: FabricObject;
 }
 
-export interface BasicTransformEvent<E extends Event = TPointerEvent>
-  extends TEvent<E> {
+export interface BasicTransformEvent<
+  E extends Event = TPointerEvent,
+> extends TEvent<E> {
   transform: Transform;
   /* This pointer is usually a scenePoint. It isn't in the case of actions inside groups,
    * where it becomes a point relative to the group center
@@ -163,8 +164,9 @@ type CanvasModificationEvents = {
   'object:modified': ModifiedEvent;
 };
 
-export interface TPointerEventInfo<E extends TPointerEvent = TPointerEvent>
-  extends TEvent<E> {
+export interface TPointerEventInfo<
+  E extends TPointerEvent = TPointerEvent,
+> extends TEvent<E> {
   target?: FabricObject;
   subTargets?: FabricObject[];
   transform?: Transform | null;
@@ -172,8 +174,9 @@ export interface TPointerEventInfo<E extends TPointerEvent = TPointerEvent>
   viewportPoint: Point;
 }
 
-interface SimpleEventHandler<T extends Event = TPointerEvent>
-  extends TEvent<T> {
+interface SimpleEventHandler<
+  T extends Event = TPointerEvent,
+> extends TEvent<T> {
   target?: FabricObject;
   subTargets: FabricObject[];
 }
@@ -288,10 +291,7 @@ export interface MiscEvents {
 }
 
 export interface ObjectEvents
-  extends ObjectPointerEvents,
-    DnDEvents,
-    MiscEvents,
-    ObjectModificationEvents {
+  extends ObjectPointerEvents, DnDEvents, MiscEvents, ObjectModificationEvents {
   // selection
   selected: Partial<TEvent> & {
     target: FabricObject;
@@ -320,7 +320,8 @@ export interface StaticCanvasEvents extends CollectionEvents {
 }
 
 export interface CanvasEvents
-  extends StaticCanvasEvents,
+  extends
+    StaticCanvasEvents,
     CanvasPointerEvents,
     CanvasDnDEvents,
     MiscEvents,

--- a/src/canvas/CanvasOptions.ts
+++ b/src/canvas/CanvasOptions.ts
@@ -227,7 +227,8 @@ export interface CanvasEventsOptions {
 }
 
 export interface CanvasOptions
-  extends StaticCanvasOptions,
+  extends
+    StaticCanvasOptions,
     CanvasTransformOptions,
     CanvasSelectionOptions,
     CanvasCursorOptions,

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -87,9 +87,9 @@ export type PatternQuality = 'fast' | 'good' | 'best' | 'nearest' | 'bilinear';
  */
 // TODO: fix `EventSpec` inheritance https://github.com/microsoft/TypeScript/issues/26154#issuecomment-1366616260
 export class StaticCanvas<
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    EventSpec extends StaticCanvasEvents = StaticCanvasEvents,
-  >
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  EventSpec extends StaticCanvasEvents = StaticCanvasEvents,
+>
   extends createCollectionMixin(CommonMethods<CanvasEvents>)
   implements StaticCanvasOptions
 {

--- a/src/canvas/StaticCanvasOptions.ts
+++ b/src/canvas/StaticCanvasOptions.ts
@@ -113,9 +113,7 @@ export interface CanvasExportOptions {
 }
 
 export interface StaticCanvasOptions
-  extends CanvasDrawableOptions,
-    CanvasRenderingOptions,
-    CanvasExportOptions {
+  extends CanvasDrawableOptions, CanvasRenderingOptions, CanvasExportOptions {
   /**
    * Width in virtual/logical pixels of the canvas.
    * The canvas can be larger than width if retina scaling is active

--- a/src/shapes/Circle.ts
+++ b/src/shapes/Circle.ts
@@ -44,8 +44,7 @@ interface UniqueCircleProps {
 }
 
 export interface SerializedCircleProps
-  extends SerializedObjectProps,
-    UniqueCircleProps {}
+  extends SerializedObjectProps, UniqueCircleProps {}
 
 export interface CircleProps extends FabricObjectProps, UniqueCircleProps {}
 
@@ -64,10 +63,10 @@ export const circleDefaultValues: Partial<TClassProperties<Circle>> = {
 };
 
 export class Circle<
-    Props extends TOptions<CircleProps> = Partial<CircleProps>,
-    SProps extends SerializedCircleProps = SerializedCircleProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TOptions<CircleProps> = Partial<CircleProps>,
+  SProps extends SerializedCircleProps = SerializedCircleProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends FabricObject<Props, SProps, EventSpec>
   implements UniqueCircleProps
 {

--- a/src/shapes/Ellipse.ts
+++ b/src/shapes/Ellipse.ts
@@ -20,18 +20,17 @@ interface UniqueEllipseProps {
 }
 
 export interface SerializedEllipseProps
-  extends SerializedObjectProps,
-    UniqueEllipseProps {}
+  extends SerializedObjectProps, UniqueEllipseProps {}
 
 export interface EllipseProps extends FabricObjectProps, UniqueEllipseProps {}
 
 const ELLIPSE_PROPS = ['rx', 'ry'] as const;
 
 export class Ellipse<
-    Props extends TOptions<EllipseProps> = Partial<EllipseProps>,
-    SProps extends SerializedEllipseProps = SerializedEllipseProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TOptions<EllipseProps> = Partial<EllipseProps>,
+  SProps extends SerializedEllipseProps = SerializedEllipseProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends FabricObject<Props, SProps, EventSpec>
   implements EllipseProps
 {

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -58,8 +58,7 @@ export interface GroupOwnProps {
 }
 
 export interface SerializedGroupProps
-  extends SerializedObjectProps,
-    GroupOwnProps {
+  extends SerializedObjectProps, GroupOwnProps {
   objects: SerializedObjectProps[];
   layoutManager: SerializedLayoutManager;
 }

--- a/src/shapes/IText/IText.ts
+++ b/src/shapes/IText/IText.ts
@@ -72,8 +72,7 @@ interface UniqueITextProps {
 }
 
 export interface SerializedITextProps
-  extends SerializedTextProps,
-    UniqueITextProps {}
+  extends SerializedTextProps, UniqueITextProps {}
 
 export interface ITextProps extends TextProps, UniqueITextProps {}
 
@@ -121,10 +120,10 @@ export interface ITextProps extends TextProps, UniqueITextProps {}
  * ```
  */
 export class IText<
-    Props extends TOptions<ITextProps> = Partial<ITextProps>,
-    SProps extends SerializedITextProps = SerializedITextProps,
-    EventSpec extends ITextEvents = ITextEvents,
-  >
+  Props extends TOptions<ITextProps> = Partial<ITextProps>,
+  SProps extends SerializedITextProps = SerializedITextProps,
+  EventSpec extends ITextEvents = ITextEvents,
+>
   extends ITextClickBehavior<Props, SProps, EventSpec>
   implements UniqueITextProps
 {

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -87,10 +87,10 @@ const IMAGE_PROPS = ['cropX', 'cropY'] as const;
  * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-1#images}
  */
 export class FabricImage<
-    Props extends TOptions<ImageProps> = Partial<ImageProps>,
-    SProps extends SerializedImageProps = SerializedImageProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TOptions<ImageProps> = Partial<ImageProps>,
+  SProps extends SerializedImageProps = SerializedImageProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends FabricObject<Props, SProps, EventSpec>
   implements ImageProps
 {

--- a/src/shapes/Line.ts
+++ b/src/shapes/Line.ts
@@ -23,8 +23,7 @@ interface UniqueLineProps {
 }
 
 export interface SerializedLineProps
-  extends SerializedObjectProps,
-    UniqueLineProps {}
+  extends SerializedObjectProps, UniqueLineProps {}
 
 /**
  * A Class to draw a line
@@ -34,10 +33,10 @@ export interface SerializedLineProps
  * @deprecated
  */
 export class Line<
-    Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
-    SProps extends SerializedLineProps = SerializedLineProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
+  SProps extends SerializedLineProps = SerializedLineProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends FabricObject<Props, SProps, EventSpec>
   implements UniqueLineProps
 {

--- a/src/shapes/Object/InteractiveObject.ts
+++ b/src/shapes/Object/InteractiveObject.ts
@@ -41,10 +41,10 @@ export type TStyleOverride = ControlRenderingStyleOverride &
   >;
 
 export class InteractiveFabricObject<
-    Props extends TFabricObjectProps = Partial<FabricObjectProps>,
-    SProps extends SerializedObjectProps = SerializedObjectProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TFabricObjectProps = Partial<FabricObjectProps>,
+  SProps extends SerializedObjectProps = SerializedObjectProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends FabricObject<Props, SProps, EventSpec>
   implements FabricObjectProps
 {

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -176,11 +176,11 @@ export type DrawContext =
  * @fires drop
  */
 export class FabricObject<
-    Props extends TOptions<ObjectProps> = Partial<ObjectProps>,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    SProps extends SerializedObjectProps = SerializedObjectProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TOptions<ObjectProps> = Partial<ObjectProps>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  SProps extends SerializedObjectProps = SerializedObjectProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends ObjectGeometry<EventSpec>
   implements ObjectProps
 {

--- a/src/shapes/Object/types/FabricObjectProps.ts
+++ b/src/shapes/Object/types/FabricObjectProps.ts
@@ -4,10 +4,7 @@ import type { LockInteractionProps } from './LockInteractionProps';
 import type { ObjectProps } from './ObjectProps';
 
 export interface FabricObjectProps
-  extends ObjectProps,
-    ControlProps,
-    BorderProps,
-    LockInteractionProps {
+  extends ObjectProps, ControlProps, BorderProps, LockInteractionProps {
   /**
    * When `true`, cache does not get updated during scaling. The picture will get blocky if scaled
    * too much and will be redrawn with correct details at the end of scaling.

--- a/src/shapes/Object/types/ObjectProps.ts
+++ b/src/shapes/Object/types/ObjectProps.ts
@@ -10,9 +10,7 @@ import type {
 } from './SerializedObjectProps';
 
 export interface ObjectProps
-  extends SerializedObjectProps,
-    ClipPathProps,
-    ObjectTransformActionProps {
+  extends SerializedObjectProps, ClipPathProps, ObjectTransformActionProps {
   clipPath?: FabricObject;
   fill: TFiller | string | null;
   stroke: TFiller | string | null;

--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -35,8 +35,7 @@ interface UniquePathProps {
 }
 
 export interface SerializedPathProps
-  extends SerializedObjectProps,
-    UniquePathProps {}
+  extends SerializedObjectProps, UniquePathProps {}
 
 export interface PathProps extends FabricObjectProps, UniquePathProps {}
 

--- a/src/shapes/Rect.ts
+++ b/src/shapes/Rect.ts
@@ -20,18 +20,17 @@ interface UniqueRectProps {
 }
 
 export interface SerializedRectProps
-  extends SerializedObjectProps,
-    UniqueRectProps {}
+  extends SerializedObjectProps, UniqueRectProps {}
 
 export interface RectProps extends FabricObjectProps, UniqueRectProps {}
 
 const RECT_PROPS = ['rx', 'ry'] as const;
 
 export class Rect<
-    Props extends TOptions<RectProps> = Partial<RectProps>,
-    SProps extends SerializedRectProps = SerializedRectProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TOptions<RectProps> = Partial<RectProps>,
+  SProps extends SerializedRectProps = SerializedRectProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends FabricObject<Props, SProps, EventSpec>
   implements RectProps
 {

--- a/src/shapes/Text/Text.ts
+++ b/src/shapes/Text/Text.ts
@@ -125,8 +125,7 @@ interface UniqueTextProps {
 }
 
 export interface SerializedTextProps
-  extends SerializedObjectProps,
-    UniqueTextProps {
+  extends SerializedObjectProps, UniqueTextProps {
   styles: TextStyleArray | TextStyle;
 }
 
@@ -139,10 +138,10 @@ export interface TextProps extends FabricObjectProps, UniqueTextProps {
  * @see {@link http://fabric5.fabricjs.com/fabric-intro-part-2#text}
  */
 export class FabricText<
-    Props extends TOptions<TextProps> = Partial<TextProps>,
-    SProps extends SerializedTextProps = SerializedTextProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TOptions<TextProps> = Partial<TextProps>,
+  SProps extends SerializedTextProps = SerializedTextProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends StyledText<Props, SProps, EventSpec>
   implements UniqueTextProps
 {

--- a/src/shapes/Textbox.ts
+++ b/src/shapes/Textbox.ts
@@ -40,7 +40,8 @@ interface UniqueTextboxProps {
 }
 
 export interface SerializedTextboxProps
-  extends SerializedITextProps,
+  extends
+    SerializedITextProps,
     Pick<UniqueTextboxProps, 'minWidth' | 'splitByGrapheme'> {}
 
 export interface TextboxProps extends ITextProps, UniqueTextboxProps {}
@@ -52,10 +53,10 @@ export interface TextboxProps extends ITextProps, UniqueTextboxProps {}
  * wrapping of lines.
  */
 export class Textbox<
-    Props extends TOptions<TextboxProps> = Partial<TextboxProps>,
-    SProps extends SerializedTextboxProps = SerializedTextboxProps,
-    EventSpec extends ITextEvents = ITextEvents,
-  >
+  Props extends TOptions<TextboxProps> = Partial<TextboxProps>,
+  SProps extends SerializedTextboxProps = SerializedTextboxProps,
+  EventSpec extends ITextEvents = ITextEvents,
+>
   extends IText<Props, SProps, EventSpec>
   implements UniqueTextboxProps
 {

--- a/src/shapes/Triangle.ts
+++ b/src/shapes/Triangle.ts
@@ -10,10 +10,10 @@ export const triangleDefaultValues: Partial<TClassProperties<Triangle>> = {
 };
 
 export class Triangle<
-    Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
-    SProps extends SerializedObjectProps = SerializedObjectProps,
-    EventSpec extends ObjectEvents = ObjectEvents,
-  >
+  Props extends TOptions<FabricObjectProps> = Partial<FabricObjectProps>,
+  SProps extends SerializedObjectProps = SerializedObjectProps,
+  EventSpec extends ObjectEvents = ObjectEvents,
+>
   extends FabricObject<Props, SProps, EventSpec>
   implements FabricObjectProps
 {


### PR DESCRIPTION
PR is a WIP but nearly there!

**FlippedImage Support**
It took me a while to figure out how to fix the crop controls when images are flipped. I had to reflect the pointer position and swap handlers. This works for standalone images but may not handle nested/flipped groups correctly - a proper solution would need scene-space positioning (otherwise grouping/flipped groups will cause inversion issues).

Now... what I did:
- [x] "Bouncy" edge resize controls (crop inward, uniform scale when bounds exhausted)
- [x] Flip-aware crop controls (withFlip wrapper swaps handlers correctly)
- [x] Unified the controls
- [x] Unit tests for flip handling
- [x] E2E tests with snapshots (I did my best here, not very familiar)

Last things I'd like to tackle
- [x] Fix edge  Resize flipped + rotated (just noticed)
- [ ] Reposition via ghostImage (better UX)
- [x] Fix exitCropMode interaction (UX should be imageDeselected)
- [ ] Handle interactions in scene space to fix local space issues when grouped/flipped
- [ ] Rotate ghost in crop mode bound by clip window (hardest interaction by far, might skip, I never solved this one)
- [x] ESC / ENTER keys (rule out trackpad double click inconsistency, and better UX)