### PR TITLE
chore(): fix some sonar issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): fix some sonar issues [#10990](https://github.com/fabricjs/fabric.js/pull/10990)
 - chore(deps): update devDependencies to latest versions [#10982](https://github.com/fabricjs/fabric.js/pull/10982)
 - chore(): address some sonar reported issues [#10981](https://github.com/fabricjs/fabric.js/pull/10981)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.organization=fabricjs
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src,extensions,fabric.ts,index.node.ts,index.ts
-sonar.exclusions=dist-extensions/**/*,dist/**/*,**/*.spec.ts,e2e/**/*,.codesandbox/**/*
+sonar.exclusions=dist-extensions/**/*,dist/**/*,**/*.spec.ts,e2e/**/*,.codesandbox/**/*,src/benchmarks/**/*,src/parkinglot/**/*,src/mixins/eraser_brush.mixin.ts
 sonar.test.inclusions=**/*.spec.*,**/*.test.*
 sonar.tests=src,extensions
 
@@ -23,6 +23,12 @@ sonar.projectBaseDir=.
 sonar.javascript.lcov.reportPaths=./.nyc_output/lcov.info
 
 # Math.hypot has accuracy issues on Chrome, see https://stackoverflow.com/questions/62931950/different-results-of-math-hypot-on-chrome-and-firefox
-sonar.issue.ignore.multicriteria=e1
+# Number static method suggestions are mostly convention churn and increase bundle size.
+# TODO comments are tracked in source and should not fail Sonar analysis.
+sonar.issue.ignore.multicriteria=e1,e2,e3
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S7769
 sonar.issue.ignore.multicriteria.e1.resourceKey=**
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S7773
+sonar.issue.ignore.multicriteria.e2.resourceKey=**
+sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S1135
+sonar.issue.ignore.multicriteria.e3.resourceKey=**

--- a/src/gradient/Gradient.spec.ts
+++ b/src/gradient/Gradient.spec.ts
@@ -272,7 +272,7 @@ describe('Gradient', () => {
     expect(gradient.coords.r1).toBe(0);
     expect(gradient.coords.r2).toBe(50);
 
-    expect(gradient.type, 'radial');
+    expect(gradient.type).toBe('radial');
 
     expect(gradient.colorStops[0].offset).toBe(0);
     expect(gradient.colorStops[0].color).toBe('red');
@@ -284,7 +284,7 @@ describe('Gradient', () => {
   test('toObject linearGradient', () => {
     const gradient = createLinearGradient();
     gradient.gradientTransform = [1, 0, 0, 1, 50, 50];
-    expect(typeof gradient.toObject === 'function');
+    expect(gradient.toObject).toBeTypeOf('function');
 
     const object = gradient.toObject();
 

--- a/src/shapes/IText/ITextKeyBehavior.ts
+++ b/src/shapes/IText/ITextKeyBehavior.ts
@@ -72,7 +72,7 @@ export abstract class ITextKeyBehavior<
       'data-fabric': 'textarea',
       wrap: 'off',
       name: 'fabricTextarea',
-    }).map(([attribute, value]) => textarea.setAttribute(attribute, value));
+    }).forEach(([attribute, value]) => textarea.setAttribute(attribute, value));
     const { top, left, fontSize } = this._calcTextareaPosition();
     // line-height: 1px; was removed from the style to fix this:
     // https://bugs.chromium.org/p/chromium/issues/detail?id=870966
@@ -91,7 +91,7 @@ export abstract class ITextKeyBehavior<
       compositionstart: 'onCompositionStart',
       compositionupdate: 'onCompositionUpdate',
       compositionend: 'onCompositionEnd',
-    } as Record<string, keyof this>).map(([eventName, handler]) =>
+    } as Record<string, keyof this>).forEach(([eventName, handler]) =>
       textarea.addEventListener(
         eventName,
         (this[handler] as EventListener).bind(this),

--- a/src/shapes/Object/StackedObject.spec.ts
+++ b/src/shapes/Object/StackedObject.spec.ts
@@ -64,10 +64,10 @@ describe('FabricObject stacking', () => {
     expect(object.group).toEqual(activeSelection);
     expect(object.parent).toEqual(parent);
     expect(object.canvas).toEqual(canvas);
-    expect(object.isDescendantOf(parent));
+    expect(object.isDescendantOf(parent)).toBe(true);
     expect(object.isDescendantOf(activeSelection)).toBe(true);
     delete object.parent;
-    expect(!object.isDescendantOf(parent));
+    expect(object.isDescendantOf(parent)).toBe(false);
     expect(object.isDescendantOf(activeSelection)).toBe(true);
   });
 


### PR DESCRIPTION
 Also excludes some rules and files
 Rule excluded is `Number.` namespaced methods, they would most likely increase bundle size.
 Also turned off the "TODO" rule since there are many TODOs in the code and causes lot of sonar complaints.
 Excluded files are deadcode, not sure if we want to keep them or remove them, but they cause noise for sonar
