### PR TITLE
chore(): disable Sonar optional chaining suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): disable Sonar optional chaining suggestions
 - chore(deps-dev): bump the vitest group across 1 directory with 4 updates [#11003](https://github.com/fabricjs/fabric.js/pull/11003)
 - chore(deps-dev): bump typescript-eslint from 8.59.4 to 8.60.1 [#11004](https://github.com/fabricjs/fabric.js/pull/11004)
 - chore(deps-dev): bump rolldown from 1.0.2 to 1.1.0 [#11005](https://github.com/fabricjs/fabric.js/pull/11005)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,10 +25,13 @@ sonar.javascript.lcov.reportPaths=./.nyc_output/lcov.info
 # Math.hypot has accuracy issues on Chrome, see https://stackoverflow.com/questions/62931950/different-results-of-math-hypot-on-chrome-and-firefox
 # Number static method suggestions are mostly convention churn and increase bundle size.
 # TODO comments are tracked in source and should not fail Sonar analysis.
-sonar.issue.ignore.multicriteria=e1,e2,e3
+# Optional chaining is available in eslint, no need to have it in sonar
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
 sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S7769
 sonar.issue.ignore.multicriteria.e1.resourceKey=**
 sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S7773
 sonar.issue.ignore.multicriteria.e2.resourceKey=**
 sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S1135
 sonar.issue.ignore.multicriteria.e3.resourceKey=**
+sonar.issue.ignore.multicriteria.e4.ruleKey=typescript:S6582
+sonar.issue.ignore.multicriteria.e4.resourceKey=**


### PR DESCRIPTION
 We can enable this in eslint instead once we drop node 22 support and can increase the build target
 no need to have this active in sonar, its just stacking noise