### PR TITLE
fix(parser): match exact class name in selectorMatches (#8838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [next]
 
 - refactor(core): move implementation source into package [#11041](https://github.com/fabricjs/fabric.js/pull/11041)
+- fix(parser): match class/id selectors exactly so `.st12` is not lost when `.st1` also exists [#8838](https://github.com/fabricjs/fabric.js/issues/8838)
 - fix(config): resolve device pixel ratio through env [#11040](https://github.com/fabricjs/fabric.js/pull/11040)
 - refactor(env): move runtime env setup to packages [#11039](https://github.com/fabricjs/fabric.js/pull/11039)
 - chore(): Monorepo follow up steps [#11033](https://github.com/fabricjs/fabric.js/pull/11033)

--- a/packages/core/src/parser/selectorMatches.spec.ts
+++ b/packages/core/src/parser/selectorMatches.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { getFabricWindow } from '../env';
+import { selectorMatches } from './selectorMatches';
+
+function getElement(svg: string) {
+  const parser = new (getFabricWindow().DOMParser)();
+  const doc = parser.parseFromString(svg.trim(), 'text/xml');
+  return doc.documentElement.getElementsByTagName('*')[0];
+}
+
+describe('selectorMatches', () => {
+  it('matches a class selector', () => {
+    const element = getElement(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect class="st1" /></svg>',
+    );
+    expect(selectorMatches(element, '.st1')).toBe(true);
+  });
+
+  it('does not treat a class as a prefix of a longer class ending in a digit', () => {
+    // element only has class `st1`, so it must NOT match the `.st12` selector
+    const element = getElement(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect class="st1" /></svg>',
+    );
+    expect(selectorMatches(element, '.st12')).toBe(false);
+  });
+
+  it('matches a class whose name is a numeric-suffixed superset of another class', () => {
+    // regression for #8838: `.st12` was lost because `.st1` matched inside it
+    const element = getElement(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect class="st12 st1" /></svg>',
+    );
+    expect(selectorMatches(element, '.st12')).toBe(true);
+    expect(selectorMatches(element, '.st1')).toBe(true);
+  });
+
+  it('matches an id selector without treating it as a prefix', () => {
+    const element = getElement(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect id="a1" /></svg>',
+    );
+    expect(selectorMatches(element, '#a1')).toBe(true);
+    expect(selectorMatches(element, '#a12')).toBe(false);
+  });
+});

--- a/packages/core/src/parser/selectorMatches.ts
+++ b/packages/core/src/parser/selectorMatches.ts
@@ -5,7 +5,12 @@ export function selectorMatches(
   const nodeName = element.nodeName;
   const classNames = element.getAttribute('class');
   const id = element.getAttribute('id');
-  const azAz = '(?![a-zA-Z\\-]+)';
+  // negative lookahead ensuring the matched id/class name is not merely a
+  // prefix of a longer name. CSS identifiers can continue with letters,
+  // digits, hyphens or underscores, so all of them must be excluded here
+  // (previously digits and underscores were missing, so `.st1` wrongly
+  // matched inside `.st12`).
+  const azAz = '(?![\\w\\-])';
   let matcher;
   // i check if a selector matches slicing away part from it.
   // if i get empty string i should match


### PR DESCRIPTION
## Description

Closes #8838.

When an SVG element carries multiple classes such as `class="st12 st1"`, the `.st12` style rule was dropped and only `.st1` applied.

The selector matcher in `src/parser/selectorMatches.ts` used a negative lookahead `(?![a-zA-Z\-]+)` to make sure a class/id name was not merely a prefix of a longer name. That lookahead excluded letters and hyphens, but not digits or underscores, so `.st1` matched inside `.st12`: the trailing `2` slipped past the lookahead, leaving a leftover token and causing the `.st12` rule to be discarded.

The fix replaces the lookahead with `(?![\w\-])`, which excludes every valid CSS identifier continuation character (letters, digits, underscore and hyphen), so numeric- and underscore-suffixed class and id names are matched exactly. This matches the exact-class-name approach @asturur prescribed in the issue.

Added `src/parser/selectorMatches.spec.ts` verifying that `.st1` no longer matches an element whose class list contains `st12`, while genuine matches still succeed. Existing parser specs remain green.

## In Action

Before: an element with `class="st12 st1"` lost its `.st12` styling because `.st1` matched inside `st12`.
After: `.st12` and `.st1` are matched independently and both rules apply.
