### PR TITLE
ci(): add GitHub Pages deploy workflow for website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,43 @@
+name: Deploy website
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Allow only one concurrent deployment
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: ./.github/actions/cached-install
+        with:
+          node-version: 24.x
+          install-system-deps: true
+      - name: Build fabric.js
+        run: pnpm run build
+      - name: Build website
+        run: pnpm --dir packages/website run build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: packages/website/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac553fd0d31 # v4.0.5

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ./.github/actions/cached-install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [next]
 
+- ci(): add GitHub Pages deploy workflow for website [#11081](https://github.com/fabricjs/fabric.js/pull/11081)
 - Pull in docs [#11070](https://github.com/fabricjs/fabric.js/pull/11070)
 - chore(deps-dev): bump @playwright/test from 1.60.0 to 1.62.0 [#11063](https://github.com/fabricjs/fabric.js/pull/11063)
 - test(), chore(): Various things i forgot [#11065](https://github.com/fabricjs/fabric.js/pull/11065)

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "lint": "eslint extensions packages --fix",
     "prettier:check": "oxfmt --check .",
     "prettier:write": "oxfmt .",
+    "web-dev": "pnpm run build && node ./scripts/index.mjs build -f -w & pnpm --dir packages/website run dev; kill $!",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -1,54 +1,34 @@
-# Astro Starter Kit: Basics
+# Fabric.js Website
 
-```sh
-npm create astro@latest -- --template basics
+Source for [fabricjs.com](https://fabricjs.com), built with [Astro](https://astro.build/) and [Starlight](https://starlight.astro.build/).
+
+This package lives inside the `fabric.js` monorepo and depends on the local `fabric` workspace build.
+
+## Prerequisites
+
+From the **repository root**:
+
+```bash
+pnpm install
+pnpm run build        # builds fabric.js (required before the website)
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
+## Development
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-│   └── favicon.svg
-├── src/
-│   ├── components/
-│   │   └── Card.astro
-│   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
-└── package.json
+```bash
+pnpm --dir packages/website run dev
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## Production build
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+```bash
+pnpm --dir packages/website run build
+```
 
-Any static assets, like images, can be placed in the `public/` directory.
+Output goes to `packages/website/dist`.
 
-## 🧞 Commands
+## Preview
 
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+```bash
+pnpm --dir packages/website run preview
+```

--- a/packages/website/src/components/GithubEditLink/index.astro
+++ b/packages/website/src/components/GithubEditLink/index.astro
@@ -9,7 +9,7 @@ const { relativePath } = Astro.props;
     class="github-edit-link"
     target="_blank"
     rel="noreferrer"
-    href={`https://github.com/fabricjs/fabricjs.github.io/edit/main/src/content/${relativePath}`}
+    href={`https://github.com/fabricjs/fabric.js/edit/master/packages/website/src/content/${relativePath}`}
 >
     Edit this page on Github
 </a>

--- a/packages/website/src/components/LatestRelease/LatestRelease.astro
+++ b/packages/website/src/components/LatestRelease/LatestRelease.astro
@@ -1,11 +1,17 @@
 ---
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(process.cwd(), '../..');
+const fabricPkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8'));
+
 export interface Props {
   version?: string;
   url?: string;
   subtitle?: string;
 }
 const {
-  version = '7.4.0',
+  version = fabricPkg.version,
   url = 'https://github.com/fabricjs/fabric.js/releases',
   subtitle = 'Download latest release from GitHub',
 } = Astro.props as Props;


### PR DESCRIPTION
Adds a GitHub Actions workflow to deploy the Astro website from packages/website to GitHub Pages on every push to master (and via manual dispatch).

Changes:
1. .github/workflows/deploy-website.yml — new workflow: cached pnpm install with canvas system deps → build fabric → build website → upload Pages artifact → deploy with actions/deploy-pages (concurrency-limited, pages: write + id-token: write, github-pages environment)
2. GithubEditLink/index.astro — "Edit this page" link now points to fabric.js/edit/master/packages/website/src/content/... instead of the old fabricjs.github.io repo
3. packages/website/README.md — replaced Astro starter template with actual instructions
4. Make astro banner updated with version from the package automatically

Post-merge: custom domain cutover
1. Settings → Pages → source: GitHub Actions
2. Custom domain: fabricjs.com
3. Verify DNS CNAME points to GitHub Pages
4. Enable Enforce HTTPS

related to #11080