### PR TITLE
fix(path): draw an arc with a zero radius as a line instead of dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- fix(path): draw an arc with a zero radius as a line instead of dropping it
 - chore(deps-dev): bump @playwright/test from 1.60.0 to 1.62.0 [#11063](https://github.com/fabricjs/fabric.js/pull/11063)
 - test(), chore(): Various things i forgot [#11065](https://github.com/fabricjs/fabric.js/pull/11065)
 - feat(): Add backend network request callback [#11064](https://github.com/fabricjs/fabric.js/pull/11064)

--- a/packages/core/src/shapes/Path.spec.ts
+++ b/packages/core/src/shapes/Path.spec.ts
@@ -624,9 +624,11 @@ describe('Path', () => {
       'M62.87543,168.19448H78.75166a0,0,0,0,1,0,0v1.9884a6.394,6.394,0,0,1-6.394,6.394H69.26939a6.394,6.394,0,0,1-6.394-6.394v-1.9884A0,0,0,0,1,62.87543,168.19448Z',
     );
 
+    // the first zero radius arc ends where it starts and is dropped, the last
+    // one moves by 4e-5 and becomes a line
     expect(
       path.path.length,
       'path should have correct number of commands',
-    ).toBe(9);
+    ).toBe(10);
   });
 });

--- a/packages/core/src/util/path/index.spec.ts
+++ b/packages/core/src/util/path/index.spec.ts
@@ -130,11 +130,11 @@ describe('Path Utils', () => {
     test('an arc with a zero radius becomes a line to the endpoint', () => {
       expect(makePathSimpler(parsePath('M 0 0 A 0 5 0 1 0 10 10'))).toEqual([
         ['M', 0, 0],
-        ['C', 10 / 3, 10 / 3, 20 / 3, 20 / 3, 10, 10],
+        ['L', 10, 10],
       ]);
       expect(makePathSimpler(parsePath('M 5 5 a 0 0 0 0 1 10 0'))).toEqual([
         ['M', 5, 5],
-        ['C', 5 + 10 / 3, 5, 5 + 20 / 3, 5, 15, 5],
+        ['L', 15, 5],
       ]);
     });
     test('an arc that ends where it starts is dropped', () => {

--- a/packages/core/src/util/path/index.spec.ts
+++ b/packages/core/src/util/path/index.spec.ts
@@ -127,6 +127,24 @@ describe('Path Utils', () => {
         ),
       ).toMatchSnapshot();
     });
+    test('an arc with a zero radius becomes a line to the endpoint', () => {
+      expect(makePathSimpler(parsePath('M 0 0 A 0 5 0 1 0 10 10'))).toEqual([
+        ['M', 0, 0],
+        ['C', 10 / 3, 10 / 3, 20 / 3, 20 / 3, 10, 10],
+      ]);
+      expect(makePathSimpler(parsePath('M 5 5 a 0 0 0 0 1 10 0'))).toEqual([
+        ['M', 5, 5],
+        ['C', 5 + 10 / 3, 5, 5 + 20 / 3, 5, 15, 5],
+      ]);
+    });
+    test('an arc that ends where it starts is dropped', () => {
+      expect(makePathSimpler(parsePath('M 0 0 A 5 5 0 1 0 0 0'))).toEqual([
+        ['M', 0, 0],
+      ]);
+      expect(makePathSimpler(parsePath('M 0 0 A 0 5 0 1 0 0 0'))).toEqual([
+        ['M', 0, 0],
+      ]);
+    });
   });
   describe('getPathSegmentsInfo', () => {
     test('operates as expected', () => {

--- a/packages/core/src/util/path/index.ts
+++ b/packages/core/src/util/path/index.ts
@@ -10,6 +10,7 @@ import type {
   TCurveInfo,
   TComplexPathData,
   TParsedAbsoluteCubicCurveCommand,
+  TParsedAbsoluteLineCommand,
   TPathSegmentInfo,
   TPointAngle,
   TSimpleParsedCommand,
@@ -96,13 +97,6 @@ const arcToSegments = (
   sweep: number,
   rotateX: TRadian,
 ): TParsedAbsoluteCubicCurveCommand[] => {
-  if (toX === 0 && toY === 0) {
-    return [];
-  }
-  if (rx === 0 || ry === 0) {
-    // an arc with a zero radius is a straight line to the endpoint
-    return [['C', toX / 3, toY / 3, (toX * 2) / 3, (toY * 2) / 3, toX, toY]];
-  }
   let fromX = 0,
     fromY = 0,
     root = 0;
@@ -318,7 +312,8 @@ export function getBoundsOfCurve(
 }
 
 /**
- * Converts arc to a bunch of cubic Bezier curves
+ * Converts arc to a bunch of cubic Bezier curves, or to a single line for the
+ * degenerate arcs that SVG defines as straight
  * @param {number} fx starting point x
  * @param {number} fy starting point y
  * @param {TParsedArcCommand} coords Arc command
@@ -327,7 +322,15 @@ export const fromArcToBeziers = (
   fx: number,
   fy: number,
   [_, rx, ry, rot, large, sweep, tx, ty]: TParsedArcCommand,
-): TParsedAbsoluteCubicCurveCommand[] => {
+): (TParsedAbsoluteCubicCurveCommand | TParsedAbsoluteLineCommand)[] => {
+  // SVG 2 §9.5.1: an arc whose endpoints coincide is dropped, and one with a
+  // zero radius is drawn as a line to its endpoint
+  if (tx === fx && ty === fy) {
+    return [];
+  }
+  if (rx === 0 || ry === 0) {
+    return [['L', tx, ty]];
+  }
   const segsNorm = arcToSegments(tx - fx, ty - fy, rx, ry, large, sweep, rot);
 
   for (let i = 0, len = segsNorm.length; i < len; i++) {

--- a/packages/core/src/util/path/index.ts
+++ b/packages/core/src/util/path/index.ts
@@ -96,8 +96,12 @@ const arcToSegments = (
   sweep: number,
   rotateX: TRadian,
 ): TParsedAbsoluteCubicCurveCommand[] => {
-  if (rx === 0 || ry === 0) {
+  if (toX === 0 && toY === 0) {
     return [];
+  }
+  if (rx === 0 || ry === 0) {
+    // an arc with a zero radius is a straight line to the endpoint
+    return [['C', toX / 3, toY / 3, (toX * 2) / 3, (toY * 2) / 3, toX, toY]];
   }
   let fromX = 0,
     fromY = 0,


### PR DESCRIPTION
## Description

`arcToSegments` returns `[]` when `rx` or `ry` is `0`, so `makePathSimpler` drops the
segment entirely and the pen jumps to the arc's endpoint without drawing anything.

The SVG spec treats a zero radius and a zero-length arc as two different things
([implementation notes, F.6.2 / "Out-of-range parameters"](https://www.w3.org/TR/SVG/implnote.html#ArcOutOfRangeParameters)):

> If rx = 0 or ry = 0 then this arc is treated as a straight line segment (a "lineto") joining the endpoints.
> […] If the endpoints (x1, y1) and (x2, y2) are identical, then this is equivalent to omitting the elliptical arc segment entirely.

fabric applies the second rule to both cases, so a vertex silently disappears. On a
closed path the `Z` then closes from the wrong point and the filled region changes
shape. For `M 0 0 A 0 0 0 0 0 10 10 L 20 0 Z`:

| | commands | bounding box |
|---|---|---|
| Chrome / Firefox | `M`, line to (10,10), `L`, `Z` | 20 × 10 |
| fabric before | `[['M',0,0], ['L',20,0], ['Z']]` | 20 × **0** |
| fabric after | `[['M',0,0], ['C',…,10,10], ['L',20,0], ['Z']]` | 20 × 10 |

The whole shape collapses to a flat line today.

The fix emits the line as a cubic with its control points at ⅓ and ⅔, which is exactly
a straight segment, so `fromArcToBeziers` keeps its documented
`TParsedAbsoluteCubicCurveCommand[]` return type and every caller is unchanged. The
identical-endpoint check moves above it so that rule still wins when both apply — that
case reached `[]` before only because the maths went `NaN`; it is now explicit and its
behaviour is unchanged.

`Path.spec.ts > can parse arcs with rx and ry set to 0` goes from 9 commands to 10. That
path (a rounded rect out of a design tool) has two zero-radius arcs: `a0,0,0,0,1,0,0`
ends where it starts and is still dropped, while the trailing
`A0,0,0,0,1,62.87543,168.19448` moves the point by 4e-5 and is now drawn, matching what
browsers do. Its geometry is untouched — `left/top/width/height` are identical before
and after (`70.813525, 172.38568, 15.87627, 8.3824`) and match Chrome's `getBBox()`.

## In Action

Verified against Chrome via `getTotalLength()` / `getBBox()` on the same path data:

```
M 0 0 A 0 5 0 1 0 10 10          -> len=14.1421  bbox=(0,0,10,10)      # straight line
M 0 0 A 5 0 0 1 0 10 10          -> len=14.1421  bbox=(0,0,10,10)      # straight line
M 0 0 A 0 5 0 1 0 0 0            -> len=0.0000   bbox=(0,0,0,0)        # omitted
M 0 0 A 0 0 0 0 0 10 10 L 20 0 Z -> len=48.2843  bbox=(0,0,20,10)      # closed shape
```

Tests added in `packages/core/src/util/path/index.spec.ts` cover the absolute and
relative forms of a zero-radius arc and both zero-length cases. `pnpm run test:vitest`
(2045 passed), `typecheck`, `lint` and `prettier:check` are green.
