### PR TITLE
ci(): tighten workflow permissions for scorecard hardening

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,8 @@ on:
   schedule:
     - cron: '28 13 * * 4'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/sonarqube_analysis.yml
+++ b/.github/workflows/sonarqube_analysis.yml
@@ -7,37 +7,28 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
 jobs:
-  sonarqube_pr:
+  sonarqube:
     name: SonarQube analysis
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion != 'cancelled' &&
-        (
-          github.event.workflow_run.event != 'pull_request' ||
-          github.event.workflow_run.head_repository.full_name == github.repository
-        )
-      }}
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout PR head
+      - name: Checkout PR merge ref
         if: ${{ github.event.workflow_run.event == 'pull_request' }}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/merge
           fetch-depth: 0
-      - name: Checkout branch head
+          persist-credentials: false
+      - name: Checkout default branch
         if: ${{ github.event.workflow_run.event == 'push' }}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          persist-credentials: false
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: refs/heads/master
           fetch-depth: 0
+          persist-credentials: false
       - name: Create temporary directories
-        run: |
-          mkdir -p ${{ runner.temp }}/artifacts/nyc_output
-          mkdir .nyc_output
+        run: mkdir -p ${{ runner.temp }}/artifacts/nyc_output .nyc_output
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-vitest-sonarqube
@@ -46,7 +37,7 @@ jobs:
           path: ${{ runner.temp }}/artifacts/nyc_output
       - run: mv ${{ runner.temp }}/artifacts/nyc_output/lcov.info ./.nyc_output
       - name: SonarQube Scan PR
-        if: ${{github.event.workflow_run.event == 'pull_request'}}
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,11 +48,11 @@ jobs:
             -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
       - name: SonarQube Scan Branch
-        if: ${{github.event.workflow_run.event == 'push'}}
+        if: ${{ github.event.workflow_run.event == 'push' }}
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
-            -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }}
+            -Dsonar.branch.name=master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ on:
     paths-ignore: [CHANGELOG.md]
 
 permissions:
-  actions: write
   contents: read
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): tighten workflow permissions for scorecard hardening [#10953](https://github.com/fabricjs/fabric.js/pull/10953)
 - feat(): Update cron schedule for scorecard workflow [#10952](https://github.com/fabricjs/fabric.js/pull/10952)
 - Version 7.3.0 [#10951](https://github.com/fabricjs/fabric.js/pull/10951)
 - fix(cropping): keep ghost scaling controls anchored on flipped images [#10943](https://github.com/fabricjs/fabric.js/pull/10943)

--- a/SCORECARD_REMEDIATION_PLAN.md
+++ b/SCORECARD_REMEDIATION_PLAN.md
@@ -1,0 +1,78 @@
+# OpenSSF Scorecard Remediation Plan
+
+Last updated: 2026-04-18
+
+Current public Scorecard snapshot for `github.com/fabricjs/fabric.js`:
+
+- Aggregate score: `6.1 / 10`
+- Report date: `2026-04-18T07:39:30Z`
+- Reported commit: `f80aa89a0614f1936952d53557ed46abd94f8d6f`
+
+Checks below `10`:
+
+- `Dangerous-Workflow`: `0`
+- `Token-Permissions`: `0`
+- `Fuzzing`: `0`
+- `CII-Best-Practices`: `0`
+- `Code-Review`: `5`
+- `Pinned-Dependencies`: `7`
+- `Binary-Artifacts`: `8`
+- `CI-Tests`: `8`
+- `SAST`: `9`
+- `Packaging`: `-1`
+- `Signed-Releases`: `-1`
+- `Branch-Protection`: `-1`
+
+## Priority Order
+
+1. Harden GitHub Actions workflows.
+2. Remove or replace checked-in binaries.
+3. Make release and packaging workflows easier for Scorecard to detect.
+4. Tighten GitHub branch protection and required-check settings.
+5. Add fuzzing and signed release provenance.
+6. Complete OpenSSF Best Practices badge requirements.
+
+## Action Plan
+
+### 1. CI hardening
+
+- Replace the Sonar workflow's explicit `head_sha` / `head_branch` checkouts.
+- Keep fork PR support by using an untrusted test workflow followed by a privileged analysis workflow that does not build or install from the fork in the privileged context.
+- Avoid explicit `head_sha` / `head_branch` checkouts in privileged follow-up workflows when a safer ref or merge ref is available.
+- Reduce workflow token permissions to read-only by default and grant writes only where they are required.
+- Add missing top-level permissions declarations so Scorecard can see least-privilege defaults.
+- Pin any remaining third-party actions by full commit SHA.
+
+### 2. Binary artifacts
+
+- Remove `lib/google_closure_compiler.jar` if it is no longer used.
+- Remove `lib/yuicompressor-2.4.6.jar` if it is no longer used.
+- If either file is still needed, fetch it during CI or replace it with maintained npm tooling.
+
+### 3. Packaging and release signals
+
+- Simplify the npm release workflow so Scorecard can detect an official packaging path.
+- Prefer `npm ci` over `npm install` in publish workflows.
+- Move opaque publish logic out of `publish.js` where possible and keep the publish command explicit in workflow YAML.
+- Evaluate `npm publish --provenance` for stronger release provenance.
+
+### 4. Repository settings
+
+- Enable or verify branch protection rules for `master`, `5.x`, and `6.x`.
+- Require pull requests, approvals, stale-review dismissal, and up-to-date checks before merge.
+- Make CI and CodeQL required checks for protected branches.
+- Configure a fine-grained `SCORECARD_TOKEN` so the Scorecard action can read branch protection state.
+
+### 5. Longer-horizon security work
+
+- Add focused fuzz targets for SVG parsing, path parsing, JSON deserialization, and text/layout edge cases.
+- Publish signed release artifacts or attestations alongside GitHub Releases.
+- Apply for the OpenSSF Best Practices badge after workflow and policy gaps are closed.
+
+## First implementation pass
+
+This branch starts with the CI hardening items:
+
+- Sonar workflow redesign
+- obvious permission tightening in CI workflows
+- documentation of the remaining Scorecard work


### PR DESCRIPTION
This hardens a few workflows that were contributing to the current Scorecard findings, while keeping Sonar analysis working for pull requests opened from forks.

- remove unnecessary broad workflow permissions in the test and CodeQL workflows
- stop the Sonar follow-up workflow from checking out workflow_run head refs directly
- add the local Scorecard remediation plan and record this PR in CHANGELOG.md

Related: #10950