### PR TITLE
fix(Gradient): escape colorStop colors in SVG export (backport GHSA-w22m to 6.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [next]
 
+- fix(Gradient): Escape colorStop colors in SVG export, backport of GHSA-w22m-hvvm-xmwx [#11032](https://github.com/fabricjs/fabric.js/pull/11032)
+
 ## [6.9.1]
 
 - fix(): Fix the situation where undefined + char exists when calculating couple [#10816](https://github.com/fabricjs/fabric.js/pull/10816)

--- a/src/gradient/Gradient.spec.ts
+++ b/src/gradient/Gradient.spec.ts
@@ -567,4 +567,56 @@ describe('Gradient', () => {
     expect(gradient.colorStops[2].opacity).toEqual(1);
     expect(gradient.colorStops[3].opacity).toEqual(1);
   });
+
+  describe('toSVG colorStop sanitization (GHSA-w22m-hvvm-xmwx)', () => {
+    const exportObject = () => new FabricObject({ width: 100, height: 100 });
+
+    it('neutralizes HTML/attribute breakout in a stop color', () => {
+      const gradient = new Gradient({
+        type: 'linear',
+        colorStops: [
+          { offset: 0, color: 'red"><img src="x" onerror="alert(1)">' },
+        ],
+      });
+      const svg = gradient.toSVG(exportObject());
+      expect(svg).not.toContain('<img');
+      expect(svg).not.toContain('onerror=');
+      expect(svg).toContain('style="stop-color:rgba(0,0,0,1);"');
+    });
+
+    it('neutralizes CSS declaration injection in a stop color', () => {
+      const gradient = new Gradient({
+        type: 'linear',
+        colorStops: [{ offset: 0, color: 'red;stop-opacity:0' }],
+      });
+      const svg = gradient.toSVG(exportObject());
+      expect(svg).not.toContain('stop-opacity:0');
+      expect(svg).toContain('style="stop-color:rgba(0,0,0,1);"');
+    });
+
+    it('rejects url-based stop color payloads', () => {
+      const gradient = new Gradient({
+        type: 'linear',
+        colorStops: [{ offset: 0, color: 'url(javascript:alert(1))' }],
+      });
+      const svg = gradient.toSVG(exportObject());
+      expect(svg).not.toContain('javascript:');
+      expect(svg).toContain('style="stop-color:rgba(0,0,0,1);"');
+    });
+
+    it('preserves valid stop colors and escapes XML metacharacters', () => {
+      const gradient = new Gradient({
+        type: 'linear',
+        colorStops: [
+          { offset: 0, color: 'currentColor' },
+          { offset: 0.5, color: 'var(--brand)' },
+          { offset: 1, color: 'red&blue' },
+        ],
+      });
+      const svg = gradient.toSVG(exportObject());
+      expect(svg).toContain('style="stop-color:currentColor;"');
+      expect(svg).toContain('style="stop-color:var(--brand);"');
+      expect(svg).toContain('style="stop-color:red&amp;blue;"');
+    });
+  });
 });

--- a/src/gradient/Gradient.ts
+++ b/src/gradient/Gradient.ts
@@ -3,7 +3,9 @@ import { iMatrix } from '../constants';
 import { parseTransformAttribute } from '../parser/parseTransformAttribute';
 import type { FabricObject } from '../shapes/Object/FabricObject';
 import type { TMat2D } from '../typedefs';
+import { isSafeSvgStyleValue } from '../util/internals/svgExportCheck';
 import { uid } from '../util/internals/uid';
+import { escapeXml } from '../util/lang_string';
 import { pick } from '../util/misc/pick';
 import { matrixToSVG } from '../util/misc/svgExport';
 import { linearDefaultCoords, radialDefaultCoords } from './constants';
@@ -271,12 +273,18 @@ export class Gradient<
     }
 
     colorStops.forEach(({ color, offset, opacity }) => {
+      const rawColor = String(color);
+      // `escapeXml` protects the SVG attribute, but the value is also embedded
+      // in a CSS declaration, so reject tokens that can break either context.
+      const serializedColor = isSafeSvgStyleValue(rawColor)
+        ? rawColor
+        : new Color(rawColor).toRgba();
       markup.push(
         '<stop ',
         'offset="',
         offset * 100 + '%',
         '" style="stop-color:',
-        color,
+        escapeXml(serializedColor),
         typeof opacity !== 'undefined' ? ';stop-opacity: ' + opacity : ';',
         '"/>\n',
       );

--- a/src/util/internals/svgExportCheck.ts
+++ b/src/util/internals/svgExportCheck.ts
@@ -1,0 +1,9 @@
+const unsafeSvgStyleValueRegex = new RegExp(
+  String.raw`[\0-\x1F\x7F;<>\\]|\/\*|\*\/|url\s*\(|expression\s*\(|(?:java|vb)script\s*:|data\s*:|@import\b`,
+  'iu',
+);
+
+export const isSafeSvgStyleValue = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.trim().length > 0 &&
+  !unsafeSvgStyleValueRegex.test(value);


### PR DESCRIPTION
The 6.x line is missing the gradient colorStop escaping that shipped on the active major in v7.4.0 for GHSA-w22m-hvvm-xmwx. On 6.9.1, `Gradient.toSVG()` inlines each colorStop `color` straight into the `style="stop-color:..."` attribute with no escaping, so a crafted color breaks out of the attribute and injects arbitrary SVG. This is reachable whenever a gradient comes from untrusted input (e.g. `loadFromJSON`) and the canvas is later serialized with `toSVG()`.

Repro on 6.9.1:

```js
const g = new Gradient({
  type: 'linear',
  colorStops: [{ offset: 0, color: 'red"><img src=x onerror=alert(1)>' }],
});
g.toSVG(new Rect({ width: 100, height: 100, fill: g }));
// <stop offset="0%" style="stop-color:red"><img src=x onerror=alert(1)>;"/>
```

This backports the v7.4.0 fix: a value that is not a safe SVG style token is normalized through `Color(...).toRgba()`, and the result is passed through `escapeXml` for the attribute context. Because `style="stop-color:..."` is a CSS declaration, XML-escaping alone is not enough, hence the normalization step. Safe values (`currentColor`, `var(--x)`, `rgb(...)`, named colors) are left as-is, so existing output is preserved.

`escapeXml` already exists on 6.x; the only new file is the `isSafeSvgStyleValue` helper, copied from the v7 implementation. Added unit tests covering the HTML, CSS-declaration and url payloads plus the safe-value passthrough.

Oracle: GHSA-w22m-hvvm-xmwx, fixed on the active major in v7.4.0.
