### PR TITLE
ci(): harden privileged workflow_run actions

### DIFF
--- a/.github/workflows/comment_coverage.yml
+++ b/.github/workflows/comment_coverage.yml
@@ -10,6 +10,11 @@ permissions:
   pull-requests: write
 jobs:
   coverage:
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     env:
       unique_id: <!-- coverage-report -->
     name: Coverage reporting
@@ -20,21 +25,13 @@ jobs:
         with:
           sparse-checkout: |
             .github
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-vitest
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ runner.temp }}/artifacts
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: prnumber
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ${{ runner.temp }}/artifacts
-      - name: Add pr number to output
-        id: prnumber
-        run: echo "pr_number=$(cat ${{ runner.temp }}/artifacts/prnumber.txt)" >> $GITHUB_OUTPUT
       - name: Build the report
         id: report
         run: |
@@ -46,7 +43,7 @@ jobs:
         uses: ./.github/actions/find-create-or-update-comment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ steps.prnumber.outputs.pr_number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           body-includes: '${{ env.unique_id }}'
           comment-author: 'github-actions[bot]'
           body-path: ./cov.txt

--- a/.github/workflows/sonarqube_analysis.yml
+++ b/.github/workflows/sonarqube_analysis.yml
@@ -11,11 +11,20 @@ permissions:
 jobs:
   sonarqube_pr:
     name: SonarQube analysis
-    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion != 'cancelled' &&
+        (
+          github.event.workflow_run.event != 'pull_request' ||
+          github.event.workflow_run.head_repository.full_name == github.repository
+        )
+      }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Create temporary directories
         run: |
           mkdir -p ${{ runner.temp }}/artifacts/nyc_output
@@ -27,17 +36,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ runner.temp }}/artifacts/nyc_output
       - run: mv ${{ runner.temp }}/artifacts/nyc_output/lcov.info ./.nyc_output
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: ${{ github.event.workflow_run.event == 'pull_request' }}
-        with:
-          name: prnumber
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ${{ runner.temp }}/artifacts
-      - name: Add pr number to output
-        if: ${{ github.event.workflow_run.event == 'pull_request' }}
-        id: prnumber
-        run: echo "pr_number=$(cat ${{ runner.temp }}/artifacts/prnumber.txt)" >> $GITHUB_OUTPUT
       - name: SonarQube Scan PR
         if: ${{github.event.workflow_run.event == 'pull_request'}}
         uses: SonarSource/sonarqube-scan-action@v6
@@ -46,7 +44,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
-            -Dsonar.pullrequest.key=${{ steps.prnumber.outputs.pr_number }}
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
             -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
       - name: SonarQube Scan Branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,7 @@ on:
 
 permissions:
   actions: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   prime-build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): harden privileged workflow_run actions [#10922](https://github.com/fabricjs/fabric.js/pull/10922)
 - refactor(tests): remove coverage merge step [#10913](https://github.com/fabricjs/fabric.js/pull/10913)
 - chore(): remove leftover babel dep [#10914](https://github.com/fabricjs/fabric.js/pull/10914)
 - chore(deps-dev): bump inquirer from 12.10.0 to 13.3.2 [#10909](https://github.com/fabricjs/fabric.js/pull/10909)


### PR DESCRIPTION
This hardens the privileged `workflow_run` post-processing workflows by tightening trust boundaries and reducing token scope where the current jobs do not need write access.

- limit privileged follow-up workflows to same-repository pull requests
- stop deriving PR numbers from artifacts produced by the unprivileged workflow
- remove unnecessary issue and pull-request write scopes from the test workflow

close #10920
