### PR TITLE
chore(): Monorepo follow up steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           node-version: 24.x
       - run: pnpm run build
+      - name: Smoke test packages
+        run: pnpm run smoke:packages
   stats:
     name: Build stats
     runs-on: ubuntu-24.04

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -64,6 +64,8 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm run build
+      - name: Smoke test packages
+        run: pnpm run smoke:packages
       - name: Publish package
         shell: bash
         run: |

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -68,9 +68,9 @@ jobs:
         shell: bash
         run: |
           if [[ -n "${{ steps.publish.outputs.npm_tag }}" ]]; then
-            echo "pnpm publish --tag ${{ steps.publish.outputs.npm_tag }} --no-git-checks"
-            pnpm publish --tag "${{ steps.publish.outputs.npm_tag }}" --no-git-checks
+            echo "pnpm -r publish --tag ${{ steps.publish.outputs.npm_tag }} --access public --no-git-checks"
+            pnpm -r publish --tag "${{ steps.publish.outputs.npm_tag }}" --access public --no-git-checks
           else
-            echo "pnpm publish --no-git-checks"
-            pnpm publish --no-git-checks
+            echo "pnpm -r publish --access public --no-git-checks"
+            pnpm -r publish --access public --no-git-checks
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- chore(): Monorepo follow up steps [#11033](https://github.com/fabricjs/fabric.js/pull/11033)
 - chore(deps-dev): bump rolldown from 1.1.0 to 1.1.2 [#11025](https://github.com/fabricjs/fabric.js/pull/11025)
 - fix(sandbox): restore vanilla startup with pnpm [#11012](https://github.com/fabricjs/fabric.js/pull/11012)
 - fix(): nested duplicated clipPath causes infinite recursion [#10774](https://github.com/fabricjs/fabric.js/pull/10774)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- test(packages): add package artifact smoke invariants [#11034](https://github.com/fabricjs/fabric.js/pull/11034)
 - chore(deps-dev): bump rolldown from 1.1.0 to 1.1.2 [#11025](https://github.com/fabricjs/fabric.js/pull/11025)
 - fix(sandbox): restore vanilla startup with pnpm [#11012](https://github.com/fabricjs/fabric.js/pull/11012)
 - fix(): nested duplicated clipPath causes infinite recursion [#10774](https://github.com/fabricjs/fabric.js/pull/10774)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [next]
 
-- test(packages): add package artifact smoke invariants [#11034](https://github.com/fabricjs/fabric.js/pull/11034)
 - chore(): Monorepo follow up steps [#11033](https://github.com/fabricjs/fabric.js/pull/11033)
 - chore(deps-dev): bump rolldown from 1.1.0 to 1.1.2 [#11025](https://github.com/fabricjs/fabric.js/pull/11025)
 - fix(sandbox): restore vanilla startup with pnpm [#11012](https://github.com/fabricjs/fabric.js/pull/11012)

--- a/packages/aligning-guidelines/package.json
+++ b/packages/aligning-guidelines/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/cropping-controls/package.json
+++ b/packages/cropping-controls/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/data-updaters/package.json
+++ b/packages/data-updaters/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/gradient-controls/package.json
+++ b/packages/gradient-controls/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": true,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/westures-integration/package.json
+++ b/packages/westures-integration/package.json
@@ -12,6 +12,9 @@
     "url": "https://github.com/fabricjs/fabric.js/issues"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -5,6 +5,15 @@ import path from 'node:path';
 import { wd } from './dirname.mjs';
 import { publishablePackages } from './workspace-packages.mjs';
 
+/**
+ * Smoke-tests the actual npm artifacts, not the workspace source.
+ *
+ * Vitest runs inside the repo, where pnpm links, TS path aliases, and dev
+ * dependencies can hide packaging bugs. This script packs each publishable
+ * package, inspects the tarballs, installs them into temporary consumer
+ * projects, and imports them through their published `exports` maps.
+ */
+
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fabric-package-smoke-'));
 const packDir = path.join(tmp, 'packs');
 
@@ -153,10 +162,31 @@ function expectNoDeclaredRuntimeDependency(pkg, dependencyName, label) {
   }
 }
 
+function hasDeclaredRuntimeDependency(pkg, dependencyName) {
+  return ['dependencies', 'peerDependencies', 'optionalDependencies'].some(
+    (field) => pkg[field]?.[dependencyName],
+  );
+}
+
 function verifyRootPackageManifest(pkg) {
   log('Checking root fabric package manifest');
   expectNoDeclaredRuntimeDependency(pkg, 'westures', 'fabric');
   log('Root fabric package manifest looks correct');
+}
+
+function verifyCorePackageManifest(pkg) {
+  log('Checking @fabricjs/core package manifest');
+  expectNoDeclaredRuntimeDependency(pkg, 'canvas', '@fabricjs/core');
+  expectNoDeclaredRuntimeDependency(pkg, 'jsdom', '@fabricjs/core');
+  log('@fabricjs/core package manifest looks correct');
+}
+
+function isFacadeRootPackage(pkg) {
+  return (
+    hasDeclaredRuntimeDependency(pkg, '@fabricjs/core') ||
+    hasDeclaredRuntimeDependency(pkg, '@fabricjs/browser') ||
+    hasDeclaredRuntimeDependency(pkg, '@fabricjs/node')
+  );
 }
 
 function verifyWorkspaceTarball(importName, list) {
@@ -231,6 +261,49 @@ function smokeImport(project, label, source) {
   log(`Imported ${label} in ${project.name}`);
 }
 
+function smokeSplitCoreIdentity(project) {
+  smokeImport(
+    project,
+    '@fabricjs/core',
+    "import { Rect, Canvas } from '@fabricjs/core'; if (typeof Rect !== 'function' || typeof Canvas !== 'function') throw new Error('@fabricjs/core import failed');",
+  );
+  smokeImport(
+    project,
+    '@fabricjs/browser core identity',
+    "import { Rect as CoreRect } from '@fabricjs/core'; import { Rect as BrowserRect } from '@fabricjs/browser'; if (CoreRect !== BrowserRect) throw new Error('@fabricjs/browser does not share @fabricjs/core runtime');",
+  );
+  smokeImport(
+    project,
+    '@fabricjs/node core identity',
+    "import { Rect as CoreRect } from '@fabricjs/core'; import { Rect as NodeRect } from '@fabricjs/node'; if (CoreRect !== NodeRect) throw new Error('@fabricjs/node does not share @fabricjs/core runtime');",
+  );
+  smokeImport(
+    project,
+    '@fabricjs/browser and @fabricjs/node core identity',
+    "import { Rect as BrowserRect } from '@fabricjs/browser'; import { Rect as NodeRect } from '@fabricjs/node'; if (BrowserRect !== NodeRect) throw new Error('@fabricjs/browser and @fabricjs/node do not share @fabricjs/core runtime');",
+  );
+}
+
+function smokeRootFacadeCoreIdentity(project, rootPkg, fabricTarball) {
+  if (!isFacadeRootPackage(rootPkg)) {
+    log(
+      'Skipping root fabric facade identity checks; root package is not a facade yet',
+    );
+    return;
+  }
+  linkPackage(project, 'fabric', fabricTarball);
+  smokeImport(
+    project,
+    'fabric and @fabricjs/core core identity',
+    "import { Rect as FabricRect } from 'fabric'; import { Rect as CoreRect } from '@fabricjs/core'; if (FabricRect !== CoreRect) throw new Error('fabric does not share @fabricjs/core runtime');",
+  );
+  smokeImport(
+    project,
+    'fabric/node and @fabricjs/node core identity',
+    "import { Rect as FabricNodeRect } from 'fabric/node'; import { Rect as NodeRect } from '@fabricjs/node'; if (FabricNodeRect !== NodeRect) throw new Error('fabric/node does not share @fabricjs/node runtime');",
+  );
+}
+
 try {
   log(`Using temp directory ${tmp}`);
   const packed = new Map(
@@ -241,7 +314,14 @@ try {
   );
 
   verifyRootTarball(tarList(packed.get('fabric').tarball));
-  verifyRootPackageManifest(tarPackageJson(packed.get('fabric').tarball));
+  const packedManifests = new Map(
+    publishablePackages.map(({ importName }) => [
+      importName,
+      tarPackageJson(packed.get(importName).tarball),
+    ]),
+  );
+  verifyRootPackageManifest(packedManifests.get('fabric'));
+  verifyCorePackageManifest(packedManifests.get('@fabricjs/core'));
   for (const { importName } of publishablePackages) {
     if (importName !== 'fabric') {
       verifyWorkspaceTarball(
@@ -289,6 +369,7 @@ try {
   linkRuntimeDependency(splitProject, 'jsdom');
   linkRuntimeDependency(splitProject, 'westures');
 
+  smokeSplitCoreIdentity(splitProject);
   smokeImport(
     splitProject,
     '@fabricjs/browser',
@@ -323,6 +404,11 @@ try {
     splitProject,
     '@fabricjs/westures-integration',
     "import { addGestures, pinchEventHandler } from '@fabricjs/westures-integration'; if (typeof addGestures !== 'function' || typeof pinchEventHandler !== 'function') throw new Error('@fabricjs/westures-integration import failed');",
+  );
+  smokeRootFacadeCoreIdentity(
+    splitProject,
+    packedManifests.get('fabric'),
+    packed.get('fabric').tarball,
   );
 
   log('Cleaning temp directory');


### PR DESCRIPTION
## Description

Adds the follow-up monorepo publishing hardening: public package metadata, recursive workspace publishing, CI/release package smoke coverage, and stronger tarball/runtime identity checks.

## Key changes

- Adds public publish config for publishable @fabricjs workspace packages.
- Publishes workspace packages recursively from the npm publish workflow.
- Runs package smoke checks in build and publish workflows.
- Extends package smoke to inspect real tarballs, verify @fabricjs/core stays free of node runtime deps, and catch duplicate core runtime/class identities.
- Keeps root fabric as the legacy package for now; facade conversion is a follow-up.
