### PR TITLE
ci(dependabot): group vite-related npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+    groups:
+      vite:
+        applies-to: 'version-updates'
+        patterns:
+          - 'vite'
+          - 'vitest'
+          - '@vitejs/*'
+          - '@vitest/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
         applies-to: 'version-updates'
         patterns:
           - 'vite'
-          - 'vitest'
           - '@vitejs/*'
+      vitest:
+        applies-to: 'version-updates'
+        patterns:
+          - 'vitest'
           - '@vitest/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(dependabot): group vite-related npm updates [#10967](https://github.com/fabricjs/fabric.js/pull/10967)
 - chore(deps-dev): bump oxfmt from 0.42.0 to 0.45.0 [#10964](https://github.com/fabricjs/fabric.js/pull/10964)
 - chore(): fix non functional typos [#10949](https://github.com/fabricjs/fabric.js/pull/10949)
 - chore(): update major eslint to 10 [#10956](https://github.com/fabricjs/fabric.js/pull/10956)


### PR DESCRIPTION
This updates Dependabot's npm configuration so Vite-related packages are grouped into a single version-update PR instead of opening separate PRs for each package.

- add a `vite` Dependabot group for `vite`, `vitest`, `@vitejs/*`, and `@vitest/*`
- keep the existing weekly npm update schedule unchanged
- document the change in `CHANGELOG.md`