### PR TITLE
ci(): comment on changelog fixes instead of pushing

### DIFF
--- a/.github/workflows/changelog_upate.yml
+++ b/.github/workflows/changelog_upate.yml
@@ -5,86 +5,220 @@ on:
     types:
       - completed
 permissions:
-  contents: write
+  actions: read
+  pull-requests: write
 jobs:
   update_changelog:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-24.04
     steps:
       - name: 'Create an empty tmp directory'
-        run: |
-          mkdir ${{ runner.temp }}/artifacts
-      - name: Recover build stats
+        run: mkdir ${{ runner.temp }}/artifacts
+      - name: Recover changelog artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: changelog_artifact
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ runner.temp }}/artifacts
-      - name: Parse the artifact in github output
+      - name: Parse the artifact in GitHub output
         id: changelog_data
         run: |
           echo "log=$(cat ${{ runner.temp }}/artifacts/changelog_artifact.txt | jq -r '.log')" >> $GITHUB_OUTPUT
           echo "prev_log=$(cat ${{ runner.temp }}/artifacts/changelog_artifact.txt | jq -r '.prev_log')" >> $GITHUB_OUTPUT
           echo "full_name=$(cat ${{ runner.temp }}/artifacts/changelog_artifact.txt | jq -r '.full_name')" >> $GITHUB_OUTPUT
           echo "pr_ref=$(cat ${{ runner.temp }}/artifacts/changelog_artifact.txt | jq -r '.pr_ref')" >> $GITHUB_OUTPUT
-      - name: Pull down the correct branch and repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          ref: ${{ steps.changelog_data.outputs.pr_ref }}
-          repository: ${{ steps.changelog_data.outputs.full_name }}
-          sparse-checkout: |
-            CHANGELOG.md
-            .oxfmtrc.json
-      - name: Update CHANGELOG.md from PR title
-        id: update
+      - name: Comment on the PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v6.4.1
         env:
           log: '${{ steps.changelog_data.outputs.log }}'
           prev_log: '${{ steps.changelog_data.outputs.prev_log }}'
-          next_version: next
+          full_name: '${{ steps.changelog_data.outputs.full_name }}'
+          pr_ref: '${{ steps.changelog_data.outputs.pr_ref }}'
         with:
-          result-encoding: string
           script: |
-            const fs = require('fs');
-            const file = 'CHANGELOG.md';
-            let content = fs.readFileSync(file).toString();
-            const title = `[${process.env.next_version}]`;
-            const log = process.env.log;
-            const prev_log = process.env.prev_log;
-            const prev_log_exists = prev_log && content.includes(prev_log);
-            const log_exists = log && content.includes(log);
-            let modified = false;
-            if (!content.includes(title)) {
-            const insertAt = content.indexOf('\n') + 1;
-            content =
-                content.slice(0, insertAt) +
-                `\n## ${title}\n\n\n` +
-                content.slice(insertAt);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflowRun = context.payload.workflow_run;
+            const pullRequest = workflowRun.pull_requests[0];
+            if (!pullRequest) {
+              core.info('No pull request attached to this workflow_run event.');
+              return;
             }
 
-            if (prev_log_exists && log) {
-                modified = true;
-                content = content.replace(prev_log, log);
-            } else if (log && !log_exists) {
-                modified = true;
-                const insertAt = content.indexOf('\n', content.indexOf(title) + title.length + 1) + 1;
-                content = content.slice(0, insertAt) + log + '\n' + content.slice(insertAt);
+            const prNumber = pullRequest.number;
+            const markerIssue = '<!-- changelog-reminder -->';
+            const markerSuggestion = '<!-- changelog-suggestion -->';
+            const expectedLine = process.env.log;
+            const previousLine = process.env.prev_log;
+            const fullName = process.env.full_name;
+            const prRef = process.env.pr_ref;
+
+            const pr = await github.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            const headSha = pr.data.head.sha;
+
+            const files = await github.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/files', {
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+            const changelogFile = files.find((file) => file.filename === 'CHANGELOG.md');
+            const patch = changelogFile?.patch || '';
+
+            const issueComments = await github.paginate('GET /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const reviewComments = await github.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/comments', {
+              owner,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            const existingIssueComment = issueComments.find(
+              (comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(markerIssue),
+            );
+            const existingSuggestionComments = reviewComments.filter(
+              (comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(markerSuggestion),
+            );
+
+            const deleteSuggestionComments = async () => {
+              for (const comment of existingSuggestionComments) {
+                await github.request('DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}', {
+                  owner,
+                  repo,
+                  comment_id: comment.id,
+                });
+              }
+            };
+
+            const deleteIssueComment = async () => {
+              if (!existingIssueComment) {
+                return;
+              }
+              await github.request('DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}', {
+                owner,
+                repo,
+                comment_id: existingIssueComment.id,
+              });
+            };
+
+            const upsertIssueComment = async (body) => {
+              await deleteSuggestionComments();
+              if (existingIssueComment) {
+                await github.request('PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}', {
+                  owner,
+                  repo,
+                  comment_id: existingIssueComment.id,
+                  body,
+                });
+                return;
+              }
+              await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+            };
+
+            const findAddedLineNumber = (diffPatch, targetLine) => {
+              let newLine = 0;
+              for (const line of diffPatch.split('\n')) {
+                const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+                if (hunk) {
+                  newLine = Number(hunk[1]);
+                  continue;
+                }
+                if (line.startsWith('+++') || line.startsWith('---')) {
+                  continue;
+                }
+                if (line.startsWith('+')) {
+                  if (line.slice(1) === targetLine) {
+                    return newLine;
+                  }
+                  newLine += 1;
+                  continue;
+                }
+                if (!line.startsWith('-')) {
+                  newLine += 1;
+                }
+              }
+              return null;
+            };
+
+            if (!changelogFile) {
+              const editUrl = `https://github.com/${fullName}/edit/${prRef}/CHANGELOG.md`;
+              const body = [
+                markerIssue,
+                'This pull request is missing the required `CHANGELOG.md` entry under `## [next]`.',
+                '',
+                'Add this line and commit it manually:',
+                '',
+                `\`${expectedLine}\``,
+                '',
+                `If you have write access to the PR branch, you can edit it in GitHub: [Edit CHANGELOG.md](${editUrl})`,
+              ].join('\n');
+              await upsertIssueComment(body);
+              return;
             }
-            fs.writeFileSync(file, content);
-            return modified;
-      - name: Setup node
-        if: fromJson(steps.update.outputs.result)
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.4
-        with:
-          node-version: 24.x
-      - name: Commit & Push
-        if: fromJson(steps.update.outputs.result)
-        run: |
-          npx oxfmt CHANGELOG.md
-          git diff
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-          git add CHANGELOG.md
-          git commit -m "update CHANGELOG.md"
-          git push
+
+            if (previousLine && patch.includes(previousLine) && !patch.includes(expectedLine)) {
+              const lineNumber = findAddedLineNumber(patch, previousLine);
+              if (lineNumber) {
+                await deleteIssueComment();
+                await deleteSuggestionComments();
+                const body = [
+                  markerSuggestion,
+                  'The PR title changed, so the changelog line should be updated to match it.',
+                  '',
+                  '```suggestion',
+                  expectedLine,
+                  '```',
+                ].join('\n');
+                await github.request('POST /repos/{owner}/{repo}/pulls/{pull_number}/comments', {
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                  body,
+                  commit_id: headSha,
+                  path: 'CHANGELOG.md',
+                  line: lineNumber,
+                  side: 'RIGHT',
+                });
+                return;
+              }
+            }
+
+            if (previousLine && !patch.includes(expectedLine)) {
+              const editUrl = `https://github.com/${fullName}/edit/${prRef}/CHANGELOG.md`;
+              const body = [
+                markerIssue,
+                'The PR title changed, so the changelog entry needs to be updated manually.',
+                '',
+                'Replace the old line with this one and commit the change:',
+                '',
+                `\`${expectedLine}\``,
+                '',
+                `If you have write access to the PR branch, you can edit it in GitHub: [Edit CHANGELOG.md](${editUrl})`,
+              ].join('\n');
+              await upsertIssueComment(body);
+              return;
+            }
+
+            await deleteSuggestionComments();
+            await deleteIssueComment();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): comment on changelog fixes instead of pushing [#10958](https://github.com/fabricjs/fabric.js/pull/10958)
 - docs(): Revise security vulnerability reporting process [#10955](https://github.com/fabricjs/fabric.js/pull/10955)
 - ci(): pin workflow dependencies for scorecard hardening [#10954](https://github.com/fabricjs/fabric.js/pull/10954)
 - ci(): tighten workflow permissions for scorecard hardening [#10953](https://github.com/fabricjs/fabric.js/pull/10953)


### PR DESCRIPTION
This keeps the existing changelog checker and changes the follow-up workflow from branch writes to PR comments.

- keep the current pull_request changelog check and artifact generation flow
- replace the privileged write-back workflow with PR comments only
- post a review suggestion on the stale CHANGELOG.md line when the PR title changed and the old line is still present
- post a normal PR comment with the expected line and a GitHub edit link when CHANGELOG.md was not updated
- drop the need for contents: write in the follow-up workflow

Related: #10950