### PR TITLE
Refresh text measuring context when env document changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- Refresh text measuring context when env document changes [#11046](https://github.com/fabricjs/fabric.js/pull/11046)
 - refactor(core): move implementation source into package [#11041](https://github.com/fabricjs/fabric.js/pull/11041)
 - fix(config): resolve device pixel ratio through env [#11040](https://github.com/fabricjs/fabric.js/pull/11040)
 - refactor(env): move runtime env setup to packages [#11039](https://github.com/fabricjs/fabric.js/pull/11039)

--- a/packages/core/src/shapes/Text/Text.spec.ts
+++ b/packages/core/src/shapes/Text/Text.spec.ts
@@ -4,11 +4,13 @@ import { config } from '../../config';
 import { Path } from '../Path';
 import { FabricText } from './Text';
 
-import { describe, expect, it, afterEach } from 'vitest';
+import { describe, expect, it, afterEach, vi } from 'vitest';
 import {
   FabricObject,
+  getEnv,
   getFabricDocument,
   IText,
+  setEnv,
   Textbox,
 } from '../../../../../fabric';
 import { toFixed } from '../../util';
@@ -71,6 +73,36 @@ describe('FabricText', () => {
       const measurement = text._measureChar('a', style, zwc, style);
       expect(measurement).toMatchSnapshot(roundSnapshotOptions);
       expect(measurement).toEqual(text._measureChar('a', style, zwc, style));
+    });
+
+    it('refreshes the measuring context when the env document changes', () => {
+      cache.clearFontCache();
+      const env = getEnv();
+      const iframe = getFabricDocument().createElement('iframe');
+      getFabricDocument().body.appendChild(iframe);
+      const nextWindow = iframe.contentWindow!;
+      const nextDocument = nextWindow.document;
+      const createElement = nextDocument.createElement.bind(nextDocument);
+      const createElementSpy = vi
+        .spyOn(nextDocument, 'createElement')
+        .mockImplementation(
+          (tagName: string, options?: ElementCreationOptions) =>
+            createElement(tagName, options),
+        );
+      const text = new FabricText('');
+      const style = text.getCompleteStyleDeclaration(0, 0);
+
+      try {
+        text._measureChar('a', style, undefined, {});
+        cache.clearFontCache();
+        setEnv({ ...env, window: nextWindow, document: nextDocument });
+        text._measureChar('b', style, undefined, {});
+
+        expect(createElementSpy).toHaveBeenCalledWith('canvas');
+      } finally {
+        setEnv(env);
+        iframe.remove();
+      }
     });
 
     it('splits into lines', () => {

--- a/packages/core/src/shapes/Text/Text.ts
+++ b/packages/core/src/shapes/Text/Text.ts
@@ -31,6 +31,7 @@ import type {
 import { classRegistry } from '../../ClassRegistry';
 import { graphemeSplit } from '../../util/lang_string';
 import { createCanvasElementFor } from '../../util/misc/dom';
+import { getFabricDocument } from '../../env';
 import type { TextStyleArray } from '../../util/misc/textStyles';
 import {
   hasStyleChanged,
@@ -63,18 +64,21 @@ import type { CSSRules } from '../../parser/typedefs';
 import { normalizeWs } from '../../util/internals/normalizeWhiteSpace';
 
 let measuringContext: CanvasRenderingContext2D | null;
+let measuringContextDocument: Document | null;
 
 /**
  * Return a context for measurement of text string.
  * if created it gets stored for reuse
  */
 function getMeasuringContext() {
-  if (!measuringContext) {
+  const fabricDocument = getFabricDocument();
+  if (!measuringContext || measuringContextDocument !== fabricDocument) {
     const canvas = createCanvasElementFor({
       width: 0,
       height: 0,
     });
     measuringContext = canvas.getContext('2d');
+    measuringContextDocument = fabricDocument;
   }
   return measuringContext;
 }


### PR DESCRIPTION
Fixes #10930.

Fabric caches a module-level text measuring context the first time text metrics are needed. If `setEnv()` later points Fabric at a new `document`, for example after an iframe-backed editor is destroyed and recreated, text measurement continues using the canvas context from the previous document.

This stores the document used to create the cached measuring context and recreates the canvas/context when the active Fabric document changes. The existing cache behavior is unchanged while the env document stays the same.

I added a regression test that measures text, switches Fabric to an iframe document, measures again, and verifies a new measuring canvas is created in the new document.

Tests run:
- `pnpm exec vitest --run --project unit-node packages/core/src/shapes/Text/Text.spec.ts`
- `pnpm exec oxfmt --check packages/core/src/shapes/Text/Text.ts packages/core/src/shapes/Text/Text.spec.ts`
- `pnpm exec eslint packages/core/src/shapes/Text/Text.ts packages/core/src/shapes/Text/Text.spec.ts`
- `pnpm run typecheck`
- `pnpm run test:vitest`

Note: the full unit test command passes; jsdom logs expected image loading errors from existing Image specs during the run.