### PR TITLE
refactor(test): fix dead assertions in Shadow.spec.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- refactor(test): fix dead assertions in Shadow.spec.ts [#10932](https://github.com/fabricjs/fabric.js/pull/10932)
 - chore(deps): update devDependencies to latest versions [#10929](https://github.com/fabricjs/fabric.js/pull/10929)
 - chore(deps-dev): bump picomatch from 2.3.1 to 2.3.2 in the npm_and_yarn group across 1 directory [#10928](https://github.com/fabricjs/fabric.js/pull/10928)
 - chore(deps): bump canvas from 3.2.1 to 3.2.2 [#10926](https://github.com/fabricjs/fabric.js/pull/10926)

--- a/src/Shadow.spec.ts
+++ b/src/Shadow.spec.ts
@@ -155,15 +155,14 @@ describe('Shadow', () => {
     const shadow = new Shadow();
 
     const object = shadow.toObject();
-    expect(
-      JSON.stringify(object),
+    expect(JSON.stringify(object)).toBe(
       '{"color":"rgb(0,0,0)","blur":0,"offsetX":0,"offsetY":0,"affectStroke":false,"nonScaling":false,"type":"shadow"}',
     );
   });
 
   it('clone with affectStroke', () => {
     const shadow = new Shadow({ affectStroke: true, blur: 5 });
-    expect(typeof shadow.toObject === 'function');
+    expect(shadow.toObject).toBeTypeOf('function');
     const object = shadow.toObject(),
       shadow2 = new Shadow(object),
       object2 = shadow2.toObject();
@@ -175,24 +174,22 @@ describe('Shadow', () => {
     const shadow = new Shadow();
     shadow.includeDefaultValues = false;
 
-    expect(JSON.stringify(shadow.toObject()), '{"type":"shadow"}');
+    expect(JSON.stringify(shadow.toObject())).toBe('{"type":"shadow"}');
 
     shadow.color = 'red';
-    expect(
-      JSON.stringify(shadow.toObject()),
+    expect(JSON.stringify(shadow.toObject())).toBe(
       '{"color":"red","type":"shadow"}',
     );
 
     shadow.offsetX = 15;
-    expect(
-      JSON.stringify(shadow.toObject()),
+    expect(JSON.stringify(shadow.toObject())).toBe(
       '{"color":"red","offsetX":15,"type":"shadow"}',
     );
   });
 
   it('fromObject', async () => {
     return Shadow.fromObject({ color: 'red', offsetX: 15 }).then((shadow) => {
-      expect(shadow instanceof Shadow);
+      expect(shadow).toBeInstanceOf(Shadow);
     });
   });
 


### PR DESCRIPTION
 Seems like this somehow went through during test migrations from qunit

I am going through sonar issues and will be opening bite sized PRs for things that make sense
this is first of those findings