### PR TITLE
refactor(tests): Migrate to official vitest API for custom snapshot matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [next]
 
 - chore(deps-dev): bump serialize-javascript from 7.0.4 to 7.0.5 in the npm_and_yarn group across 1 directory [#10936](https://github.com/fabricjs/fabric.js/pull/10936)
+- Vitest snapshot [#10937](https://github.com/fabricjs/fabric.js/pull/10937)
+- refactor(tests): Migrate to official vitest API for custom snapshot matchers [#10937](https://github.com/fabricjs/fabric.js/pull/10937)
 - refactor(test): fix dead assertions in Shadow.spec.ts [#10932](https://github.com/fabricjs/fabric.js/pull/10932)
 - chore(): update typescript to 6 [#10935](https://github.com/fabricjs/fabric.js/pull/10935)
 - chore(deps): update devDependencies to latest versions [#10929](https://github.com/fabricjs/fabric.js/pull/10929)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## [next]
 
 - chore(deps-dev): bump serialize-javascript from 7.0.4 to 7.0.5 in the npm_and_yarn group across 1 directory [#10936](https://github.com/fabricjs/fabric.js/pull/10936)
-- Vitest snapshot [#10937](https://github.com/fabricjs/fabric.js/pull/10937)
 - refactor(tests): Migrate to official vitest API for custom snapshot matchers [#10937](https://github.com/fabricjs/fabric.js/pull/10937)
 - refactor(test): fix dead assertions in Shadow.spec.ts [#10932](https://github.com/fabricjs/fabric.js/pull/10932)
 - chore(): update typescript to 6 [#10935](https://github.com/fabricjs/fabric.js/pull/10935)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "@types/jsdom": "^21.1.7",
         "@types/micromatch": "^4.0.10",
         "@types/node": "^24.7.0",
-        "@vitest/browser-playwright": "https://pkg.pr.new/@vitest/browser-playwright@6392a1f",
-        "@vitest/coverage-v8": "https://pkg.pr.new/@vitest/coverage-v8@6392a1f",
-        "@vitest/ui": "https://pkg.pr.new/@vitest/ui@6392a1f",
+        "@vitest/browser-playwright": "4.1.3",
+        "@vitest/coverage-v8": "4.1.3",
+        "@vitest/ui": "4.1.3",
         "commander": "^14.0.3",
         "es-toolkit": "1.45.1",
         "eslint-config-prettier": "^10.1.8",
@@ -32,7 +32,7 @@
         "tsc-files": "^1.1.4",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.0",
-        "vitest": "https://pkg.pr.new/vitest@6392a1f",
+        "vitest": "4.1.3",
         "westures": "^1.1.1"
       },
       "engines": {
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1962,15 +1962,15 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/browser@6392a1f",
-      "integrity": "sha512-QJZ8qVDbZkuNkG/DM+/WqEL+/R3w7vURPrc4l++IVzcZ6koQLqykpLcrrn+KLObc/h34PnCITw2LZiINBZvN4g==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.3.tgz",
+      "integrity": "sha512-CS9KjO2vijuBlbwz0JIgC0YuoI1BuqWI5ziD3Nll6jkpNYtWdjPMVgGynQ9vZovjsECeUqEeNjWrypP414d0CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "https://pkg.pr.new/vitest-dev/vitest/@vitest/mocker@6392a1f",
-        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
+        "@vitest/mocker": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "magic-string": "^0.30.21",
         "pngjs": "^7.0.0",
         "sirv": "^3.0.2",
@@ -1981,18 +1981,18 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.2"
+        "vitest": "4.1.3"
       }
     },
     "node_modules/@vitest/browser-playwright": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/@vitest/browser-playwright@6392a1f",
-      "integrity": "sha512-S7Xow/RdkWT9qzhSyU1kVQlALUVn/XjRogQjdyX3rQpGhuuwkOeqAFgEipdTIr2vaMv2RVtozGCvxqTCUI3ZCA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.3.tgz",
+      "integrity": "sha512-D3Q+YozvSpiFaLPgd6/OMbyqEIZeucSe6AHJJ7VnNJKQhIyBE60TlBZlxzwM8bvjzQE9ZnYWQCPeCw5pnhbiNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/browser": "https://pkg.pr.new/vitest-dev/vitest/@vitest/browser@6392a1f",
-        "@vitest/mocker": "https://pkg.pr.new/vitest-dev/vitest/@vitest/mocker@6392a1f",
+        "@vitest/browser": "4.1.3",
+        "@vitest/mocker": "4.1.3",
         "tinyrainbow": "^3.1.0"
       },
       "funding": {
@@ -2000,7 +2000,7 @@
       },
       "peerDependencies": {
         "playwright": "*",
-        "vitest": "4.1.2"
+        "vitest": "4.1.3"
       },
       "peerDependenciesMeta": {
         "playwright": {
@@ -2009,14 +2009,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/@vitest/coverage-v8@6392a1f",
-      "integrity": "sha512-XaP6tpkISeOron7D2XRu2Adnk2PUwzd0fflscov8nOosfW7U21KJ2u8N1zlGDBcUEJAIGW6p1raeQHZ8Ldr7Dg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.3.tgz",
+      "integrity": "sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
+        "@vitest/utils": "4.1.3",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -2030,8 +2030,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.2",
-        "vitest": "4.1.2"
+        "@vitest/browser": "4.1.3",
+        "vitest": "4.1.3"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2040,16 +2040,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/expect@6392a1f",
-      "integrity": "sha512-gUVYkFCT5C0g+shzy2vex8Eybqx3G5Pd7V4by2mkCb4xa/lKcRyALQe8n1bVnLQaS5GjlAcvJaQwVMBrPlsE5Q==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.3.tgz",
+      "integrity": "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "https://pkg.pr.new/vitest-dev/vitest/@vitest/spy@6392a1f",
-        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
+        "@vitest/spy": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2058,13 +2058,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/mocker@6392a1f",
-      "integrity": "sha512-7rSWl0P86WhyIbL+uIztGBOCCD4FarXuX+czlG6UxYXjyarHmQgcO2MGX+oBxYvvbAdAVOGa6/mpwBPu5Ufkww==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
+      "integrity": "sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "https://pkg.pr.new/vitest-dev/vitest/@vitest/spy@6392a1f",
+        "@vitest/spy": "4.1.3",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/pretty-format@6392a1f",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
+      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2098,13 +2098,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/runner@6392a1f",
-      "integrity": "sha512-ANLp3/0tLZ8v1V/Y+hcHNZBPGJk/4jl35G3L4jfb+yGcjsrngwKm/7wVfWoNK9kFscR5rDxFIEouP3vFmuCAbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.3.tgz",
+      "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
+        "@vitest/utils": "4.1.3",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2112,14 +2112,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/snapshot@6392a1f",
-      "integrity": "sha512-+/nEak9V0vOnNBFNCrxY7vj6CsO1N8Ro6eu65pG+nAKfl8Mc4N3wYbVE9h8T6AqQipD/d4z+ETyaqnkSikm3nQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.3.tgz",
+      "integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "https://pkg.pr.new/vitest-dev/vitest/@vitest/pretty-format@6392a1f",
-        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
+        "@vitest/pretty-format": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2128,9 +2128,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/spy@6392a1f",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.3.tgz",
+      "integrity": "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2138,13 +2138,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/@vitest/ui@6392a1f",
-      "integrity": "sha512-XLE/wSRII72fgXK0ZKXIgwiXH2Yr6w41cn9Q+16zqYKOSTqc0AW5UrHluLAxOwE+vSoFlcNXR5hM/Sx4fTWLhA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.3.tgz",
+      "integrity": "sha512-xBPy+43o1fgMLUDlufUXh7tlT/Es8uS5eiyBY2PyPfFYSGpApZskLw65DROoDz+rgYkPuAmb20Mv9Z9g1WQE7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
+        "@vitest/utils": "4.1.3",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -2156,17 +2156,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.2"
+        "vitest": "4.1.3"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
-      "integrity": "sha512-yzcyX6Xw5uMK3ay0FWMY6AvQ6LP33Y5cedM5Ac/vKdajevJa2+yWoSMqVgi/7JT5C1+DygS4l8KjJkc1W7w/uA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
+      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "https://pkg.pr.new/vitest-dev/vitest/@vitest/pretty-format@6392a1f",
+        "@vitest/pretty-format": "4.1.3",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2369,13 +2369,6 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
       }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3842,22 +3835,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-report/node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -3871,6 +3848,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "26.1.0",
@@ -4434,6 +4418,22 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -6005,9 +6005,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6032,7 +6032,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -6083,19 +6083,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://pkg.pr.new/vitest@6392a1f",
-      "integrity": "sha512-1jHcm6YBnB9Cj/h4ZaSlnwB31AVQgfHVQxrlW/WXhGdNSCng5BY2pdZrQNjhEcGro+PMcA89+eUfDjeYEy2ecQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.3.tgz",
+      "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "https://pkg.pr.new/vitest-dev/vitest/@vitest/expect@6392a1f",
-        "@vitest/mocker": "https://pkg.pr.new/vitest-dev/vitest/@vitest/mocker@6392a1f",
-        "@vitest/pretty-format": "https://pkg.pr.new/vitest-dev/vitest/@vitest/pretty-format@6392a1f",
-        "@vitest/runner": "https://pkg.pr.new/vitest-dev/vitest/@vitest/runner@6392a1f",
-        "@vitest/snapshot": "https://pkg.pr.new/vitest-dev/vitest/@vitest/snapshot@6392a1f",
-        "@vitest/spy": "https://pkg.pr.new/vitest-dev/vitest/@vitest/spy@6392a1f",
-        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
+        "@vitest/expect": "4.1.3",
+        "@vitest/mocker": "4.1.3",
+        "@vitest/pretty-format": "4.1.3",
+        "@vitest/runner": "4.1.3",
+        "@vitest/snapshot": "4.1.3",
+        "@vitest/spy": "4.1.3",
+        "@vitest/utils": "4.1.3",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6123,12 +6123,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/coverage-istanbul": "4.1.2",
-        "@vitest/coverage-v8": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.3",
+        "@vitest/browser-preview": "4.1.3",
+        "@vitest/browser-webdriverio": "4.1.3",
+        "@vitest/coverage-istanbul": "4.1.3",
+        "@vitest/coverage-v8": "4.1.3",
+        "@vitest/ui": "4.1.3",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "@types/jsdom": "^21.1.7",
         "@types/micromatch": "^4.0.10",
         "@types/node": "^24.7.0",
-        "@vitest/browser-playwright": "^4.1.2",
-        "@vitest/coverage-v8": "^4.1.2",
-        "@vitest/ui": "^4.1.2",
+        "@vitest/browser-playwright": "https://pkg.pr.new/@vitest/browser-playwright@6392a1f",
+        "@vitest/coverage-v8": "https://pkg.pr.new/@vitest/coverage-v8@6392a1f",
+        "@vitest/ui": "https://pkg.pr.new/@vitest/ui@6392a1f",
         "commander": "^14.0.3",
         "es-toolkit": "1.45.1",
         "eslint-config-prettier": "^10.1.8",
@@ -32,7 +32,7 @@
         "tsc-files": "^1.1.4",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.2",
+        "vitest": "https://pkg.pr.new/vitest@6392a1f",
         "westures": "^1.1.1"
       },
       "engines": {
@@ -1963,14 +1963,14 @@
     },
     "node_modules/@vitest/browser": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.2.tgz",
-      "integrity": "sha512-CwdIf90LNf1Zitgqy63ciMAzmyb4oIGs8WZ40VGYrWkssQKeEKr32EzO8MKUrDPPcPVHFI9oQ5ni2Hp24NaNRQ==",
+      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/browser@6392a1f",
+      "integrity": "sha512-QJZ8qVDbZkuNkG/DM+/WqEL+/R3w7vURPrc4l++IVzcZ6koQLqykpLcrrn+KLObc/h34PnCITw2LZiINBZvN4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/mocker": "https://pkg.pr.new/vitest-dev/vitest/@vitest/mocker@6392a1f",
+        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
         "magic-string": "^0.30.21",
         "pngjs": "^7.0.0",
         "sirv": "^3.0.2",
@@ -1986,13 +1986,13 @@
     },
     "node_modules/@vitest/browser-playwright": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.2.tgz",
-      "integrity": "sha512-N0Z2HzMLvMR6k/tWPTS6Q/DaRscrkax/f2f9DIbNQr+Cd1l4W4wTf/I6S983PAMr0tNqqoTL+xNkLh9M5vbkLg==",
+      "resolved": "https://pkg.pr.new/@vitest/browser-playwright@6392a1f",
+      "integrity": "sha512-S7Xow/RdkWT9qzhSyU1kVQlALUVn/XjRogQjdyX3rQpGhuuwkOeqAFgEipdTIr2vaMv2RVtozGCvxqTCUI3ZCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/browser": "4.1.2",
-        "@vitest/mocker": "4.1.2",
+        "@vitest/browser": "https://pkg.pr.new/vitest-dev/vitest/@vitest/browser@6392a1f",
+        "@vitest/mocker": "https://pkg.pr.new/vitest-dev/vitest/@vitest/mocker@6392a1f",
         "tinyrainbow": "^3.1.0"
       },
       "funding": {
@@ -2010,13 +2010,13 @@
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
-      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "resolved": "https://pkg.pr.new/@vitest/coverage-v8@6392a1f",
+      "integrity": "sha512-XaP6tpkISeOron7D2XRu2Adnk2PUwzd0fflscov8nOosfW7U21KJ2u8N1zlGDBcUEJAIGW6p1raeQHZ8Ldr7Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -2041,15 +2041,15 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/expect@6392a1f",
+      "integrity": "sha512-gUVYkFCT5C0g+shzy2vex8Eybqx3G5Pd7V4by2mkCb4xa/lKcRyALQe8n1bVnLQaS5GjlAcvJaQwVMBrPlsE5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "https://pkg.pr.new/vitest-dev/vitest/@vitest/spy@6392a1f",
+        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2059,12 +2059,12 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/mocker@6392a1f",
+      "integrity": "sha512-7rSWl0P86WhyIbL+uIztGBOCCD4FarXuX+czlG6UxYXjyarHmQgcO2MGX+oBxYvvbAdAVOGa6/mpwBPu5Ufkww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "https://pkg.pr.new/vitest-dev/vitest/@vitest/spy@6392a1f",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2086,7 +2086,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/pretty-format@6392a1f",
       "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
       "dev": true,
       "license": "MIT",
@@ -2099,12 +2099,12 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/runner@6392a1f",
+      "integrity": "sha512-ANLp3/0tLZ8v1V/Y+hcHNZBPGJk/4jl35G3L4jfb+yGcjsrngwKm/7wVfWoNK9kFscR5rDxFIEouP3vFmuCAbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2113,13 +2113,13 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/snapshot@6392a1f",
+      "integrity": "sha512-+/nEak9V0vOnNBFNCrxY7vj6CsO1N8Ro6eu65pG+nAKfl8Mc4N3wYbVE9h8T6AqQipD/d4z+ETyaqnkSikm3nQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "https://pkg.pr.new/vitest-dev/vitest/@vitest/pretty-format@6392a1f",
+        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2129,7 +2129,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/spy@6392a1f",
       "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
       "dev": true,
       "license": "MIT",
@@ -2139,12 +2139,12 @@
     },
     "node_modules/@vitest/ui": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.2.tgz",
-      "integrity": "sha512-/irhyeAcKS2u6Zokagf9tqZJ0t8S6kMZq4ZG9BHZv7I+fkRrYfQX4w7geYeC2r6obThz39PDxvXQzZX+qXqGeg==",
+      "resolved": "https://pkg.pr.new/@vitest/ui@6392a1f",
+      "integrity": "sha512-XLE/wSRII72fgXK0ZKXIgwiXH2Yr6w41cn9Q+16zqYKOSTqc0AW5UrHluLAxOwE+vSoFlcNXR5hM/Sx4fTWLhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -2161,12 +2161,12 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "resolved": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
+      "integrity": "sha512-yzcyX6Xw5uMK3ay0FWMY6AvQ6LP33Y5cedM5Ac/vKdajevJa2+yWoSMqVgi/7JT5C1+DygS4l8KjJkc1W7w/uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "https://pkg.pr.new/vitest-dev/vitest/@vitest/pretty-format@6392a1f",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -6084,18 +6084,18 @@
     },
     "node_modules/vitest": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "resolved": "https://pkg.pr.new/vitest@6392a1f",
+      "integrity": "sha512-1jHcm6YBnB9Cj/h4ZaSlnwB31AVQgfHVQxrlW/WXhGdNSCng5BY2pdZrQNjhEcGro+PMcA89+eUfDjeYEy2ecQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "https://pkg.pr.new/vitest-dev/vitest/@vitest/expect@6392a1f",
+        "@vitest/mocker": "https://pkg.pr.new/vitest-dev/vitest/@vitest/mocker@6392a1f",
+        "@vitest/pretty-format": "https://pkg.pr.new/vitest-dev/vitest/@vitest/pretty-format@6392a1f",
+        "@vitest/runner": "https://pkg.pr.new/vitest-dev/vitest/@vitest/runner@6392a1f",
+        "@vitest/snapshot": "https://pkg.pr.new/vitest-dev/vitest/@vitest/snapshot@6392a1f",
+        "@vitest/spy": "https://pkg.pr.new/vitest-dev/vitest/@vitest/spy@6392a1f",
+        "@vitest/utils": "https://pkg.pr.new/vitest-dev/vitest/@vitest/utils@6392a1f",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6126,6 +6126,8 @@
         "@vitest/browser-playwright": "4.1.2",
         "@vitest/browser-preview": "4.1.2",
         "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/coverage-istanbul": "4.1.2",
+        "@vitest/coverage-v8": "4.1.2",
         "@vitest/ui": "4.1.2",
         "happy-dom": "*",
         "jsdom": "*",
@@ -6148,6 +6150,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -71,9 +71,9 @@
     "@types/jsdom": "^21.1.7",
     "@types/micromatch": "^4.0.10",
     "@types/node": "^24.7.0",
-    "@vitest/browser-playwright": "^4.1.2",
-    "@vitest/coverage-v8": "^4.1.2",
-    "@vitest/ui": "^4.1.2",
+    "@vitest/browser-playwright": "https://pkg.pr.new/@vitest/browser-playwright@6392a1f",
+    "@vitest/coverage-v8": "https://pkg.pr.new/@vitest/coverage-v8@6392a1f",
+    "@vitest/ui": "https://pkg.pr.new/@vitest/ui@6392a1f",
     "commander": "^14.0.3",
     "es-toolkit": "1.45.1",
     "eslint-config-prettier": "^10.1.8",
@@ -88,7 +88,7 @@
     "tsc-files": "^1.1.4",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",
-    "vitest": "^4.1.2",
+    "vitest": "https://pkg.pr.new/vitest@6392a1f",
     "westures": "^1.1.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -71,9 +71,9 @@
     "@types/jsdom": "^21.1.7",
     "@types/micromatch": "^4.0.10",
     "@types/node": "^24.7.0",
-    "@vitest/browser-playwright": "https://pkg.pr.new/@vitest/browser-playwright@6392a1f",
-    "@vitest/coverage-v8": "https://pkg.pr.new/@vitest/coverage-v8@6392a1f",
-    "@vitest/ui": "https://pkg.pr.new/@vitest/ui@6392a1f",
+    "@vitest/browser-playwright": "4.1.3",
+    "@vitest/coverage-v8": "4.1.3",
+    "@vitest/ui": "4.1.3",
     "commander": "^14.0.3",
     "es-toolkit": "1.45.1",
     "eslint-config-prettier": "^10.1.8",
@@ -88,7 +88,7 @@
     "tsc-files": "^1.1.4",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",
-    "vitest": "https://pkg.pr.new/vitest@6392a1f",
+    "vitest": "4.1.3",
     "westures": "^1.1.1"
   },
   "engines": {

--- a/vitest.extend.ts
+++ b/vitest.extend.ts
@@ -1,4 +1,4 @@
-import { expect, chai } from 'vitest';
+import { expect, SnapshotMatchers } from 'vitest';
 
 import { cloneDeepWith } from 'es-toolkit/compat';
 import type { FabricObject } from './src/shapes/Object/Object';
@@ -46,13 +46,11 @@ export const roundSnapshotOptions = {
   },
 };
 
-const rawToMatchSnapshot = (chai.Assertion.prototype as any).toMatchSnapshot;
+const { toMatchSnapshot } = SnapshotMatchers;
 
-chai.util.addMethod(
-  chai.Assertion.prototype,
-  'toMatchObjectSnapshot',
-  function (
-    this: Chai.AssertionStatic,
+expect.extend({
+  toMatchObjectSnapshot(
+    received: unknown,
     {
       cloneDeepWith: customiser,
       includeDefaultValues,
@@ -60,8 +58,7 @@ chai.util.addMethod(
     }: ObjectOptions = {},
     hint?: string,
   ) {
-    const received = chai.util.flag(this, 'object');
-    let snap: Record<string, unknown> = received;
+    let snap = received as Record<string, unknown>;
 
     if (looksLikeFabricObject(received)) {
       const restore = received.includeDefaultValues;
@@ -82,21 +79,14 @@ chai.util.addMethod(
       if (k === 'id' && typeof v === 'number') return 0;
     });
 
-    chai.util.flag(this, 'object', value);
-    return rawToMatchSnapshot.call(this, properties, hint);
+    return toMatchSnapshot.call(this, value, properties, hint);
   },
-);
 
-chai.util.addMethod(
-  chai.Assertion.prototype,
-  'toMatchSnapshot',
-  function (
-    this: Chai.AssertionStatic,
+  toMatchSnapshot(
+    received: unknown,
     propertiesOrHint?: ExtendedOptions | string,
     hint?: string,
   ) {
-    const received = chai.util.flag(this, 'object');
-
     const { cloneDeepWith: customiser, ...rest } =
       typeof propertiesOrHint === 'object' && propertiesOrHint !== null
         ? propertiesOrHint
@@ -109,40 +99,20 @@ chai.util.addMethod(
           ? cloneDeepWith(received, customiser)
           : received;
 
-    chai.util.flag(this, 'object', value);
-
-    const args: unknown[] = [];
-
     if (typeof propertiesOrHint === 'string') {
-      args.push(propertiesOrHint);
+      return toMatchSnapshot.call(this, value, propertiesOrHint);
     } else if (propertiesOrHint && Object.keys(rest).length > 0) {
-      args.push(rest);
-      if (hint) args.push(hint);
+      return toMatchSnapshot.call(this, value, rest, hint);
     } else if (hint) {
-      args.push(hint);
+      return toMatchSnapshot.call(this, value, undefined, hint);
     }
-
-    return rawToMatchSnapshot.apply(this, args);
+    return toMatchSnapshot.call(this, value);
   },
-);
 
-chai.util.addMethod(
-  chai.Assertion.prototype,
-  'toMatchSVGSnapshot',
-  function (
-    this: Chai.AssertionStatic,
-    propertiesOrHint?: ExtendedOptions | string,
-    hint?: string,
-  ) {
-    const received = chai.util.flag(this, 'object');
-
-    const value = sanitizeSVG(received);
-
-    chai.util.flag(this, 'object', value);
-
-    return rawToMatchSnapshot.call(this, propertiesOrHint, hint);
+  toMatchSVGSnapshot(received: string, hint?: string) {
+    return toMatchSnapshot.call(this, sanitizeSVG(received), hint);
   },
-);
+});
 
 expect.extend({
   toSameImageObject(actual: FabricImage, expected: FabricImage) {

--- a/vitest.extend.ts
+++ b/vitest.extend.ts
@@ -14,9 +14,11 @@ function basename(link: string) {
 }
 
 function replaceLinks(value: string) {
-  return (value.match(SVG_XLINK_HREF_RE) || []).reduce(function (final, curr) {
-    return final.replace(curr, `xlink:href="assets/${basename(curr)}"`);
-  }, value);
+  return (value.match(SVG_XLINK_HREF_RE) ?? []).reduce(
+    (acc, match) =>
+      acc.replace(match, `xlink:href="assets/${basename(match)}"`),
+    value,
+  );
 }
 
 export function sanitizeSVG(value: string) {
@@ -62,8 +64,7 @@ expect.extend({
 
     if (looksLikeFabricObject(received)) {
       const restore = received.includeDefaultValues;
-      if (typeof includeDefaultValues === 'boolean')
-        received.includeDefaultValues = includeDefaultValues;
+      received.includeDefaultValues = includeDefaultValues ?? restore;
       snap = received.toObject();
       received.includeDefaultValues = restore;
     }
@@ -88,8 +89,7 @@ expect.extend({
     hint?: string,
   ) {
     const value = customiser ? cloneDeepWith(received, customiser) : received;
-    const hasProperties = Object.keys(rest).length > 0;
-    return hasProperties
+    return Object.keys(rest).length > 0
       ? toMatchSnapshot.call(this, value, rest, hint)
       : toMatchSnapshot.call(this, value, hint);
   },

--- a/vitest.extend.ts
+++ b/vitest.extend.ts
@@ -84,37 +84,20 @@ expect.extend({
 
   toMatchSnapshot(
     received: unknown,
-    propertiesOrHint?: ExtendedOptions | string,
+    { cloneDeepWith: customiser, ...rest }: ExtendedOptions = {},
     hint?: string,
   ) {
-    const { cloneDeepWith: customiser, ...rest } =
-      typeof propertiesOrHint === 'object' && propertiesOrHint !== null
-        ? propertiesOrHint
-        : {};
-
-    const value =
-      typeof received === 'string'
-        ? received
-        : customiser
-          ? cloneDeepWith(received, customiser)
-          : received;
-
-    if (typeof propertiesOrHint === 'string') {
-      return toMatchSnapshot.call(this, value, propertiesOrHint);
-    } else if (propertiesOrHint && Object.keys(rest).length > 0) {
-      return toMatchSnapshot.call(this, value, rest, hint);
-    } else if (hint) {
-      return toMatchSnapshot.call(this, value, undefined, hint);
-    }
-    return toMatchSnapshot.call(this, value);
+    const value = customiser ? cloneDeepWith(received, customiser) : received;
+    const hasProperties = Object.keys(rest).length > 0;
+    return hasProperties
+      ? toMatchSnapshot.call(this, value, rest, hint)
+      : toMatchSnapshot.call(this, value, hint);
   },
 
   toMatchSVGSnapshot(received: string, hint?: string) {
     return toMatchSnapshot.call(this, sanitizeSVG(received), hint);
   },
-});
 
-expect.extend({
   toSameImageObject(actual: FabricImage, expected: FabricImage) {
     const normalizedActual = {
       ...actual,

--- a/vitest.extend.ts
+++ b/vitest.extend.ts
@@ -1,4 +1,4 @@
-import { expect, SnapshotMatchers } from 'vitest';
+import { expect, Snapshots } from 'vitest';
 
 import { cloneDeepWith } from 'es-toolkit/compat';
 import type { FabricObject } from './src/shapes/Object/Object';
@@ -48,7 +48,7 @@ export const roundSnapshotOptions = {
   },
 };
 
-const { toMatchSnapshot } = SnapshotMatchers;
+const { toMatchSnapshot } = Snapshots;
 
 expect.extend({
   toMatchObjectSnapshot(


### PR DESCRIPTION
Some time ago when we were migrating from jest to vitest I created this issue for vitest
https://github.com/vitest-dev/vitest/issues/7848
it got closed since there was a workaround using chai
Now maintainers decided to actually add official API for this 
https://github.com/vitest-dev/vitest/issues/9948

Vitest maintainer now has asked me for a feedback https://github.com/vitest-dev/vitest/issues/7848#issuecomment-4173697535
I tried it out and it looks good
This PR will stay in draft until vitest stable is released with new API
but this will serve as a feedback to them for now